### PR TITLE
Fix duplicate fullscreen IPC handlers

### DIFF
--- a/src/ts/app.tsx
+++ b/src/ts/app.tsx
@@ -247,8 +247,6 @@ class App extends React.Component<object, State> {
 		Renderer.on('enter-full-screen', () => S.Common.fullscreenSet(true));
 		Renderer.on('leave-full-screen', () => S.Common.fullscreenSet(false));
 		Renderer.on('config', (e: any, config: any) => S.Common.configSet(config, true));
-		Renderer.on('enter-full-screen', () => S.Common.fullscreenSet(true));
-		Renderer.on('leave-full-screen', () => S.Common.fullscreenSet(false));
 		Renderer.on('logout', () => S.Auth.logout(false, false));
 		Renderer.on('data-path', (e: any, p: string) => S.Common.dataPathSet(p));
 		Renderer.on('will-close-window', this.onWillCloseWindow);


### PR DESCRIPTION
## Summary
- remove duplicate fullscreen listeners in `registerIpcEvents`
- fix indentation with tabs for fullscreen handlers

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_b_683ffd44ff048321a24138be50a2ab71