### PR TITLE
Remove "duplicate" keyboard shortcut:

### DIFF
--- a/src/ts/component/popup/shortcut.tsx
+++ b/src/ts/component/popup/shortcut.tsx
@@ -260,8 +260,6 @@ class PopupShortcut extends React.Component<I.Popup, State> {
 							{ com: '->',				 name: UtilCommon.sprintf(translate('popupShortcutMarkdownWhileTypingInserts'), '→') },
 							{ com: '<-',				 name: UtilCommon.sprintf(translate('popupShortcutMarkdownWhileTypingInserts'), '←') },
 							{ com: '--',				 name: UtilCommon.sprintf(translate('popupShortcutMarkdownWhileTypingInserts'), '—') },
-							{ com: '—>',				 name: UtilCommon.sprintf(translate('popupShortcutMarkdownWhileTypingInserts'), '⟶') },
-							{ com: '<—',				 name: UtilCommon.sprintf(translate('popupShortcutMarkdownWhileTypingInserts'), '⟵') },
 							{ com: '(c)',				 name: UtilCommon.sprintf(translate('popupShortcutMarkdownWhileTypingInserts'), '©') },
 							{ com: '(r)',				 name: UtilCommon.sprintf(translate('popupShortcutMarkdownWhileTypingInserts'), '®') },
 							{ com: '(tm)',				 name: UtilCommon.sprintf(translate('popupShortcutMarkdownWhileTypingInserts'), '™') },


### PR DESCRIPTION
### Description

Reason: The mdash variant is confusing to most users and will probably barely be used. It seems better to keep docs concise and not overwhelm with dupllicate options to accomplish the same thing.

### What type of PR is this? (check all applicable)

- [x] 📝 Documentation Update

### Desktop Screenshot

![image](https://github.com/anyproto/anytype-ts/assets/2923/5b6c41c0-1089-4d4c-b14f-1e650eb76c44)

### Added tests?

- [x] 🙅 no, because they aren't needed

### Added to documentation?

- [x] 🙅 no documentation needed

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)