### PR TITLE
Checkbox toggle shortcut

### DIFF
--- a/src/json/text.json
+++ b/src/json/text.json
@@ -1129,7 +1129,7 @@
 	"popupShortcutNavigationMenu4": "Go to the right side of navigation. Link to page",
 	"popupShortcutNavigationMenu5": "Select option",
 	"popupShortcutNavigationPage": "Editor navigation",
-	"popupShortcutNavigationPage1": "Expand / Collapse Toggle; Check / Uncheck Checkbox",
+	"popupShortcutNavigationPage1": "Expand / Collapse Toggle",
 	"popupShortcutNavigationPage2": "Go down one line",
 	"popupShortcutNavigationPage3": "Go up one line",
 	"popupShortcutNavigationPage4": "Go to the start of the line",
@@ -1138,6 +1138,7 @@
 	"popupShortcutNavigationPage7": "Go to the end of the Object",
 	"popupShortcutNavigationPage8": "Move selected block(s) around",
 	"popupShortcutNavigationPage9": "Open relations view",
+	"popupShortcutNavigationPage10": "Check / Uncheck Checkbox",
 	
 	"popupShortcutMarkdownWhileTyping": "While typing",
 	"popupShortcutMarkdownWhileTyping1": "Inline code",

--- a/src/json/text.json
+++ b/src/json/text.json
@@ -1129,7 +1129,7 @@
 	"popupShortcutNavigationMenu4": "Go to the right side of navigation. Link to page",
 	"popupShortcutNavigationMenu5": "Select option",
 	"popupShortcutNavigationPage": "Editor navigation",
-	"popupShortcutNavigationPage1": "Expand / Collapse Toggle",
+	"popupShortcutNavigationPage1": "Expand / Collapse Toggle; Check / Uncheck Checkbox",
 	"popupShortcutNavigationPage2": "Go down one line",
 	"popupShortcutNavigationPage3": "Go up one line",
 	"popupShortcutNavigationPage4": "Go to the start of the line",

--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -793,8 +793,16 @@ const EditorPage = observer(class EditorPage extends React.Component<Props, Stat
 			});
 
 			if (block.isTextToggle()) {
-				keyboard.shortcut(`${cmd}+shift+t`, e, () => {
+				keyboard.shortcut(`${cmd}+enter`, e, () => {
 					blockStore.toggle(rootId, block.id, !Storage.checkToggle(rootId, block.id));
+				});
+			};
+
+			if (block.isTextCheckbox()) {
+				keyboard.shortcut(`${cmd}+enter`, e, () => {
+					UtilData.blockSetText(rootId, block.id, text, marks, true, () => {
+						C.BlockTextSetChecked(rootId, block.id, !block.content.checked);
+					});
 				});
 			};
 		};

--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -793,7 +793,7 @@ const EditorPage = observer(class EditorPage extends React.Component<Props, Stat
 			});
 
 			if (block.isTextToggle()) {
-				keyboard.shortcut(`${cmd}+enter`, e, () => {
+				keyboard.shortcut(`${cmd}+shift+t`, e, () => {
 					blockStore.toggle(rootId, block.id, !Storage.checkToggle(rootId, block.id));
 				});
 			};

--- a/src/ts/component/popup/shortcut.tsx
+++ b/src/ts/component/popup/shortcut.tsx
@@ -229,7 +229,7 @@ class PopupShortcut extends React.Component<I.Popup, State> {
 
 					{
 						name: translate('popupShortcutNavigationPage'), children: [
-							{ com: `${cmd} + Shift + T`, name: translate('popupShortcutNavigationPage1') },
+							{ com: `${cmd} + Enter`, name: translate('popupShortcutNavigationPage1') },
 							{ com: '↓',				 name: translate('popupShortcutNavigationPage2') },
 							{ com: '↑',				 name: translate('popupShortcutNavigationPage3') },
 							{ com: `${cmd} + ←`,	 name: translate('popupShortcutNavigationPage4') },

--- a/src/ts/component/popup/shortcut.tsx
+++ b/src/ts/component/popup/shortcut.tsx
@@ -229,7 +229,7 @@ class PopupShortcut extends React.Component<I.Popup, State> {
 
 					{
 						name: translate('popupShortcutNavigationPage'), children: [
-							{ com: `${cmd} + Enter`, name: translate('popupShortcutNavigationPage1') },
+							{ com: `${cmd} + Shift + T`, name: translate('popupShortcutNavigationPage1') },
 							{ com: '↓',				 name: translate('popupShortcutNavigationPage2') },
 							{ com: '↑',				 name: translate('popupShortcutNavigationPage3') },
 							{ com: `${cmd} + ←`,	 name: translate('popupShortcutNavigationPage4') },
@@ -238,6 +238,7 @@ class PopupShortcut extends React.Component<I.Popup, State> {
 							{ com: `${cmd} + ↓`,	 name: translate('popupShortcutNavigationPage7') },
 							{ com: `${cmd} + Shift + ↑↓`, name: translate('popupShortcutNavigationPage8') },
 							{ com: `${cmd} + Shift + R`, name: translate('popupShortcutNavigationPage9') },
+							{ com: `${cmd} + Enter`, name: translate('popupShortcutNavigationPage10') },
 						]
 					},
 				],


### PR DESCRIPTION
- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---

### Description

### What
This PR adds a new shortcut for checking/unchecking checkboxes and suggests a change to the shortcut for expanding/collapsing toggles for both to be the same.

### Why
It's very practical to be able to mark checkbox items in a list when you can do that directly from the keyboard in a text heavy application.

The suggestion for the toggle shortcut is to keep both equal, since they both have similar effects, and with easier access. Since `cmd + enter` wasn't being currently used in Anytype and other similar apps in the market use that combination, I thought it would make sense.

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed