### PR TITLE
Feature/JS-2736: Set as default text update in dataview

### DIFF
--- a/src/json/text.json
+++ b/src/json/text.json
@@ -1140,6 +1140,7 @@
     "menuDataviewViewListViews": "Views",
 
     "menuDataviewTemplateSetDefault": "Set as default",
+    "menuDataviewTemplateSetDefaultForView": "Default for this view",
     "menuDataviewTemplateEdit": "Edit template",
 
     "menuGraphSettingsTitles": "Titles",

--- a/src/ts/component/block/dataview.tsx
+++ b/src/ts/component/block/dataview.tsx
@@ -775,6 +775,7 @@ const BlockDataview = observer(class BlockDataview extends React.Component<Props
 						horizontal: I.MenuDirection.Right,
 						data: {
 							template: item,
+							isView: true,
 							onOver: () => menuStore.closeAll([ 'previewObject' ]),
 							onSetDefault: () => {
 								this.setDefaultTemplateForView(item.id, () => {

--- a/src/ts/component/menu/dataview/template.tsx
+++ b/src/ts/component/menu/dataview/template.tsx
@@ -49,11 +49,11 @@ class MenuTemplate extends React.Component<I.Menu> {
     getItems () {
         const { param } = this.props;
         const { data } = param;
-        const { template } = data;
+        const { template, isView } = data;
         const { isBlank, isDefault } = template;
        
-		 return [
-			!isDefault ? ({ id: 'default', name: translate('menuDataviewTemplateSetDefault') }) : null,
+		return [
+			!isDefault ? ({ id: 'default', name: translate(isView ? 'menuDataviewTemplateSetDefaultForView' : 'menuDataviewTemplateSetDefault') }) : null,
 			!isBlank ? ({ id: 'edit', name: translate('menuDataviewTemplateEdit') }) : null,
 			{ id: 'duplicate', name: translate('commonDuplicate') },
 			!isBlank ? ({ id: 'remove', name: translate('commonDelete') }) : null,


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
