### PR TITLE
Feature/JS-2783: Readonly for archived objects in menuBlockRelationView

### DIFF
--- a/src/ts/component/header/main/object.tsx
+++ b/src/ts/component/header/main/object.tsx
@@ -138,6 +138,7 @@ const HeaderMainObject = observer(class HeaderMainObject extends React.Component
 	onRelation () {
 		const { isPopup, rootId, menuOpen } = this.props;
 		const cnw = [ 'fixed' ];
+		const object = detailStore.get(rootId, rootId, [ 'isArchived' ]);
 
 		if (!isPopup) {
 			cnw.push('fromHeader');
@@ -152,6 +153,7 @@ const HeaderMainObject = observer(class HeaderMainObject extends React.Component
 			data: {
 				isPopup,
 				rootId,
+				readonly: object.isArchived
 			},
 		});
 	};

--- a/src/ts/component/menu/block/relation/view.tsx
+++ b/src/ts/component/menu/block/relation/view.tsx
@@ -69,7 +69,7 @@ const MenuBlockRelationView = observer(class MenuBlockRelationView extends React
 								readonly={!(allowedValue && !item.isReadonlyValue && !readonly)}
 								canEdit={allowedRelation && !item.isReadonlyRelatione && !readonly}
 								canDrag={allowedBlock && !readonly}
-								canFav={allowedValue}
+								canFav={allowedValue && !readonly}
 								isFeatured={section.id == 'featured'}
 								classNameWrap={classNameWrap}
 								onCellClick={this.onCellClick}


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
