### PR TITLE
chore: remove unnecessary GH token

### DIFF
--- a/.github/workflows/mirror-text.yml
+++ b/.github/workflows/mirror-text.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           repository: anyproto/l10n-anytype-ts
           path: l10n-anytype-ts
-          token: ${{ secrets.ANY_CLA_TOKEN }}
 
       - name: Copy files
         run: |


### PR DESCRIPTION
---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---

### Description

This PR Fixes the [mirror-text](https://github.com/anyproto/anytype-ts/blob/ae78d791d480ef84619a3767ea6691dfba8b2908/.github/workflows/mirror-text.yml) GitHub workflow failing on forked repositories due to missing token. Since the [`anyproto/l10n-anytype-ts`](https://github.com/anyproto/l10n-anytype-ts) repository is now public, there is no need for a GitHub token anymore.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI

### Related Tickets & Documents

*None*

### Mobile & Desktop Screenshots/Recordings

*None*

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed
