### PR TITLE
use yyyy.mm.dd format for date input if the date display format is ISO

### DIFF
--- a/src/ts/component/block/dataview/cell/text.tsx
+++ b/src/ts/component/block/dataview/cell/text.tsx
@@ -83,18 +83,18 @@ const CellText = observer(class CellText extends React.Component<I.Cell, State> 
 						mask.push('9999.99.99');
 						ph.push('yyyy.mm.dd');
 						break;
-					}
+					};
 					case I.DateFormat.ShortUS: {
 						mask.push('99.99.9999');
 						ph.push('mm.dd.yyyy');
 						break;
-					}
+					};
 					default: {
 						mask.push('99.99.9999');
 						ph.push('dd.mm.yyyy');
 						break;
-					}
-				}
+					};
+				};
 				
 				if (viewRelation.includeTime) {
 					mask.push('99:99');
@@ -255,16 +255,16 @@ const CellText = observer(class CellText extends React.Component<I.Cell, State> 
 					case I.DateFormat.ISO: {
 						format.push('Y.m.d');
 						break;
-					}
+					};
 					case I.DateFormat.ShortUS: {
 						format.push('m.d.Y');
 						break;
-					}
+					};
 					default: {
 						format.push('d.m.Y');
 						break;
-					}
-				}
+					};
+				};
 				if (viewRelation.includeTime) {
 					format.push('H:i');
 				};

--- a/src/ts/component/block/dataview/cell/text.tsx
+++ b/src/ts/component/block/dataview/cell/text.tsx
@@ -80,17 +80,17 @@ const CellText = observer(class CellText extends React.Component<I.Cell, State> 
 
 				switch (viewRelation.dateFormat) {
 					case I.DateFormat.ISO: {
-						mask.push('9999.99.99')
+						mask.push('9999.99.99');
 						ph.push('yyyy.mm.dd');
 						break;
 					}
 					case I.DateFormat.ShortUS: {
-						mask.push('99.99.9999')
+						mask.push('99.99.9999');
 						ph.push('mm.dd.yyyy');
 						break;
 					}
 					default: {
-						mask.push('99.99.9999')
+						mask.push('99.99.9999');
 						ph.push('dd.mm.yyyy');
 						break;
 					}

--- a/src/ts/component/block/dataview/cell/text.tsx
+++ b/src/ts/component/block/dataview/cell/text.tsx
@@ -75,14 +75,26 @@ const CellText = observer(class CellText extends React.Component<I.Cell, State> 
 				EditorComponent = () => <span>{value}</span>;
 			} else 
 			if (isDate) {
-				const mask = [ '99.99.9999' ];
+				const mask = [];
 				const ph = [];
 
-				if (viewRelation.dateFormat == I.DateFormat.ShortUS) {
-					ph.push('mm.dd.yyyy');
-				} else {
-					ph.push('dd.mm.yyyy');
-				};
+				switch (viewRelation.dateFormat) {
+					case I.DateFormat.ISO: {
+						mask.push('9999.99.99')
+						ph.push('yyyy.mm.dd');
+						break;
+					}
+					case I.DateFormat.ShortUS: {
+						mask.push('99.99.9999')
+						ph.push('mm.dd.yyyy');
+						break;
+					}
+					default: {
+						mask.push('99.99.9999')
+						ph.push('dd.mm.yyyy');
+						break;
+					}
+				}
 				
 				if (viewRelation.includeTime) {
 					mask.push('99:99');
@@ -238,9 +250,21 @@ const CellText = observer(class CellText extends React.Component<I.Cell, State> 
 				};
 			} else
 			if (relation.format == I.RelationType.Date) {
-				const format = [
-					(viewRelation.dateFormat == I.DateFormat.ShortUS) ? 'm.d.Y' : 'd.m.Y'
-				];
+				const format = [];
+				switch (viewRelation.dateFormat) {
+					case I.DateFormat.ISO: {
+						format.push('Y.m.d');
+						break;
+					}
+					case I.DateFormat.ShortUS: {
+						format.push('m.d.Y');
+						break;
+					}
+					default: {
+						format.push('d.m.Y');
+						break;
+					}
+				}
 				if (viewRelation.includeTime) {
 					format.push('H:i');
 				};

--- a/src/ts/lib/util/date.ts
+++ b/src/ts/lib/util/date.ts
@@ -51,16 +51,16 @@ class UtilDate {
 			case I.DateFormat.ISO: {
 				[ y, m, d ] = String(date || '').split('.');
 				break;
-			}
+			};
 			case I.DateFormat.ShortUS: {
 				[ m, d, y ] = String(date || '').split('.');
 				break;
-			}
+			};
 			default: {
 				[ d, m, y ] = String(date || '').split('.');
 				break;
-			}
-		}
+			};
+		};
 
 		[ h, i, s ] = String(time || '').split(':');
 

--- a/src/ts/lib/util/date.ts
+++ b/src/ts/lib/util/date.ts
@@ -47,11 +47,21 @@ class UtilDate {
 		let i: any = 0;
 		let s: any = 0;
 
-		if (format == I.DateFormat.ShortUS) {
-			[ m, d, y ] = String(date || '').split('.');
-		} else {
-			[ d, m, y ] = String(date || '').split('.');
-		};
+		switch (format) {
+			case I.DateFormat.ISO: {
+				[ y, m, d ] = String(date || '').split('.');
+				break;
+			}
+			case I.DateFormat.ShortUS: {
+				[ m, d, y ] = String(date || '').split('.');
+				break;
+			}
+			default: {
+				[ d, m, y ] = String(date || '').split('.');
+				break;
+			}
+		}
+
 		[ h, i, s ] = String(time || '').split(':');
 
 		y = Number(y) || 0;


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
Closes #891 

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
Before:
<img width="317" alt="スクリーンショット 2024-08-13 21 49 07" src="https://github.com/user-attachments/assets/27bf66c4-498a-4832-85dd-fab25ab25508">

After:
<img width="316" alt="スクリーンショット 2024-08-13 21 49 45" src="https://github.com/user-attachments/assets/c6025a67-6a54-4c2f-a468-39cfc24f3cc4">

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
