### PR TITLE
Improve keyboard control on emoji picker

### DIFF
--- a/src/ts/component/menu/smile.tsx
+++ b/src/ts/component/menu/smile.tsx
@@ -549,9 +549,9 @@ class MenuSmile extends React.Component<I.Menu, State> {
 		if (this.row == -1) {
 			return;
 		};
-		
+
 		this.coll += dir;
-		
+
 		const rows = this.getItems();
 		const current = rows[this.row];
 

--- a/src/ts/component/menu/smile.tsx
+++ b/src/ts/component/menu/smile.tsx
@@ -514,7 +514,6 @@ class MenuSmile extends React.Component<I.Menu, State> {
 
 	onArrowVertical (dir: number) {
 		const rows = this.getItems();
-		console.log('dir',dir);
 
 		this.row += dir;
 
@@ -537,7 +536,7 @@ class MenuSmile extends React.Component<I.Menu, State> {
 
 		const firstBlankIndex = current.children.findIndex((item: any) => item.itemId == ID_BLANK);
 
-		if (firstBlankIndex > -1) {
+		if ((firstBlankIndex > -1) && (firstBlankIndex <= this.coll)) {
 			this.coll = firstBlankIndex - 1;
 		}
 

--- a/src/ts/component/menu/smile.tsx
+++ b/src/ts/component/menu/smile.tsx
@@ -514,6 +514,7 @@ class MenuSmile extends React.Component<I.Menu, State> {
 
 	onArrowVertical (dir: number) {
 		const rows = this.getItems();
+		console.log('dir',dir);
 
 		this.row += dir;
 
@@ -534,11 +535,13 @@ class MenuSmile extends React.Component<I.Menu, State> {
 			return;
 		};
 
-		const child = current.children[this.coll];
+		const firstBlankIndex = current.children.findIndex((item: any) => item.itemId == ID_BLANK);
 
-		if ((this.coll > current.children.length) || (child && (child.itemId == ID_BLANK))) {
-			this.coll = 0;
-		};
+		if (firstBlankIndex > -1) {
+			this.coll = firstBlankIndex - 1;
+		}
+
+		const child = current.children[this.coll];
 
 		this.setActive(child, this.row);
 	};
@@ -547,9 +550,9 @@ class MenuSmile extends React.Component<I.Menu, State> {
 		if (this.row == -1) {
 			return;
 		};
-
+		
 		this.coll += dir;
-
+		
 		const rows = this.getItems();
 		const current = rows[this.row];
 


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description
When using the keyboard to control the emoji picker, the column index of the selected item will become 0 under the following two situations:
1. when moving left and right across section titles.
2. when moving up and down to a blank space.

This clearly isn't very reasonable, so I fixed it.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
