### PR TITLE
Add double clic on tray to open Anytype window

### DIFF
--- a/electron/js/menu.js
+++ b/electron/js/menu.js
@@ -323,6 +323,14 @@ class MenuManager {
 
 			{ label: Util.translate('electronMenuQuit'), click: () => { hide(); Api.exit(this.win, '', false); } },
 		]));
+
+		this.tray.on('double-click', () => {
+			// Force on top and focus because in some case Electron fail with show()
+			this.win.setAlwaysOnTop(true);
+			this.win.show();
+			this.win.setAlwaysOnTop(false);
+		  });
+
 	};
 
 	openSettings (page, param) {


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [X] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description
Double-clicking on the Anytype icon on the taskbar should consistently open the window, as is the case with other applications.
Done here :
- Add double-click event to app tray, which show the window (and force in the top, because in sme case, show() in Electon doesn't do it properly


### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
https://community.anytype.io/t/unable-to-maximize-the-window-with-double-clicking-the-icon/10547

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [X] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


