### PR TITLE
Fix trailing spaces before export lines

### DIFF
--- a/src/ts/store/auth.ts
+++ b/src/ts/store/auth.ts
@@ -211,4 +211,4 @@ class AuthStore {
 
 };
 
- export const Auth: AuthStore = new AuthStore();
+export const Auth: AuthStore = new AuthStore();

--- a/src/ts/store/block.ts
+++ b/src/ts/store/block.ts
@@ -656,4 +656,4 @@ class BlockStore {
 
 };
 
- export const Block: BlockStore = new BlockStore();
+export const Block: BlockStore = new BlockStore();

--- a/src/ts/store/record.ts
+++ b/src/ts/store/record.ts
@@ -442,4 +442,4 @@ class RecordStore {
 
 };
 
- export const Record: RecordStore = new RecordStore();
+export const Record: RecordStore = new RecordStore();


### PR DESCRIPTION
## Summary
- remove leading spaces before `export const` lines in block store, auth store, and record store

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration - dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_b_683eb384c668832185d78ca019a4f341