### PR TITLE
fix double accountSelect on start

### DIFF
--- a/src/ts/component/page/auth/setup.tsx
+++ b/src/ts/component/page/auth/setup.tsx
@@ -137,7 +137,6 @@ const PageAuthSetup = observer(class PageAuthSetup extends React.Component<I.Pag
 						return;
 					};
 
-					this.select(accountId, false);
 				});
 			});
 		});

--- a/src/ts/component/page/auth/setup.tsx
+++ b/src/ts/component/page/auth/setup.tsx
@@ -120,24 +120,29 @@ const PageAuthSetup = observer(class PageAuthSetup extends React.Component<I.Pag
 		const { dataPath } = commonStore;  
 		const accountId = Storage.get('accountId');
 
+		if (!accountId) {
+			UtilRouter.go('/auth/account-select', { replace: true });
+			return;
+		}
+
 		Renderer.send('keytarGet', accountId).then((phrase: string) => {
 			C.WalletRecover(dataPath, phrase, (message: any) => {
 				if (this.setError(message.error)) {
 					return;
 				};
 
-				if (accountId) {
-					this.select(accountId, false);
+				if (phrase) {
+					UtilData.createSession(phrase, '' ,(message: any) => {
+						if (this.setError(message.error)) {
+							return;
+						};
+
+						this.select(accountId, false);
+					});
 				} else {
 					UtilRouter.go('/auth/account-select', { replace: true });
 				};
 
-				UtilData.createSession(phrase, '' ,(message: any) => {
-					if (this.setError(message.error)) {
-						return;
-					};
-
-				});
 			});
 		});
 	};

--- a/src/ts/component/page/auth/setup.tsx
+++ b/src/ts/component/page/auth/setup.tsx
@@ -123,7 +123,7 @@ const PageAuthSetup = observer(class PageAuthSetup extends React.Component<I.Pag
 		if (!accountId) {
 			UtilRouter.go('/auth/account-select', { replace: true });
 			return;
-		}
+		};
 
 		Renderer.send('keytarGet', accountId).then((phrase: string) => {
 			C.WalletRecover(dataPath, phrase, (message: any) => {


### PR DESCRIPTION
For the full-client the account cycle should be one of these
1. WalletRecover (deprecated, to be removed later)
2. WalletCreateSession
3. AccountSelect

or

1. WalletCreate
2. WalletCreateSession
3. AccountCreate.

Currently it was a bug that accountSelect was called twice, like this
1. WalletRecover
2. AccountSelect
3. WalletCreateSession
4. AccountSelect

This resulted in the second AccountSelect being hanging and waiting for the lock of the first accountSelect. After first accountSelect finishes, the second returns success without ding any work under the hood. 
But in case of problems, e.g. when AccountSelect was unsuccessful, the second accountSelect actually was starting it over again.
Also, in the last changes in mw we introduced account-start cancelation https://github.com/anyproto/anytype-heart/pull/1050. So this error becomes even more critical