### PR TITLE
use plain as the default language code

### DIFF
--- a/src/json/constant.ts
+++ b/src/json/constant.ts
@@ -38,7 +38,7 @@ export default {
 
 	default: {
 		interfaceLang:	 'en-US',
-		codeLang:		 'javascript',
+		codeLang:		 'plain',
 		typeKey:		 'ot-note',
 		pinTime:		 600,
 	},

--- a/src/ts/component/form/select.tsx
+++ b/src/ts/component/form/select.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import $ from 'jquery';
-import { I, S, Relation } from 'Lib';
+import { I, S, J, Relation } from 'Lib';
 import { Icon, MenuItemVertical } from 'Component';
 
 interface Props {
@@ -68,8 +68,9 @@ class Select extends React.Component<Props, State> {
 			};
 		});
 
-		if (!current.length && options.length) {
-			current.push(options[0]);
+		if (!current.length) {
+			const { codeLang } = J.Constant.default;
+			current.push({ id: codeLang, name: J.Lang.code[codeLang] });
 		};
 
 		let onClick = null;


### PR DESCRIPTION
---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---

### Description

For the cases that some unsupported code snippets are pasted:

````
```bar
foo
```
````

Currently, Anytype automatically treats unsupported code snippets as `javascript`, which complicates the migration process.

I believe keeping the default as plain text is better because:

1. Anytype already remembers historical choices, so this won't burden the creation of new code snippets.

2. There is no data indicating that defaulting to JavaScript better aligns with user habits.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
