### PR TITLE
Feature/JS-5148: Local-only warning buttons update

### DIFF
--- a/src/json/text.json
+++ b/src/json/text.json
@@ -863,8 +863,8 @@
 	"popupSettingsOnboardingLocalOnlyWarningConfirm": "Yes, I understand",
 	"popupSettingsOnboardingLocalOnlyNote": "This is an experimental mode.<br/>Use at your own risk.",
 	"popupSettingsOnboardingLocalOnlyConfirmText": "Local-only mode is an experimental feature and does not provide security benefits. Please use it at your own risk, as data loss may occur.",
-	"popupSettingsOnboardingLocalOnlyConfirmConfirm": "I'm feeling lucky",
-	"popupSettingsOnboardingLocalOnlyConfirmCancel": "I’ll stay safe",
+	"popupSettingsOnboardingLocalOnlyConfirmConfirm": "Yes, I accept risks",
+	"popupSettingsOnboardingLocalOnlyConfirmCancel": "No, don’t use it",
 
 
 	"popupSettingsDataLocalFiles": "Local files",

--- a/src/scss/popup/confirm.scss
+++ b/src/scss/popup/confirm.scss
@@ -73,4 +73,9 @@
 		.innerWrap { width: 488px; padding: 24px; border-radius: 16px; background: linear-gradient(180deg, #fef2c6 0%, #ececec 100%); }
 		.label { margin-bottom: 12px; }
 	}
+
+	.popup.popupConfirm.localOnlyWarning {
+		.innerWrap { padding: 32px 32px 24px 32px; }
+		.buttons { flex-direction: column-reverse; gap: 8px 0px; }
+	}
 }

--- a/src/ts/component/popup/settings/onboarding.tsx
+++ b/src/ts/component/popup/settings/onboarding.tsx
@@ -160,12 +160,15 @@ const PopupSettingsOnboarding = observer(class PopupSettingsOnboarding extends R
 
 		if (this.config.mode == I.NetworkMode.Local) {
 			S.Popup.open('confirm', {
+				className: 'localOnlyWarning',
 				data: {
 					icon: 'warning',
 					title: translate('commonAreYouSure'),
 					text: translate('popupSettingsOnboardingLocalOnlyConfirmText'),
 					textConfirm: translate('popupSettingsOnboardingLocalOnlyConfirmConfirm'),
 					textCancel: translate('popupSettingsOnboardingLocalOnlyConfirmCancel'),
+					colorConfirm: 'blank',
+					colorCancel: 'blank',
 					onConfirm: save,
 					onCancel: () => {
 						this.config.mode = I.NetworkMode.Default;


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
