### PR TITLE
chore: simplify update script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Update Addon Windows
         if: matrix.os == 'windows-latest'
         shell: bash  
-        run: ./update.sh ${{secrets.USER}} ${{secrets.TOKEN}} ${{matrix.os}}
+        run: ./update.sh ${{matrix.os}}
 
       - name: Update Addon
         if: matrix.os != 'windows-latest'
         shell: bash  
         run: |
-          ./update.sh ${{secrets.USER}} ${{secrets.TOKEN}} ${{matrix.os}} arm
-          ./update.sh ${{secrets.USER}} ${{secrets.TOKEN}} ${{matrix.os}} amd
+          ./update.sh ${{matrix.os}} arm
+          ./update.sh ${{matrix.os}} amd
 
       - name: Build Front Mac OS
         if: matrix.os == 'macos-latest'

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Also, [install `gitleaks`](https://github.com/zricethezav/gitleaks#installing) t
 Fetch the latest binary from the [github releases](https://github.com/anytypeio/go-anytype-middleware/releases/latest)
 
 ```shell
-./update.sh <GITHUB_USER> <GITHUB_TOKEN> <macos-latest|ubuntu-latest|windows-latest>
+./update.sh <macos-latest|ubuntu-latest|windows-latest>
 ```
 	
 Or compile from the source code. Follow instructions at [`anytype-heart`](https://github.com/anyproto/anytype-heart#how-to-build).

--- a/update.sh
+++ b/update.sh
@@ -4,10 +4,8 @@ REPO="anyproto/anytype-heart"
 FILE="addon.tar.gz"
 GITHUB="api.github.com"
 
-user=$1
-token=$2;
-platform=$3;
-arch=$4;
+platform=${1:-ubuntu-latest};
+arch=$2;
 folder="build";
 
 if [ "$platform" = "ubuntu-latest" ]; then
@@ -26,11 +24,6 @@ echo "Arch: $arch"
 echo "Folder: $folder"
 echo ""
 
-if [ "$token" = "" ]; then
-  echo "ERROR: token is empty"
-  exit 1
-fi;
-
 if [ "$arch" = "" ]; then
   echo "ERROR: arch not found"
   exit 1
@@ -38,7 +31,7 @@ fi;
 
 mwv=`cat middleware.version`
 
-version=`curl -u "$user:$token" -H "Accept: application/vnd.github.v3+json" -sL https://$GITHUB/repos/$REPO/releases/tags/v$mwv | jq .`
+version=`curl -H "Accept: application/vnd.github.v3+json" -sL https://$GITHUB/repos/$REPO/releases/tags/v$mwv | jq .`
 
 tag=`echo $version | jq ".tag_name"`
 asset_id=`echo $version | jq ".assets | map(select(.name | match(\"js_v[0-9]+.[0-9]+.[0-9]+(-rc[0-9]+)?_$arch\";\"i\")))[0].id"`
@@ -51,7 +44,7 @@ fi;
 printf "Version: $tag\n"
 printf "Found asset: $asset_id\n"
 echo -n "Downloading file..."
-curl -sL -H "Authorization: token $token" -H 'Accept: application/octet-stream' "https://$GITHUB/repos/$REPO/releases/assets/$asset_id" > $FILE
+curl -sL -H 'Accept: application/octet-stream' "https://$GITHUB/repos/$REPO/releases/assets/$asset_id" > $FILE
 printf "Done\n"
 
 if [ "$platform" = "windows-latest" ]; then


### PR DESCRIPTION
anyproto-heart artifacts do not need github authentication to download. This might be left over from before this project was public. Anonymous downloading is safer for developers and preserves a bit more privacy.

Make "ubuntu-latest" the default platform. A bit opinionated, but linux is generally a safe default for CI and Docker, so might be reasonable. I can yoink this particular if it's too controversial.

Thanks!