### PR TITLE
ci: downgrade macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        os: [ macos-12, ubuntu-latest, windows-latest ]
 
     steps:
       - name: Setup


### PR DESCRIPTION
Compiling electron on macOS 14 and running on macOS 11 leads to segfault