### PR TITLE
Css for empty object

### DIFF
--- a/src/scss/block/link.scss
+++ b/src/scss/block/link.scss
@@ -21,11 +21,7 @@
         .deleted {
             .icon.ghost { width: 24px; height: 24px; }
         }
-		
-		.emptyObjectLink{
-    		border-bottom: $colorShapePrimary 0.05em dashed;
-    		line-height: 22px;
-		}
+	.emptyObjectLink{border-bottom: $colorShapePrimary 0.05em dashed;line-height: 22px;}
 
         .linkCard {
             .sides { display: flex; flex-direction: row; }

--- a/src/scss/block/link.scss
+++ b/src/scss/block/link.scss
@@ -23,7 +23,7 @@
         }
 		
 		.emptyObjectLink{
-    		border-bottom: $colorTextSecondary 0.05em dashed;
+    		border-bottom: $colorShapePrimary 0.05em dashed;
     		line-height: 22px;
 		}
 

--- a/src/scss/block/link.scss
+++ b/src/scss/block/link.scss
@@ -21,6 +21,11 @@
         .deleted {
             .icon.ghost { width: 24px; height: 24px; }
         }
+		
+		.emptyObjectLink{
+    		border-bottom: $colorDarkGrey 0.05em dashed;
+    		line-height: 22px;
+		}
 
         .linkCard {
             .sides { display: flex; flex-direction: row; }

--- a/src/scss/block/link.scss
+++ b/src/scss/block/link.scss
@@ -23,7 +23,7 @@
         }
 		
 		.emptyObjectLink{
-    		border-bottom: $colorDarkGrey 0.05em dashed;
+    		border-bottom: $colorTextSecondary 0.05em dashed;
     		line-height: 22px;
 		}
 

--- a/src/ts/component/block/link.tsx
+++ b/src/ts/component/block/link.tsx
@@ -130,13 +130,15 @@ const BlockLink = observer(class BlockLink extends React.Component<I.BlockCompon
 			if (withType && type) n++;
 			cnc.push('c' + n);
 
+			const isEmpty = (cardStyle == I.LinkCardStyle.Text) && (layout === I.ObjectLayout.Page) && (object.snippet.length===0);
+
 			element = (
 				<div className={cnc.join(' ')} onMouseDown={this.onClick}>
 					<div id="sides" className={cns.join(' ')}>
 						<div key="sideLeft" className={cnl.join(' ')}>
 							<div className="relationItem cardName">
 								{icon}
-								<ObjectName object={object} />
+								{isEmpty ? <span className="emptyObjectLink"><ObjectName object={object} /></span> : <ObjectName object={object} />}
 								{archive}
 							</div>
 

--- a/src/ts/component/block/link.tsx
+++ b/src/ts/component/block/link.tsx
@@ -138,7 +138,7 @@ const BlockLink = observer(class BlockLink extends React.Component<I.BlockCompon
 						<div key="sideLeft" className={cnl.join(' ')}>
 							<div className="relationItem cardName">
 								{icon}
-								<ObjectName className={isEmpty ? "name emptyObjectLink" : "name"} object={object} />
+								<ObjectName className={isEmpty ? 'name emptyObjectLink' : 'name'} object={object} />
 								{archive}
 							</div>
 

--- a/src/ts/component/block/link.tsx
+++ b/src/ts/component/block/link.tsx
@@ -130,7 +130,7 @@ const BlockLink = observer(class BlockLink extends React.Component<I.BlockCompon
 			if (withType && type) n++;
 			cnc.push('c' + n);
 
-			const isEmpty = (cardStyle == I.LinkCardStyle.Text) && (layout === I.ObjectLayout.Page) && (object.snippet.length===0);
+			const isEmpty = (cardStyle == I.LinkCardStyle.Text) && (layout == I.ObjectLayout.Page) && !object.snippet.length;
 
 			element = (
 				<div className={cnc.join(' ')} onMouseDown={this.onClick}>
@@ -138,7 +138,7 @@ const BlockLink = observer(class BlockLink extends React.Component<I.BlockCompon
 						<div key="sideLeft" className={cnl.join(' ')}>
 							<div className="relationItem cardName">
 								{icon}
-								{isEmpty ? <span className="emptyObjectLink"><ObjectName object={object} /></span> : <ObjectName object={object} />}
+								<ObjectName className={isEmpty ? "name emptyObjectLink" : "name"} object={object} />
 								{archive}
 							</div>
 

--- a/src/ts/component/block/link.tsx
+++ b/src/ts/component/block/link.tsx
@@ -138,7 +138,7 @@ const BlockLink = observer(class BlockLink extends React.Component<I.BlockCompon
 						<div key="sideLeft" className={cnl.join(' ')}>
 							<div className="relationItem cardName">
 								{icon}
-								<ObjectName className={isEmpty ? 'name emptyObjectLink' : 'name'} object={object} />
+								<ObjectName className={[ 'name', (isEmpty ? 'emptyObjectLink' : '') ].join(' ')} />
 								{archive}
 							</div>
 


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [X] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description
Add a custom CSS to link when object linked is an object with template Page.
- Pehaps other objects can be create and considerate as empty (those with template Note and pehaps Tasks and Human) but the definition of empty is more vague (does a task need content? Can a note consist of just one line?). This could be improved based on community feedback.
- Same for the CSS, I choose something not too strong in terms of presence, and the underline is already used sometimes for empty links. But it depends on the feedback from the team or the community...

CSS is applied to the text, so there shouldn't be any display issues (no icon underlined ^^). 
It creates a div within a span: I wanted to avoid modifying the ObjectName component (or its properties) to minimize the scope of this change (and better control it). (which is entirely focused on links without affecting ObjectName ). I hope this works for you?

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
https://community.anytype.io/t/creating-new-objects-from-the-link-to-object-ui/7059/2

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
![image](https://github.com/anyproto/anytype-ts/assets/16141040/d6e9e3db-a47e-40e5-836d-6aba8d1a6eca)

### Added tests?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [X] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?
No

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
