### PR TITLE
update the highlight effect display for the confirm popup

### DIFF
--- a/src/ts/component/popup/confirm.tsx
+++ b/src/ts/component/popup/confirm.tsx
@@ -7,7 +7,7 @@ const PopupConfirm = observer(class PopupConfirm extends React.Component<I.Popup
 
 	refButtons: any = null;
 	refCheckbox: any = null;
-	n = 0;
+	n: number = null;
 
 	constructor (props: I.Popup) {
 		super(props);
@@ -16,6 +16,7 @@ const PopupConfirm = observer(class PopupConfirm extends React.Component<I.Popup
 		this.onConfirm = this.onConfirm.bind(this);
 		this.onCancel = this.onCancel.bind(this);
 		this.onMouseEnter = this.onMouseEnter.bind(this);
+		this.onMouseLeave = this.onMouseLeave.bind(this);
 		this.setHighlight = this.setHighlight.bind(this);
 	};
 
@@ -50,8 +51,8 @@ const PopupConfirm = observer(class PopupConfirm extends React.Component<I.Popup
 				) : ''}
 
 				<div ref={ref => this.refButtons = ref} className="buttons">
-					{canConfirm ? <Button text={textConfirm} color={colorConfirm} className="c36" onClick={this.onConfirm} onMouseEnter={this.onMouseEnter} /> : ''}
-					{canCancel ? <Button text={textCancel} color={colorCancel} className="c36" onClick={this.onCancel} onMouseEnter={this.onMouseEnter} /> : ''}
+					{canConfirm ? <Button text={textConfirm} color={colorConfirm} className="c36" onClick={this.onConfirm} onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave} /> : ''}
+					{canCancel ? <Button text={textCancel} color={colorCancel} className="c36" onClick={this.onCancel} onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave} /> : ''}
 				</div>
 
 				<Error text={error} />
@@ -103,6 +104,12 @@ const PopupConfirm = observer(class PopupConfirm extends React.Component<I.Popup
 			if (buttons.length < 2) {
 				return;
 			};
+
+			if (this.n === null) {
+				this.n = 0;
+				this.setHighlight();
+				return;
+			}
 
 			this.n += dir;
 			if (this.n < 0) {
@@ -159,6 +166,17 @@ const PopupConfirm = observer(class PopupConfirm extends React.Component<I.Popup
 		this.n = $(buttons).index(e.currentTarget);
 		this.setHighlight();
 	};
+
+	onMouseLeave (e: any) {
+		const buttons = $(this.refButtons).find('.button');
+		this.n = $(buttons).index(e.currentTarget);
+
+		if (buttons[this.n]) {
+			$(this.refButtons).find('.hover').removeClass('hover');
+		};
+
+		this.n = null;
+	}
 
 	setHighlight () {
 		const buttons = $(this.refButtons).find('.button');


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description
Currently, the confirm popup default will highlight the confirm button, although you have not hover your cursor on it yet, and will not remove the last highlighted button after you move your cursor away.
I think this is a bit unintuitive and could cause confusion.


https://github.com/user-attachments/assets/59624fad-7552-4c5c-b3c0-d1eba3329878



<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
