### PR TITLE
Last opened object homepage setting with window context

### DIFF
--- a/electron/js/window.js
+++ b/electron/js/window.js
@@ -226,11 +226,6 @@ class WindowManager {
 		return { x, y };
 	};
 
-	getWindowId () {
-		const currentWindow = BrowserWindow.getFocusedWindow();
-		return currentWindow.id;
-	}
-
 	sendToAll () {
 		const args = [ ...arguments ];
 		this.list.forEach(it => Util.send.apply(this, [ it ].concat(args)));

--- a/electron/js/window.js
+++ b/electron/js/window.js
@@ -53,6 +53,10 @@ class WindowManager {
 
 		this.list.add(win);
 
+		win.on('close', () => {
+			Util.send(win, 'will-close-window', win.id);
+		});
+
 		win.on('closed', () => {
 			this.list.delete(win);
 			win = null;
@@ -60,7 +64,7 @@ class WindowManager {
 
 		win.on('focus', () => { 
 			UpdateManager.setWindow(win);
-			MenuManager.setWindow(win); 
+			MenuManager.setWindow(win);
 		});
 		win.on('enter-full-screen', () => Util.send(win, 'enter-full-screen'));
 		win.on('leave-full-screen', () => Util.send(win, 'leave-full-screen'));
@@ -234,7 +238,7 @@ class WindowManager {
 	reloadAll () {
 		this.sendToAll('reload');
 	};
-
+	
 };
 
 module.exports = new WindowManager();

--- a/electron/js/window.js
+++ b/electron/js/window.js
@@ -226,6 +226,11 @@ class WindowManager {
 		return { x, y };
 	};
 
+	getWindowId () {
+		const currentWindow = BrowserWindow.getFocusedWindow();
+		return currentWindow.id;
+	}
+
 	sendToAll () {
 		const args = [ ...arguments ];
 		this.list.forEach(it => Util.send.apply(this, [ it ].concat(args)));

--- a/src/ts/app.tsx
+++ b/src/ts/app.tsx
@@ -279,10 +279,12 @@ class App extends React.Component<object, State> {
 		Renderer.on('leave-full-screen', () => commonStore.fullscreenSet(false));
 		Renderer.on('logout', () => authStore.logout(false, false));
 		Renderer.on('data-path', (e: any, p: string) => commonStore.dataPathSet(p));
+		Renderer.on('will-close-window', this.onWillCloseWindow);
 
 		Renderer.on('shutdownStart', () => {
 			this.setState({ loading: true });
 			Storage.delete('menuSearchText');
+			Storage.deleteAllLastOpened();
 		});
 
 		Renderer.on('zoom', () => {
@@ -392,6 +394,10 @@ class App extends React.Component<object, State> {
 		} else {
 			cb();
 		};
+	};
+
+	onWillCloseWindow (e: any, windowId: string) {
+		Storage.deleteLastOpenedByWindowId([windowId]);
 	};
 
 	onPopup (e: any, id: string, param: any, close?: boolean) {

--- a/src/ts/lib/action.ts
+++ b/src/ts/lib/action.ts
@@ -336,7 +336,7 @@ class Action {
 					};
 
 					// Remove last opened objects in case any is deleted
-					Storage.unsetLastOpened(ids);
+					Storage.deleteLastOpenedByObjectId(ids);
 
 					analytics.event('RemoveCompletely', { count, route });
 				},

--- a/src/ts/lib/action.ts
+++ b/src/ts/lib/action.ts
@@ -335,10 +335,12 @@ class Action {
 						callBack();
 					};
 
+					const windowId = UtilCommon.getCurrentElectronWindowId();
+
 					// Remove last opened object in case it is deleted
-					const home = Storage.get('lastOpened');
+					const home = Storage.get('lastOpened')[windowId];
 					if (home && ids.includes(home.id)) {
-						Storage.delete('lastOpened');
+						Storage.unsetPath('lastOpened', [`${windowId}`]);
 					};
 
 					analytics.event('RemoveCompletely', { count, route });

--- a/src/ts/lib/action.ts
+++ b/src/ts/lib/action.ts
@@ -335,13 +335,8 @@ class Action {
 						callBack();
 					};
 
-					const windowId = UtilCommon.getCurrentElectronWindowId();
-
-					// Remove last opened object in case it is deleted
-					const home = Storage.get('lastOpened')[windowId];
-					if (home && ids.includes(home.id)) {
-						Storage.unsetPath('lastOpened', [`${windowId}`]);
-					};
+					// Remove last opened objects in case any is deleted
+					Storage.unsetLastOpened(ids);
 
 					analytics.event('RemoveCompletely', { count, route });
 				},

--- a/src/ts/lib/api/command.ts
+++ b/src/ts/lib/api/command.ts
@@ -1309,9 +1309,8 @@ export const ObjectOpen = (objectId: string, traceId: string, spaceId: string, c
 		// Save last opened object
 		const object = detailStore.get(objectId, objectId, []);
 		const windowId = UtilCommon.getCurrentElectronWindowId();
-
 		if (!object._empty_ && ![ I.ObjectLayout.Dashboard ].includes(object.layout)) {
-			Storage.set('lastOpened', { [windowId]: { id: object.id, layout: object.layout, spaceId: object.spaceId }});
+			Storage.setLastOpened(windowId, { id: object.id, layout: object.layout, spaceId: object.spaceId });
 		};
 
 		if (callBack) {

--- a/src/ts/lib/api/command.ts
+++ b/src/ts/lib/api/command.ts
@@ -1308,8 +1308,10 @@ export const ObjectOpen = (objectId: string, traceId: string, spaceId: string, c
 
 		// Save last opened object
 		const object = detailStore.get(objectId, objectId, []);
+		const windowId = UtilCommon.getCurrentElectronWindowId();
+
 		if (!object._empty_ && ![ I.ObjectLayout.Dashboard ].includes(object.layout)) {
-			Storage.set('lastOpened', { id: object.id, layout: object.layout, spaceId: object.spaceId });
+			Storage.set('lastOpened', { [windowId]: { id: object.id, layout: object.layout, spaceId: object.spaceId }});
 		};
 
 		if (callBack) {

--- a/src/ts/lib/storage.ts
+++ b/src/ts/lib/storage.ts
@@ -58,35 +58,6 @@ class Storage {
 			this.storage[key] = JSON.stringify(o);
 		};
 	};
-
-	unsetPath (key: string, path: string[]): void {
-		if (!key || !path) {
-			console.log('[Storage].unset: key or path not specified');
-			return;
-		};
-		
-		const o = this.get(key);
-
-		if ((typeof o !== 'object') || (o !== null) || path.length == 0) {
-			console.log('[Storage].unset: unset should be used on a stored object with a valid path');
-			return;
-		}
-
-		const lastKey = path.pop();
-		let aux = o;
-
-		for (const pathKey in path) {
-			aux = aux[pathKey];
-		}
-
-		delete aux[lastKey];
-
-		if (this.isSpaceKey(key)) {
-			this.setSpaceKey(key, o);
-		} else {
-			this.storage[key] = JSON.stringify(o);
-		};
-	};
 	
 	delete (key: string) {
 		if (this.isSpaceKey(key)) {
@@ -135,6 +106,32 @@ class Storage {
 		delete(obj[id]);
 
 		this.setSpace(obj);
+	};
+
+	setLastOpened (windowId: string, param: any) {
+		const obj = this.get('lastOpened') || {};
+		obj[windowId] = Object.assign(obj[windowId] || {}, param);
+		this.set('lastOpened', obj, true);
+	};
+
+	unsetLastOpened (objectIds: string[]) {
+		const obj = this.get('lastOpened') || {};
+
+		let windowIdsToDelete = Object.keys(obj).reduce(
+			(windowIds, windowId) => objectIds.includes(obj[windowId].id) ? windowIds.concat(windowId) : windowIds, []
+		);
+
+		if (windowIdsToDelete.length == 0) {
+			return;
+		}
+
+		windowIdsToDelete.forEach ((windowId) => delete(obj[windowId]));
+		this.set('lastOpened', obj, true);
+	}
+	
+	getLastOpened (windowId: string) {
+		const obj = this.get('lastOpened') || {};
+		return obj[windowId];
 	};
 
 	setToggle (rootId: string, id: string, value: boolean) {

--- a/src/ts/lib/storage.ts
+++ b/src/ts/lib/storage.ts
@@ -133,7 +133,7 @@ class Storage {
 
 		if (!homeIncluded) {
 			windowIdsToDelete = windowIdsToDelete.filter((id) => id !== '1');
-		}
+		};
 
 		windowIdsToDelete.forEach ((windowId) => delete(obj[windowId]));
 		this.set('lastOpened', obj, true);

--- a/src/ts/lib/storage.ts
+++ b/src/ts/lib/storage.ts
@@ -65,7 +65,7 @@ class Storage {
 			return;
 		};
 		
-		let o = this.get(key);
+		const o = this.get(key);
 
 		if ((typeof o !== 'object') || (o !== null) || path.length == 0) {
 			console.log('[Storage].unset: unset should be used on a stored object with a valid path');

--- a/src/ts/lib/storage.ts
+++ b/src/ts/lib/storage.ts
@@ -118,12 +118,12 @@ class Storage {
 		const obj = this.get('lastOpened') || {};
 
 		let windowIdsToDelete = Object.keys(obj).reduce(
-			(windowIds, windowId) => objectIds.includes(obj[windowId].id) ? windowIds.concat(windowId) : windowIds, []
+			(windowIds, windowId) => !obj[windowId] || objectIds.includes(obj[windowId].id) ? windowIds.concat(windowId) : windowIds, []
 		);
 
 		if (windowIdsToDelete.length == 0) {
 			return;
-		}
+		};
 
 		windowIdsToDelete.forEach ((windowId) => delete(obj[windowId]));
 		this.set('lastOpened', obj, true);

--- a/src/ts/lib/storage.ts
+++ b/src/ts/lib/storage.ts
@@ -114,20 +114,36 @@ class Storage {
 		this.set('lastOpened', obj, true);
 	};
 
-	unsetLastOpened (objectIds: string[]) {
+	deleteLastOpenedByObjectId (objectIds: string[]) {
 		const obj = this.get('lastOpened') || {};
 
 		let windowIdsToDelete = Object.keys(obj).reduce(
 			(windowIds, windowId) => !obj[windowId] || objectIds.includes(obj[windowId].id) ? windowIds.concat(windowId) : windowIds, []
 		);
 
+		this.deleteLastOpenedByWindowId(windowIdsToDelete, true);
+	};
+
+	deleteLastOpenedByWindowId (windowIdsToDelete: string[], homeIncluded?: boolean) {
 		if (windowIdsToDelete.length == 0) {
 			return;
 		};
 
+		const obj = this.get('lastOpened') || {};
+
+		if (!homeIncluded) {
+			windowIdsToDelete = windowIdsToDelete.filter((id) => id !== '1');
+		}
+
 		windowIdsToDelete.forEach ((windowId) => delete(obj[windowId]));
 		this.set('lastOpened', obj, true);
-	}
+	};
+
+	deleteAllLastOpened () {
+		const obj = this.get('lastOpened') || {};
+		let windowIdsToDelete = Object.keys(obj);
+		this.deleteLastOpenedByWindowId(windowIdsToDelete);
+	};
 	
 	getLastOpened (windowId: string) {
 		const obj = this.get('lastOpened') || {};

--- a/src/ts/lib/storage.ts
+++ b/src/ts/lib/storage.ts
@@ -58,6 +58,35 @@ class Storage {
 			this.storage[key] = JSON.stringify(o);
 		};
 	};
+
+	unsetPath (key: string, path: string[]): void {
+		if (!key || !path) {
+			console.log('[Storage].unset: key or path not specified');
+			return;
+		};
+		
+		let o = this.get(key);
+
+		if ((typeof o !== 'object') || (o !== null) || path.length == 0) {
+			console.log('[Storage].unset: unset should be used on a stored object with a valid path');
+			return;
+		}
+
+		const lastKey = path.pop();
+		let aux = o;
+
+		for (const pathKey in path) {
+			aux = aux[pathKey];
+		}
+
+		delete aux[lastKey];
+
+		if (this.isSpaceKey(key)) {
+			this.setSpaceKey(key, o);
+		} else {
+			this.storage[key] = JSON.stringify(o);
+		};
+	};
 	
 	delete (key: string) {
 		if (this.isSpaceKey(key)) {

--- a/src/ts/lib/util/common.ts
+++ b/src/ts/lib/util/common.ts
@@ -14,14 +14,14 @@ class UtilCommon {
 		return window.Electron || {};
 	};
 
-	getCurrentElectronWindowId () {
+	getCurrentElectronWindowId (): string {
 		const electron = this.getElectron();
 
 		if (!electron) {
-			return 0;
+			return '0';
 		}
 
-		return electron.currentWindow().windowId;
+		return electron.currentWindow().windowId.toString();
 	}
 
 	getGlobalConfig () {

--- a/src/ts/lib/util/common.ts
+++ b/src/ts/lib/util/common.ts
@@ -14,6 +14,16 @@ class UtilCommon {
 		return window.Electron || {};
 	};
 
+	getCurrentElectronWindowId () {
+		const electron = this.getElectron();
+
+		if (!electron) {
+			return 0;
+		}
+
+		return electron.currentWindow().windowId;
+	}
+
 	getGlobalConfig () {
 		return window.AnytypeGlobalConfig || {};
 	};

--- a/src/ts/lib/util/common.ts
+++ b/src/ts/lib/util/common.ts
@@ -19,7 +19,7 @@ class UtilCommon {
 
 		if (!electron) {
 			return '0';
-		}
+		};
 
 		return electron.currentWindow().windowId.toString();
 	}

--- a/src/ts/lib/util/common.ts
+++ b/src/ts/lib/util/common.ts
@@ -22,7 +22,7 @@ class UtilCommon {
 		};
 
 		return electron.currentWindow().windowId.toString();
-	}
+	};
 
 	getGlobalConfig () {
 		return window.AnytypeGlobalConfig || {};

--- a/src/ts/lib/util/space.ts
+++ b/src/ts/lib/util/space.ts
@@ -10,7 +10,8 @@ class UtilSpace {
 		
 		let home = this.getDashboard();
 		if (home && (home.id == I.HomePredefinedId.Last)) {
-			home = Storage.get('lastOpened');
+			const windowId = UtilCommon.getCurrentElectronWindowId();
+			home = Storage.get('lastOpened')[windowId];
 			if (home && !home.spaceId) {
 				home.spaceId = commonStore.space;
 			};

--- a/src/ts/lib/util/space.ts
+++ b/src/ts/lib/util/space.ts
@@ -11,7 +11,7 @@ class UtilSpace {
 		let home = this.getDashboard();
 		if (home && (home.id == I.HomePredefinedId.Last)) {
 			const windowId = UtilCommon.getCurrentElectronWindowId();
-			home = Storage.get('lastOpened')[windowId];
+			home = Storage.getLastOpened(windowId);
 			if (home && !home.spaceId) {
 				home.spaceId = commonStore.space;
 			};


### PR DESCRIPTION
- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---

### Description

### What

This PR makes it so that the _Last opened object_ homepage setting now considers the context of different windows (i.e. different windows have different last opened objects and each is loaded accordingly when the _Last opened object_ home page setting is selected).

Also when closing a window its object is removed from the local storage _Last opened_ context and when closing the app all objects, besides the last opened for by the first window, are removed from the local storage.

### Why

*The reasoning here is based on my usage and is open for discussion*

#### Practical reason

Currently when users have the _Last opened object_ homepage selected and have multiple windows opened, any time any of those windows are refreshed it then loads the last opened object period (which in many cases was opened in another window).

One example in my workflow is: I have a window with a set of active notes on different topics and frequently either create a new note in the set and open it in a new window or open an active note in a new window. The window with the set of notes should always only display that object, but opening new notes on new pages overrides the _Lsat opened object_ and after having the computer go to sleep and wake it up again, now all windows show the same object (which was the created/opened note).

#### Reasonable... reason

It seems reasonable to me that users with the _Last opened object_ homepage selected wouldn't want all windows to load the same object after a mass refresh (such as the computer waking up from sleep) 😜 .

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed