### PR TITLE
Bug/leapyear: Fixed the calculation of leap years and incorrect display of feb29 on…

### DIFF
--- a/src/ts/lib/util/date.ts
+++ b/src/ts/lib/util/date.ts
@@ -65,7 +65,7 @@ class UtilDate {
 		m = Math.min(12, Math.max(1, m));
 
 		let maxDays = Constant.monthDays[m];
-		if ((m == 2) && (y % 4 === 0)) {
+		if ((m == 2) && (this.isLeapYear(y))) {
 			maxDays = 29;
 		};
 		d = Math.min(maxDays, Math.max(1, d));
@@ -286,10 +286,10 @@ class UtilDate {
 
 	getCalendarMonth (value: number) {
 		const { m, y } = this.getCalendarDateParam(value);
-		const md = Constant.monthDays;
+		const md = {...Constant.monthDays};
 		
 		// February
-		if (y % 4 === 0) {
+		if (this.isLeapYear(y)) {
 			md[2] = 29;
 		};
 		
@@ -323,6 +323,26 @@ class UtilDate {
 		};
 
 		return days;
+	};
+
+	/**
+	 * Checks wether a given year is a leap year.
+	 * @remarks A given year is considered a leap year, if it's divisible by 4, but not divisible by 100, unless also divisible by 400.
+	 * 
+	 * @param year - the year to check.
+	 * @returns True, if the given year is considered a leap year.
+	 */
+	isLeapYear (year: number): boolean {
+		if (year % 4 !== 0) {
+			return false;
+		}
+		if (year % 400 === 0) {
+			return true;
+		}
+		if (year % 100 === 0) {
+			return false;
+		}
+		return true;
 	};
 
 };

--- a/src/ts/lib/util/date.ts
+++ b/src/ts/lib/util/date.ts
@@ -326,7 +326,7 @@ class UtilDate {
 	};
 
 	/**
-	 * Checks wether a given year is a leap year.
+	 * Checks whether a given year is a leap year.
 	 * @remarks A given year is considered a leap year, if it's divisible by 4, but not divisible by 100, unless also divisible by 400.
 	 * 
 	 * @param year - the year to check.


### PR DESCRIPTION
… non leap years.

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->
---

### Description

This PR fixes (1) the calculation of leap years and (2) the incorrect display of February 29th in non leap years.

1. Leap years are currently calculated as `year % 4 === 0`. This is incorrect. A year is actually considered a leap year, if it is divisible by 4, but not by 100, unless it's also divisible by 400. That means, that the years 2000 and 2024 are leap years, but the year 2100 is not.
This is fixed by adding a function `isLeapYear (year: number): boolean` and replacing the previous calculations with calling this function.

2. Currently, if a calendar (as date selector or view) displays a February in a leap year, it will display a Feb 29th for every February that is displayed afterwards, regardless of whether that year is a leap year.
This is fixed by copying `Constant.monthDays` contents, instead of manipulating it directly: `const md = {...Constant.monthDays}`.


<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

An example how February 29th is displayed in 2025, despite it not being a leap year.

![feb2025](https://github.com/anyproto/anytype-ts/assets/155772554/2059a42d-4f0d-4830-96cc-539e64227606)

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?

No

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
