### PR TITLE
Fix create shortcut to use filter as name in the search popup

### DIFF
--- a/src/ts/component/popup/search.tsx
+++ b/src/ts/component/popup/search.tsx
@@ -436,6 +436,12 @@ const PopupSearch = observer(class PopupSearch extends React.Component<I.Popup, 
 				this.onClick(e, item);
 			};
 		});
+
+		keyboard.shortcut(`${cmd}+n`, e, () => {
+			e.preventDefault();
+
+			this.pageCreate(filter);
+		})
 	};
 
 	onArrow (dir: number) {
@@ -775,6 +781,10 @@ const PopupSearch = observer(class PopupSearch extends React.Component<I.Popup, 
 		});
 	};
 
+	pageCreate (filter: string) {
+		keyboard.pageCreate({ name: filter }, 'Search', [ I.ObjectFlag.SelectTemplate, I.ObjectFlag.DeleteEmpty ]);
+	}
+
 	filterMapper (it: any, config: any) {
 		return !(it.isHidden && !config.debug.hiddenObject);
 	};
@@ -834,7 +844,7 @@ const PopupSearch = observer(class PopupSearch extends React.Component<I.Popup, 
 			} else {
 				switch (item.id) {
 					case 'add': {
-						keyboard.pageCreate({ name: filter }, 'Search', [ I.ObjectFlag.SelectTemplate, I.ObjectFlag.DeleteEmpty ]);
+						this.pageCreate(filter)
 						break;
 					};
 

--- a/src/ts/lib/keyboard.ts
+++ b/src/ts/lib/keyboard.ts
@@ -267,8 +267,10 @@ class Keyboard {
 			if (canWrite) {
 				// Create new page
 				this.shortcut(`${cmd}+n`, e, () => {
-					e.preventDefault();
-					this.pageCreate({}, analytics.route.shortcut, [ I.ObjectFlag.SelectType, I.ObjectFlag.SelectTemplate, I.ObjectFlag.DeleteEmpty ]);
+					if (!S.Popup.isOpen('search')) {
+						e.preventDefault();
+						this.pageCreate({}, analytics.route.shortcut, [ I.ObjectFlag.SelectType, I.ObjectFlag.SelectTemplate, I.ObjectFlag.DeleteEmpty ]);
+					}
 				});
 
 				// Lock/Unlock


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

Overrides the default create (`cmd+n`) shortcut to use the filter as name in the new page and has the same behavior as manually selecting the option in the menu.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

Before:

https://github.com/user-attachments/assets/60d945f4-4345-44b6-a7fb-cbcaeb60c142

After:

https://github.com/user-attachments/assets/cd49f741-19ab-4bcf-b25b-15f7dd691d90

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
