### PR TITLE
Priorize HTML from Clipboard

### DIFF
--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -1837,12 +1837,23 @@ const EditorPage = observer(class EditorPage extends React.Component<Props, Stat
 			data = this.getClipboardData(e);
 		};
 
-		if (files.length && !data.files.length) {
-			U.Common.saveClipboardFiles(files, data, data => this.onPasteEvent(e, props, data));
-		} else {
-			e.preventDefault();
-			this.onPaste(data);
-		};
+		// Priorize HTML content
+		const hasHtml = data && data.html && data.html.length > 0;
+		
+		if (hasHtml) {
+        	e.preventDefault();
+        	this.onPaste(data);
+	    } else {
+	        const clipboardItems = (e.clipboardData || e.originalEvent.clipboardData).items;
+	        const files = U.Common.getDataTransferFiles(clipboardItems);
+	        
+	        if (files.length && !data.files.length) {
+	            U.Common.saveClipboardFiles(files, data, data => this.onPasteEvent(e, props, data));
+	        } else {
+	            e.preventDefault();
+	            this.onPaste(data);
+	        };
+	    };
 	};
 
 	onPaste (data: any) {

--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -1838,7 +1838,7 @@ const EditorPage = observer(class EditorPage extends React.Component<Props, Stat
 		};
 
 		// Priorize HTML content
-		const hasHtml = data && data.html && data.html.length > 0;
+		const hasHtml = data && data.html;
 		
 		if (hasHtml) {
         	e.preventDefault();


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description
When pasting from Clipboard, priorize HTML content > File content > Other Content.

Under Windows, copying from Office tools adds BITMAP and DIB image formats.
Paste therefore processes the image instead of the actual HTML content.

Please note that the HTML rendering engine needs improvement!

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
https://community.anytype.io/t/text-copied-from-onenote-pasted-in-anytype-pastes-as-image-png/5102

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?
