### PR TITLE
JS-7272: Add includeTypeEdges toggle to graph appearance settings

### DIFF
--- a/src/json/text.json
+++ b/src/json/text.json
@@ -1690,6 +1690,7 @@
 	"menuGraphSettingsFiles": "Files",
 	"menuGraphSettingsLocal": "Local graph",
 	"menuGraphSettingsDepth": "Depth",
+	"menuGraphSettingsTypeEdges": "Type Edges",
 
 	"menuHelpWhatsNew": "What's New",
 	"menuHelpShortcut": "Keyboard Shortcuts",

--- a/src/ts/component/block/dataview/view/graph.tsx
+++ b/src/ts/component/block/dataview/view/graph.tsx
@@ -72,7 +72,10 @@ const ViewGraph = observer(class ViewGraph extends React.Component<I.ViewCompone
 			filters.push({ relationKey: 'id', condition: I.FilterCondition.In, value: searchIds || [] });
 		};
 
-		C.ObjectGraph(S.Common.space, filters, 0, [], J.Relation.graph, (isCollection ? target.id : ''), target.setOf, (message: any) => {
+		const settings = S.Common.getGraph(J.Constant.graphId.dataview);
+		const includeTypeEdges = settings.includeTypeEdges !== undefined ? settings.includeTypeEdges : true;
+
+		C.ObjectGraph(S.Common.space, filters, 0, [], J.Relation.graph, (isCollection ? target.id : ''), target.setOf, includeTypeEdges, (message: any) => {
 			if (!this._isMounted || message.error.code) {
 				return;
 			};

--- a/src/ts/component/menu/graph/settings.tsx
+++ b/src/ts/component/menu/graph/settings.tsx
@@ -252,6 +252,7 @@ const MenuGraphSettings = observer(class MenuGraphSettings extends React.Compone
 					{ id: 'link', name: translate('menuGraphSettingsLinks') },
 					{ id: 'relation', name: translate('menuGraphSettingsRelations') },
 					{ id: 'orphan', name: translate('menuGraphSettingsUnlinkedObjects') },
+					{ id: 'includeTypeEdges', name: translate('menuGraphSettingsTypeEdges') },
 				] 
 			},
 		];

--- a/src/ts/component/page/main/graph.tsx
+++ b/src/ts/component/page/main/graph.tsx
@@ -14,7 +14,7 @@ const PageMainGraph = observer(forwardRef<I.PageRef, I.PageComponent>((props, re
 	const rootIdRef = useRef('');
 
 	const unbind = () => {
-		$(window).off(`keydown.graphPage updateGraphRoot.graphPage removeGraphNode.graphPage sidebarResize.graphPage`);
+		$(window).off(`keydown.graphPage updateGraphRoot.graphPage removeGraphNode.graphPage sidebarResize.graphPage updateGraphSettings.graphPage`);
 	};
 
 	const rebind = () => {
@@ -24,6 +24,7 @@ const PageMainGraph = observer(forwardRef<I.PageRef, I.PageComponent>((props, re
 		win.on(`keydown.graphPage`, e => onKeyDown(e));
 		win.on('updateGraphRoot.graphPage', (e: any, data: any) => initRootId(data.id));
 		win.on('sidebarResize.graphPage', () => resize());
+		win.on('updateGraphSettings.graphPage', () => load());
 	};
 
 	const onKeyDown = (e: any) => {
@@ -33,7 +34,10 @@ const PageMainGraph = observer(forwardRef<I.PageRef, I.PageComponent>((props, re
 	const load = () => {
 		setLoading(true);
 
-		C.ObjectGraph(S.Common.space, U.Data.getGraphFilters(), 0, [], J.Relation.graph, '', [], (message: any) => {
+		const settings = S.Common.getGraph(J.Constant.graphId.global);
+		const includeTypeEdges = settings.includeTypeEdges !== undefined ? settings.includeTypeEdges : true;
+
+		C.ObjectGraph(S.Common.space, U.Data.getGraphFilters(), 0, [], J.Relation.graph, '', [], includeTypeEdges, (message: any) => {
 			if (message.error.code) {
 				return;
 			};

--- a/src/ts/component/widget/view/graph/index.tsx
+++ b/src/ts/component/widget/view/graph/index.tsx
@@ -18,8 +18,10 @@ const WidgetViewGraph = observer(forwardRef<{}, I.WidgetViewComponent>((props, r
 		const filters = [].concat(view.filters).concat(U.Data.getGraphFilters()).map(it => Dataview.filterMapper(view, it));
 		const object = getObject();
 		const isCollection = U.Object.isCollectionLayout(object.layout);
+		const settings = S.Common.getGraph(J.Constant.graphId.dataview);
+		const includeTypeEdges = settings.includeTypeEdges !== undefined ? settings.includeTypeEdges : true;
 
-		C.ObjectGraph(S.Common.space, filters, 0, [], J.Relation.graph, (isCollection ? object.id : ''), object.setOf, (message: any) => {
+		C.ObjectGraph(S.Common.space, filters, 0, [], J.Relation.graph, (isCollection ? object.id : ''), object.setOf, includeTypeEdges, (message: any) => {
 			setData({
 				edges: message.edges,
 				nodes: message.nodes.map(it => S.Detail.mapper(it))

--- a/src/ts/interface/common.ts
+++ b/src/ts/interface/common.ts
@@ -301,6 +301,7 @@ export interface GraphSettings {
 	filter: string;
 	depth: number;
 	filterTypes: string[];
+	includeTypeEdges: boolean;
 };
 
 export interface FocusState {

--- a/src/ts/lib/api/command.ts
+++ b/src/ts/lib/api/command.ts
@@ -1758,7 +1758,7 @@ export const ObjectSetIsFavorite = (contextId: string, isFavorite: boolean, call
 	dispatcher.request(ObjectSetIsFavorite.name, request, callBack);
 };
 
-export const ObjectGraph = (spaceId: string, filters: any[], limit: number, types: string[], keys: string[], collectionId: string, sources: string[], callBack?: (message: any) => void) => {
+export const ObjectGraph = (spaceId: string, filters: any[], limit: number, types: string[], keys: string[], collectionId: string, sources: string[], includeTypeEdges: boolean = true, callBack?: (message: any) => void) => {
 	keys = (keys || []).filter(it => it);
 
 	const request = new Rpc.Object.Graph.Request();
@@ -1770,6 +1770,7 @@ export const ObjectGraph = (spaceId: string, filters: any[], limit: number, type
 	request.setKeysList(keys);
 	request.setCollectionid(collectionId);
 	request.setSetsourceList(sources);
+	request.setIncludetypeedges(includeTypeEdges);
 
 	dispatcher.request(ObjectGraph.name, request, callBack);
 };

--- a/src/ts/store/common.ts
+++ b/src/ts/store/common.ts
@@ -75,6 +75,7 @@ class CommonStore {
 		filter: '',
 		depth: 1,
 		filterTypes: [],
+		includeTypeEdges: true,
 	};
 
 	private timeoutMap = new Map<string, number>();


### PR DESCRIPTION
## Summary
- Add includeTypeEdges field to GraphSettings interface with default value of true
- Add "Type Edges" toggle in Graph Appearance settings menu under "Show on Graph" section
- Update ObjectGraph API command to accept includeTypeEdges parameter
- Pass includeTypeEdges setting to all ObjectGraph API calls in main graph, widget graph, and dataview graph components
- Add listener to reload graph when settings change

## Test plan
- [ ] Open graph view and check that Graph Appearance settings shows "Type Edges" toggle
- [ ] Verify toggle is enabled by default
- [ ] Test that toggling the setting updates the graph display
- [ ] Check that the setting persists when navigating away and back
- [ ] Verify graph reloads when toggle is changed
- [ ] Test in widget graph view and dataview graph view

🤖 Generated with [Claude Code](https://claude.ai/code)