### PR TITLE
Filter by type on collection doesn't work properly

### DIFF
--- a/src/ts/component/menu/dataview/filter/values.tsx
+++ b/src/ts/component/menu/dataview/filter/values.tsx
@@ -138,7 +138,7 @@ const MenuDataviewFilterValues = observer(class MenuDataviewFilterValues extends
 					);
 				};
 
-				list = Relation.getArrayValue(item.value).map(it => detailStore.get(subId, it, []));
+				list = Relation.getArrayValue(item.value).map(it => dbStore.getType(it));
 				list = list.filter(it => !it._empty_);
 
 				value = (

--- a/src/ts/component/menu/item/filter.tsx
+++ b/src/ts/component/menu/item/filter.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { I, Relation, UtilCommon, translate } from 'Lib';
 import { Icon, Tag, IconObject } from 'Component';
-import { detailStore } from 'Store';
+import { detailStore, dbStore } from 'Store';
 import { SortableHandle, SortableElement } from 'react-sortable-hoc';
 import { observer } from 'mobx-react';
 
@@ -110,7 +110,7 @@ const MenuItemFilter = observer(class MenuItemFilter extends React.Component<Pro
 					);
 				};
 
-				list = Relation.getArrayValue(value).map(it => detailStore.get(subId, it, []));
+				list = Relation.getArrayValue(value).map(it => dbStore.getType(it));
 				list = list.filter(it => !it._empty_);
 
 				v = (


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [X] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description
So, when user filter by object type, he can choose in a list.
But if this type is not already present as linked object to the collection :
- filter seems to be applied with the type added (type doesn't appear in the list anymore, confirmed by test in dev)
- type doesn't appears in the "Object type" in list of active filter 
- type doesn't appears in selected type list when we edit this filter  (so, it cannot be removed)

Object was return with  detail.get(subId, id), and for collection type returned are empty.

Pehaps, there is a reason of this (like not allowing a collection to be filtered if the type is not in the collection)? If yes, the list of selection in search must be filtered too.
I suppose no (I can filter by type=audio, if I don't have one I won't get any results and that's it).
It's applied via this PL, I hope it's good for you :)

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
https://community.anytype.io/t/object-type-filter-is-not-working-properly-in-collections/10768

### Mobile & Desktop Screenshots/Recordings
_Collection (with only page) filtered by type = set or Image or page, etc_
![image](https://github.com/anyproto/anytype-ts/assets/16141040/f8f5ab9b-46c9-447d-a597-8fee6dbf4700)
![image](https://github.com/anyproto/anytype-ts/assets/16141040/325b461b-0868-4fa8-9315-3cd1f0ccaa8b)




### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [X] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [X] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
