### PR TITLE
Prohibit clicking already activated tab

### DIFF
--- a/src/ts/component/page/main/store.tsx
+++ b/src/ts/component/page/main/store.tsx
@@ -322,8 +322,12 @@ const PageMainStore = observer(class PageMainStore extends React.Component<I.Pag
 	onTab (id: any, isInner: boolean) {
 		const { isPopup } = this.props;
 
+		if (this.tab == id) {
+			return;
+		};
+
 		this.tab = id;
-		this.onView(Storage.get('viewStore') || View.Library, isInner);
+		this.onView(Storage.get('viewStore') || View.Library, isInner, true);
 
 		Storage.set('tabStore', id);
 
@@ -340,7 +344,11 @@ const PageMainStore = observer(class PageMainStore extends React.Component<I.Pag
 		};
 	};
 
-	onView (id: View, isInner: boolean) {
+	onView (id: View, isInner: boolean, isChangeTab: boolean = false) {
+		if (!isChangeTab && this.view == id) {
+			return;
+		};
+
 		this.view = id;
 		this.getData(true);
 

--- a/src/ts/component/page/main/store.tsx
+++ b/src/ts/component/page/main/store.tsx
@@ -273,7 +273,7 @@ const PageMainStore = observer(class PageMainStore extends React.Component<I.Pag
 
 		this.resize();
 		this.rebind();
-		this.onTab(Storage.get('tabStore') || I.StoreTab.Type, false);
+		this.onTab(Storage.get('tabStore') || I.StoreTab.Type, false, true);
 	};
 
 	componentDidUpdate () {
@@ -319,10 +319,10 @@ const PageMainStore = observer(class PageMainStore extends React.Component<I.Pag
 		return h;
 	};
 
-	onTab (id: any, isInner: boolean) {
+	onTab (id: any, isInner: boolean, isMount: boolean = false) {
 		const { isPopup } = this.props;
 
-		if (this.tab == id) {
+		if (!isMount && this.tab == id) {
 			return;
 		};
 

--- a/src/ts/component/page/main/store.tsx
+++ b/src/ts/component/page/main/store.tsx
@@ -33,7 +33,7 @@ const PageMainStore = observer(class PageMainStore extends React.Component<I.Pag
 	cache: any = null;
 	refList: any = null;
 	refFilter: any = null;
-	tab: I.StoreTab = I.StoreTab.Type;
+	tab: I.StoreTab = null;
 	view: View = View.Marketplace;
 	frame = 0;
 	limit = 0;
@@ -273,7 +273,7 @@ const PageMainStore = observer(class PageMainStore extends React.Component<I.Pag
 
 		this.resize();
 		this.rebind();
-		this.onTab(Storage.get('tabStore') || I.StoreTab.Type, false, true);
+		this.onTab(Storage.get('tabStore') || I.StoreTab.Type, false);
 	};
 
 	componentDidUpdate () {
@@ -319,10 +319,10 @@ const PageMainStore = observer(class PageMainStore extends React.Component<I.Pag
 		return h;
 	};
 
-	onTab (id: any, isInner: boolean, isMount: boolean = false) {
+	onTab (id: any, isInner: boolean) {
 		const { isPopup } = this.props;
 
-		if (!isMount && this.tab == id) {
+		if (this.tab == id) {
 			return;
 		};
 

--- a/src/ts/component/page/main/store.tsx
+++ b/src/ts/component/page/main/store.tsx
@@ -345,7 +345,7 @@ const PageMainStore = observer(class PageMainStore extends React.Component<I.Pag
 	};
 
 	onView (id: View, isInner: boolean, isChangeTab: boolean = false) {
-		if (!isChangeTab && this.view == id) {
+		if (!isChangeTab && (this.view == id)) {
 			return;
 		};
 


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description
CLS are very annoying things, and would be even more annoying if they could frequently trigger.
It is better to start from prohibiting activated tab from being repeatedly clicked.
![before](https://github.com/anyproto/anytype-ts/assets/48022591/d67894be-927f-4da7-a570-f825a5f432b4)


### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents


### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
