### PR TITLE
Fix lint-staged not applying to any file

### DIFF
--- a/package.json
+++ b/package.json
@@ -550,8 +550,7 @@
 		}
 	},
 	"lint-staged": {
-		"{src,electron}/*.{ts,tsx}": "npx tsc --noEmit -p tsconfig.json",
-		"{src,electron}/*.{js,jsx,ts,tsx}": "npx eslint --fix"
+		"./{src,electron}/**/*.{js,jsx,ts,tsx}": "eslint --fix"
 	},
 	"husky": {
 		"hooks": {


### PR DESCRIPTION
Running `npm run precommit` doesn't show any error, but that was because it wasn't being run on any files in the first place. This PR fixes that. The `tsc` stuff was removed because of this (https://github.com/okonet/lint-staged/issues/468) and because eslint handles typescript errors for us anyway.