### PR TITLE
feat: Add the ability to upload gifs as page cover/icon

### DIFF
--- a/src/json/constant.json
+++ b/src/json/constant.json
@@ -58,7 +58,7 @@
 	"fileExtension": {
 		"image": [ "jpg", "jpeg", "png", "gif", "svg", "webp" ],
 		"video": [ "mp4", "m4v", "mov" ],
-		"cover": [ "jpg", "jpeg", "png" ],
+		"cover": [ "jpg", "jpeg", "png", "gif" ],
 		"audio": [ "mp3", "m4a", "flac", "ogg", "wav" ],
 		"pdf": [ "pdf" ],
 		"import": {


### PR DESCRIPTION
- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)
---

### Description

This PR adds the ability to use GIFs in page cover/icon.

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

**Being able to use GIF as wallpaper, object/page icon and cover** : https://community.anytype.io/t/being-able-to-use-gif-as-wallpaper-object-page-icon-and-cover/4698

**File upload prompt does not list all the eligible filetypes** : https://community.anytype.io/t/file-upload-prompt-does-not-list-all-the-eligible-filetypes/5041/1

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed