### PR TITLE
Graph deselect when clicking on the empty space

### DIFF
--- a/dist/workers/graph.js
+++ b/dist/workers/graph.js
@@ -616,9 +616,7 @@ onDragEnd = ({ active }) => {
 
 onClick = ({ x, y }) => {
   	const d = getNodeByCoords(x, y);
-	if (d) {
-		send('onClick', { node: d.id });
-	};
+	send('onClick', { node: d?.id });
 };
 
 onSelect = ({ x, y, selectRelated }) => {

--- a/src/ts/component/graph/provider.tsx
+++ b/src/ts/component/graph/provider.tsx
@@ -290,7 +290,11 @@ const Graph = observer(forwardRef<GraphRefProps, Props>(({
 
 		switch (id) {
 			case 'onClick': {
-				onClickObject(data.node);
+				if (data.node === undefined){
+					setSelected([]);
+				} else {
+					onClickObject(data.node);
+				}
 				break;
 			};
 

--- a/src/ts/component/graph/provider.tsx
+++ b/src/ts/component/graph/provider.tsx
@@ -290,10 +290,10 @@ const Graph = observer(forwardRef<GraphRefProps, Props>(({
 
 		switch (id) {
 			case 'onClick': {
-				if (data.node === undefined){
-					setSelected([]);
-				} else {
+				if (data.node){
 					onClickObject(data.node);
+				} else {
+					setSelected([]);
 				}
 				break;
 			};


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->
I added a feature on the graph page that deselects all nodes when you click on the empty space.

https://github.com/user-attachments/assets/56be400c-2825-4dc8-9446-7f0d0bbf9e9d

---



- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
