### PR TITLE
Fix drawio embed resize

### DIFF
--- a/src/ts/lib/util/embed.ts
+++ b/src/ts/lib/util/embed.ts
@@ -469,7 +469,6 @@ class UtilEmbed {
 			I.EmbedProcessor.Kroki,
 			I.EmbedProcessor.Chart,
 			I.EmbedProcessor.Image,
-			I.EmbedProcessor.Drawio,
 		].includes(p);
 	};
 


### PR DESCRIPTION

---

- [X] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---

### Description
Drawio embed block has a size bug with allowIframResize activate : 
![2025-07-07 09_39_33-Demo Drawio - Travaux dev - Anytype](https://github.com/user-attachments/assets/5ac751fd-9586-4537-87e9-69c4ea4b6581)

It's ok with allowIframeResize deactivated : 
![image](https://github.com/user-attachments/assets/3658745c-87b9-4144-90bc-856ecbdf4ae1)



### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
https://community.anytype.io/t/drawio-embed-block-size-is-unsuitable/28229

### Mobile & Desktop Screenshots/Recordings

See above

### Added tests?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [X] 🙅 no documentation needed
