### PR TITLE
Link to with multiple selected objects

### DIFF
--- a/src/ts/component/menu/dataview/context.tsx
+++ b/src/ts/component/menu/dataview/context.tsx
@@ -144,7 +144,6 @@ class MenuContext extends React.Component<I.Menu> {
 
 		if (length > 1) {
 			open = null;
-			linkTo = null;
 		};
 
 		if (archiveCnt == length) {
@@ -246,9 +245,9 @@ class MenuContext extends React.Component<I.Menu> {
 					],
 					rootId: itemId,
 					blockId: itemId,
-					blockIds: [ itemId ],
+					blockIds: objectIds,
 					type: I.NavigationType.LinkTo,
-					skipIds: [ itemId ],
+					skipIds: objectIds,
 					position: I.BlockPosition.Bottom,
 					canAdd: true,
 					onSelect: (el: any) => {

--- a/src/ts/component/menu/search/object.tsx
+++ b/src/ts/component/menu/search/object.tsx
@@ -439,16 +439,20 @@ const MenuSearchObject = observer(class MenuSearchObject extends React.Component
 						const isCollection = target.type == Constant.typeId.collection;
 						const action = isCollection ? I.ToastAction.Collection : I.ToastAction.Link;
 						const linkType = isCollection ? 'Collection' : 'Object';
-
-						Preview.toastShow({ action, objectId: blockId, targetId: target.id });
+						const count = blockIds.length;
+						const cnt = (count > 1) ? `${count} ${UtilCommon.plural(count, translate('pluralObject'))}` : '';
+						
+						Preview.toastShow({ action, objectId: blockId, text: cnt, targetId: target.id });
 						analytics.event('LinkToObject', { objectType: target.type, linkType });
 					};
 
-					if (target.type == Constant.typeId.collection) {
-						C.ObjectCollectionAdd(target.id, [ rootId ], cb);
-					} else {
-						C.BlockCreate(target.id, '', position, this.getBlockParam(blockId, object.type), cb);
-					};
+					blockIds.forEach((itemId: any)=> {
+						if (target.type == Constant.typeId.collection) {
+							C.ObjectCollectionAdd(target.id, [ itemId ], cb);
+						} else {
+							C.BlockCreate(target.id, '', position, this.getBlockParam(itemId, object.type), cb);
+						};
+					});
 					break;
 			};
 		};

--- a/src/ts/component/util/toast.tsx
+++ b/src/ts/component/util/toast.tsx
@@ -29,7 +29,7 @@ const Toast = observer(class Toast extends React.Component<object, State> {
 		if (!toast) {
 			return null;
 		};
-
+        
         const { count, action, text, value, object, target, origin, ids } = toast;
 
         let buttons = [];
@@ -92,7 +92,7 @@ const Toast = observer(class Toast extends React.Component<object, State> {
 				};
 
 				textAction = translate(action == I.ToastAction.Collection ? 'toastAddedToCollection' : 'toastLinkedTo');
-				textObject = <Element {...object} />;
+                textObject = text.length ? text : <Element {...object} />;
 				textTarget = <Element {...target} />;
 
                 if (target.id != keyboard.getRootId()) {

--- a/src/ts/component/util/toast.tsx
+++ b/src/ts/component/util/toast.tsx
@@ -29,7 +29,7 @@ const Toast = observer(class Toast extends React.Component<object, State> {
 		if (!toast) {
 			return null;
 		};
-        
+
         const { count, action, text, value, object, target, origin, ids } = toast;
 
         let buttons = [];


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [X] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description
When selecting multiples object in a set/collection, add the option "Link to" in the contextual menu (like with only one objct)
Now we can link to multiples object at once.
Toaster is updated to show number of object linked.

![Capture d'écran 2023-09-22 170829](https://github.com/anyproto/anytype-ts/assets/16141040/e365b1aa-9d4b-4b71-906d-7aa579ecbe0a)


### What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
https://community.anytype.io/t/multi-select-link-to/9336/5

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [X] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [X] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?
No
