### PR TITLE
fix the relations to display even after they have been moved to the bin

### DIFF
--- a/src/ts/component/menu/block/relation/view.tsx
+++ b/src/ts/component/menu/block/relation/view.tsx
@@ -185,6 +185,10 @@ const MenuBlockRelationView = observer(class MenuBlockRelationView extends React
 				return false;
 			};
 
+			if (it.isArchived) {
+				return false;
+			}
+
 			return !config.debug.hiddenObject ? !it.isHidden : true;
 		});
 

--- a/src/ts/component/menu/block/relation/view.tsx
+++ b/src/ts/component/menu/block/relation/view.tsx
@@ -187,7 +187,7 @@ const MenuBlockRelationView = observer(class MenuBlockRelationView extends React
 
 			if (it.isArchived) {
 				return false;
-			}
+			};
 
 			return !config.debug.hiddenObject ? !it.isHidden : true;
 		});


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description
I'm not sure if this is the correct way to fix the issue, but based on my observation, the `isArchived` property is set to true when a relation is moved to the bin. Therefore, I added a check for that.
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://github.com/anyproto/anytype-ts/issues/1166

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
