### PR TITLE
fix dataview title disappearing when it's empty

### DIFF
--- a/src/scss/block/dataview.scss
+++ b/src/scss/block/dataview.scss
@@ -67,7 +67,7 @@
 			.icon.source { background-image: url('~img/icon/dataview/button/source0.svg'); opacity: 0; flex-shrink: 0; }
 			.icon.source.active { opacity: 1; }
 
-			.editableWrap { @include text-header2; height: 28px; @include text-overflow-nw; }
+			.editableWrap { @include text-header2; height: 28px; @include text-overflow-nw; flex: auto; }
 			.editableWrap.isEmpty { min-width: 90px; }
 			.editableWrap {
 				.editable { height: 100%; }


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description
The width of the `editableWrap` in both collection and set is not displaying correctly. It appears that the width changes according to the title's length, causing the placeholder to disappear when the title is empty, as the width becomes zero.


![image](https://github.com/user-attachments/assets/efaba521-86da-4833-a593-ca8902cc4ff7)

As shown in the image, the width becomes 0 when the title is empty.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
