### PR TITLE
refactor: convert media block components to functional components

### DIFF
--- a/src/ts/component/block/media/audio.tsx
+++ b/src/ts/component/block/media/audio.tsx
@@ -1,163 +1,49 @@
-import * as React from 'react';
+import React, { useRef, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react';
 import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { InputWithFile, Loader, Error, MediaAudio, Icon } from 'Component';
 import { I, S, J, U, translate, focus, keyboard, Action } from 'Lib';
 
-const BlockAudio = observer(class BlockAudio extends React.Component<I.BlockComponent> {
+const BlockAudio = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref) => {
 
-	_isMounted = false;
-	node: any = null;
-	refPlayer: any = null;
+	const isMountedRef = useRef(false);
+	const nodeRef = useRef<any>(null);
+	const refPlayerRef = useRef<any>(null);
 
-	constructor (props: I.BlockComponent) {
-		super(props);
+	const { rootId, block, readonly, onKeyDown, onKeyUp } = props;
+	const { id, content } = block;
+	const { state, targetObjectId } = content;
+	const object = S.Detail.get(rootId, targetObjectId, [ 'name', 'isDeleted', 'fileExt' ], true);
+	const { name } = object;
 
-		this.onPlay = this.onPlay.bind(this);
-		this.onPause = this.onPause.bind(this);
-		this.onKeyDown = this.onKeyDown.bind(this);
-		this.onKeyUp = this.onKeyUp.bind(this);
-		this.onFocus = this.onFocus.bind(this);
-		this.onChangeUrl = this.onChangeUrl.bind(this);
-		this.onChangeFile = this.onChangeFile.bind(this);
-	};
-
-	render () {
-		const { rootId, block, readonly } = this.props;
-		const { id, content } = block;
-		const { state, targetObjectId } = content;
-		const object = S.Detail.get(rootId, targetObjectId, [ 'name', 'isDeleted', 'fileExt' ], true);
-		const { name } = object;
-		
-		let element = null;
-
-		if (object.isDeleted) {
-			element = (
-				<div className="deleted">
-					<Icon className="ghost" />
-					<div className="name">{translate('commonDeletedObject')}</div>
-				</div>
-			);
-		} else {
-			switch (state) {
-				default:
-				case I.FileState.Error:
-				case I.FileState.Empty: {
-					element = (
-						<>
-							{state == I.FileState.Error ? <Error text={translate('blockFileError')} /> : ''}
-							<InputWithFile 
-								block={block} 
-								icon="audio" 
-								textFile={translate('blockAudioUpload')} 
-								accept={J.Constant.fileExtension.audio} 
-								onChangeUrl={this.onChangeUrl} 
-								onChangeFile={this.onChangeFile} 
-								readonly={readonly} 
-							/>
-						</>
-					);
-					break;
-				};
-					
-				case I.FileState.Uploading: {
-					element = <Loader />;
-					break;
-				};
-					
-				case I.FileState.Done: {
-					element = (
-						<MediaAudio
-							ref={node => this.refPlayer = node}
-							playlist={this.getPlaylist()}
-							onPlay={this.onPlay}
-							onPause={this.onPause}
-						/>
-					);
-					break;
-				};
-			};
-		};
-		
-		return (
-			<div
-				ref={node => this.node = node}
-				className={[ 'focusable', 'c' + id ].join(' ')}
-				tabIndex={0}
-				onKeyDown={this.onKeyDown}
-				onKeyUp={this.onKeyUp}
-				onFocus={this.onFocus}
-			>
-				{element}
-			</div>
-		);
-	};
-
-	componentDidMount () {
-		this._isMounted = true;
-		this.rebind();
-	};
-
-	componentDidUpdate () {
-		this.rebind();
-		this.refPlayer?.updatePlaylist(this.getPlaylist());
-	};
-
-	componentWillUnmount () {
-		this._isMounted = false;
-		this.unbind();
-	};
-
-	rebind () {
-		if (!this._isMounted) {
-			return;
-		};
-
-		$(this.node).on('resize', () => {
-			if (this.refPlayer) {
-				this.refPlayer.resize();
-			};
-		});
-	};
-
-	unbind () {
-		if (this._isMounted) {
-			$(this.node).off('resize');
-		};
-	};
-
-	getPlaylist () {
-		const { rootId, block } = this.props;
-		const { targetObjectId } = block.content;
+	const getPlaylist = useCallback(() => {
 		const object = S.Detail.get(rootId, targetObjectId, [ 'name', 'isDeleted', 'fileExt' ], true);
 
 		return [ 
 			{ name: U.File.name(object), src: S.Common.fileUrl(object.id) },
 		];
-	};
+	}, [ rootId, targetObjectId ]);
 
-	onPlay () {
-		if (this._isMounted) {
-			$(this.node).addClass('isPlaying');
+	const onPlay = useCallback(() => {
+		if (isMountedRef.current) {
+			$(nodeRef.current).addClass('isPlaying');
 		};
-	};
+	}, []);
 
-	onPause () {
-		if (this._isMounted) {
-			$(this.node).removeClass('isPlaying');
+	const onPause = useCallback(() => {
+		if (isMountedRef.current) {
+			$(nodeRef.current).removeClass('isPlaying');
 		};
-	};
+	}, []);
 
-	onKeyDown (e: any) {
-		const { onKeyDown } = this.props;
-
+	const onKeyDownHandler = useCallback((e: any) => {
 		let ret = false;
 
 		keyboard.shortcut('space', e, (pressed: string) => {
 			e.preventDefault();
 			e.stopPropagation();
 
-			this.refPlayer?.onPlay();
+			refPlayerRef.current?.onPlay();
 			ret = true;
 		});
 
@@ -166,32 +52,126 @@ const BlockAudio = observer(class BlockAudio extends React.Component<I.BlockComp
 		};
 		
 		if (onKeyDown) {
-			onKeyDown(e, '', [], { from: 0, to: 0 }, this.props);
+			onKeyDown(e, '', [], { from: 0, to: 0 }, props);
 		};
-	};
+	}, [ onKeyDown, props ]);
 	
-	onKeyUp (e: any) {
-		const { onKeyUp } = this.props;
-
+	const onKeyUpHandler = useCallback((e: any) => {
 		if (onKeyUp) {
-			onKeyUp(e, '', [], { from: 0, to: 0 }, this.props);
+			onKeyUp(e, '', [], { from: 0, to: 0 }, props);
+		};
+	}, [ onKeyUp, props ]);
+
+	const onFocus = useCallback(() => {
+		focus.set(block.id, { from: 0, to: 0 });
+	}, [ block.id ]);
+
+	const onChangeUrl = useCallback((e: any, url: string) => {
+		Action.upload(I.FileType.Audio, rootId, block.id, url, '');
+	}, [ rootId, block.id ]);
+	
+	const onChangeFile = useCallback((e: any, path: string) => {
+		Action.upload(I.FileType.Audio, rootId, block.id, '', path);
+	}, [ rootId, block.id ]);
+
+	const rebind = useCallback(() => {
+		if (!isMountedRef.current) {
+			return;
+		};
+
+		$(nodeRef.current).on('resize', () => {
+			if (refPlayerRef.current) {
+				refPlayerRef.current.resize();
+			};
+		});
+	}, []);
+
+	const unbind = useCallback(() => {
+		if (isMountedRef.current) {
+			$(nodeRef.current).off('resize');
+		};
+	}, []);
+
+	useEffect(() => {
+		isMountedRef.current = true;
+		rebind();
+
+		return () => {
+			isMountedRef.current = false;
+			unbind();
+		};
+	}, [ rebind, unbind ]);
+
+	useEffect(() => {
+		rebind();
+		refPlayerRef.current?.updatePlaylist(getPlaylist());
+	});
+
+	useImperativeHandle(ref, () => ({}));
+	
+	let element = null;
+
+	if (object.isDeleted) {
+		element = (
+			<div className="deleted">
+				<Icon className="ghost" />
+				<div className="name">{translate('commonDeletedObject')}</div>
+			</div>
+		);
+	} else {
+		switch (state) {
+			default:
+			case I.FileState.Error:
+			case I.FileState.Empty: {
+				element = (
+					<>
+						{state == I.FileState.Error ? <Error text={translate('blockFileError')} /> : ''}
+						<InputWithFile 
+							block={block} 
+							icon="audio" 
+							textFile={translate('blockAudioUpload')} 
+							accept={J.Constant.fileExtension.audio} 
+							onChangeUrl={onChangeUrl} 
+							onChangeFile={onChangeFile} 
+							readonly={readonly} 
+						/>
+					</>
+				);
+				break;
+			};
+				
+			case I.FileState.Uploading: {
+				element = <Loader />;
+				break;
+			};
+				
+			case I.FileState.Done: {
+				element = (
+					<MediaAudio
+						ref={refPlayerRef}
+						playlist={getPlaylist()}
+						onPlay={onPlay}
+						onPause={onPause}
+					/>
+				);
+				break;
+			};
 		};
 	};
-
-	onFocus () {
-		focus.set(this.props.block.id, { from: 0, to: 0 });
-	};
-
-	onChangeUrl (e: any, url: string) {
-		const { rootId, block } = this.props;
-		Action.upload(I.FileType.Audio, rootId, block.id, url, '');
-	};
 	
-	onChangeFile (e: any, path: string) {
-		const { rootId, block } = this.props;
-		Action.upload(I.FileType.Audio, rootId, block.id, '', path);
-	};
+	return (
+		<div
+			ref={nodeRef}
+			className={[ 'focusable', 'c' + id ].join(' ')}
+			tabIndex={0}
+			onKeyDown={onKeyDownHandler}
+			onKeyUp={onKeyUpHandler}
+			onFocus={onFocus}
+		>
+			{element}
+		</div>
+	);
 
-});
+}));
 
 export default BlockAudio;

--- a/src/ts/component/block/media/pdf.tsx
+++ b/src/ts/component/block/media/pdf.tsx
@@ -1,337 +1,34 @@
-import * as React from 'react';
+import React, { useState, useRef, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react';
+import $ from 'jquery';
 import { InputWithFile, Loader, Error, Pager, Icon, MediaPdf, ObjectName } from 'Component';
 import { I, C, S, U, J, translate, focus, Action, keyboard, analytics } from 'Lib';
 import { observer } from 'mobx-react';
 
-interface State {
-	pages: number;
-	page: number;
-};
-
-const BlockPdf = observer(class BlockPdf extends React.Component<I.BlockComponent, State> {
+const BlockPdf = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref) => {
 	
-	state = {
-		pages: 0,
-		page: 1,
-	};
-	_isMounted = false;
-	node: any = null;
-	refMedia = null;
-	height = 0;
+	const [pages, setPages] = useState(0);
+	const [page, setPage] = useState(1);
+	const isMountedRef = useRef(false);
+	const nodeRef = useRef<any>(null);
+	const refMediaRef = useRef<any>(null);
+	const heightRef = useRef(0);
 
-	constructor (props: I.BlockComponent) {
-		super(props);
-		
-		this.onKeyDown = this.onKeyDown.bind(this);
-		this.onKeyUp = this.onKeyUp.bind(this);
-		this.onFocus = this.onFocus.bind(this);
-		this.onChangeUrl = this.onChangeUrl.bind(this);
-		this.onChangeFile = this.onChangeFile.bind(this);
-		this.onDocumentLoad = this.onDocumentLoad.bind(this);
-		this.onPageRender = this.onPageRender.bind(this);
-		this.onOpenFile = this.onOpenFile.bind(this);
-		this.onOpenObject = this.onOpenObject.bind(this);
+	const { rootId, block, readonly, onKeyDown, onKeyUp } = props;
+	const { id, fields, content } = block;
+	const { state, targetObjectId } = content;
+	const object = S.Detail.get(rootId, targetObjectId, []);
+	const width = Number(fields.width) || 0;
+	const css: any = {};
+
+	if (width) {
+		css.width = (width * 100) + '%';
 	};
 
-	render () {
-		const { rootId, block, readonly } = this.props;
-		const { id, fields, content } = block;
-		const { state, targetObjectId } = content;		
-		const { page, pages } = this.state;
-		const object = S.Detail.get(rootId, targetObjectId, []);
-		const width = Number(fields.width) || 0;
-		const css: any = {};
-
-		let element = null;
-		let pager = null;
-		
-		if (width) {
-			css.width = (width * 100) + '%';
-		};
-
-		if (this.height) {
-			css.minHeight = this.height;
-		};
-
-		if (object.isDeleted) {
-			element = (
-				<div className="deleted">
-					<Icon className="ghost" />
-					<div className="name">{translate('commonDeletedObject')}</div>
-				</div>
-			);
-		} else {
-			switch (state) {
-				default:
-				case I.FileState.Error:
-				case I.FileState.Empty: {
-					element = (
-						<>
-							{state == I.FileState.Error ? <Error text={translate('blockFileError')} /> : ''}
-							<InputWithFile 
-								block={block} 
-								icon="pdf" 
-								textFile={translate('blockPdfUpload')}
-								accept={J.Constant.fileExtension.pdf} 
-								onChangeUrl={this.onChangeUrl} 
-								onChangeFile={this.onChangeFile} 
-								readonly={readonly} 
-							/>
-						</>
-					);
-					break;
-				};
-					
-				case I.FileState.Uploading: {
-					element = <Loader />;
-					break;
-				};
-					
-				case I.FileState.Done: {
-					if (pages > 1) {
-						pager = (
-							<Pager 
-								offset={page - 1} 
-								limit={1} 
-								total={pages} 
-								pageLimit={1}
-								isShort={true}
-								onChange={page => this.setState({ page })} 
-							/>
-						);
-					};
-
-					element = (
-						<div className={[ 'wrap', 'pdfWrapper', (pager ? 'withPager' : '') ].join(' ')} style={css}>
-							<div className="info" onMouseDown={this.onOpenObject}>
-								<ObjectName object={object} />
-								<span className="size">{U.File.size(object.sizeInBytes)}</span>
-							</div>
-
-							<MediaPdf 
-								id={`pdf-block-${id}`}
-								ref={ref => this.refMedia = ref}
-								src={S.Common.fileUrl(targetObjectId)}
-								page={page}
-								onDocumentLoad={this.onDocumentLoad}
-								onPageRender={this.onPageRender}
-								onClick={this.onOpenFile}
-							/>
-
-							{pager}
-
-							<Icon className="resize" onMouseDown={e => this.onResizeStart(e, false)} />
-						</div>
-					);
-					break;
-				};
-			};
-		};
-		
-		return (
-			<div 
-				ref={node => this.node = node}
-				className={[ 'focusable', 'c' + id ].join(' ')} 
-				tabIndex={0} 
-				onKeyDown={this.onKeyDown} 
-				onKeyUp={this.onKeyUp} 
-				onFocus={this.onFocus}
-			>
-				{element}
-			</div>
-		);
+	if (heightRef.current) {
+		css.minHeight = heightRef.current;
 	};
 
-	componentDidMount(): void {
-		this._isMounted = true;
-		this.rebind();
-	};
-
-	componentDidUpdate () {
-		this.rebind();
-	};
-	
-	componentWillUnmount () {
-		this._isMounted = false;
-		this.unbind();
-	};
-
-	rebind () {
-		if (!this._isMounted) {
-			return;
-		};
-		
-		const node = $(this.node);
-		
-		this.unbind();
-		node.on('resizeStart', (e: any, oe: any) => this.onResizeStart(oe, true));
-		node.on('resizeMove', (e: any, oe: any) => this.onResizeMove(oe, true));
-		node.on('resizeEnd', (e: any, oe: any) => this.onResizeEnd(oe, true));
-		node.on('resizeInit', (e: any, oe: any) => this.onResizeInit());
-	};
-
-	unbind () {
-		if (!this._isMounted) {
-			return;
-		};
-		
-		const node = $(this.node);
-		const video = node.find('video');
-		
-		node.off('resizeInit resizeStart resizeMove resizeEnd');
-		video.off('canplay');
-	};
-	
-	onKeyDown (e: any) {
-		const { onKeyDown } = this.props;
-		
-		if (onKeyDown) {
-			onKeyDown(e, '', [], { from: 0, to: 0 }, this.props);
-		};
-	};
-	
-	onKeyUp (e: any) {
-		const { onKeyUp } = this.props;
-
-		if (onKeyUp) {
-			onKeyUp(e, '', [], { from: 0, to: 0 }, this.props);
-		};
-	};
-
-	onFocus () {
-		focus.set(this.props.block.id, { from: 0, to: 0 });
-	};
-	
-	onChangeUrl (e: any, url: string) {
-		const { rootId, block } = this.props;
-		const { id } = block;
-		
-		Action.upload(I.FileType.Pdf, rootId, id, url, '');
-	};
-	
-	onChangeFile (e: any, path: string) {
-		const { rootId, block } = this.props;
-		const { id } = block;
-		
-		Action.upload(I.FileType.Pdf, rootId, id, '', path);
-	};
-
-	onDocumentLoad (result: any) {
-		this.setState({ pages: result.numPages });
-	};
-
-	onPageRender () {
-		const node = $(this.node);
-		const wrap = node.find('.wrap');
-
-		this.height = wrap.outerHeight();
-	};
-
-	onOpenFile () {
-		Action.openFile(this.props.block.getTargetObjectId(), analytics.route.block);
-	};
-
-	onOpenObject (e: any) {
-		if (!keyboard.withCommand(e)) {
-			U.Object.openConfig({ id: this.props.block.getTargetObjectId(), layout: I.ObjectLayout.Pdf });
-		};
-	};
-
-	onResizeInit () {
-		if (!this._isMounted) {
-			return;
-		};
-		
-		const node = $(this.node);
-		const wrap = node.find('.wrap');
-		
-		if (wrap.length) {
-			wrap.css({ width: (this.getWidth(true, 0) * 100) + '%' });
-		};
-
-		this.refMedia?.resize();
-	};
-
-	onResizeStart (e: any, checkMax: boolean) {
-		e.preventDefault();
-		e.stopPropagation();
-		
-		if (!this._isMounted) {
-			return;
-		};
-		
-		const { block } = this.props;
-		const selection = S.Common.getRef('selectionProvider');
-		const win = $(window);
-		
-		focus.set(block.id, { from: 0, to: 0 });
-		win.off('mousemove.media mouseup.media');
-		selection?.hide();
-
-		$(`#block-${block.id}`).addClass('isResizing');
-
-		keyboard.setResize(true);
-		keyboard.disableSelection(true);
-		win.on('mousemove.media', e => this.onResizeMove(e, checkMax));
-		win.on('mouseup.media', e => this.onResizeEnd(e, checkMax));
-	};
-	
-	onResizeMove (e: any, checkMax: boolean) {
-		e.preventDefault();
-		e.stopPropagation();
-		
-		if (!this._isMounted) {
-			return;
-		};
-		
-		const node = $(this.node);
-		const wrap = node.find('.wrap');
-		
-		if (!wrap.length) {
-			return;
-		};
-		
-		const rect = (wrap.get(0) as Element).getBoundingClientRect() as DOMRect;
-		const w = this.getWidth(checkMax, e.pageX - rect.x + 20);
-		
-		wrap.css({ width: (w * 100) + '%' });
-		this.refMedia?.resize();
-	};
-	
-	onResizeEnd (e: any, checkMax: boolean) {
-		if (!this._isMounted) {
-			return;
-		};
-		
-		const { rootId, block } = this.props;
-		const { id, fields } = block;
-		const node = $(this.node);
-		const wrap = node.find('.wrap');
-		
-		if (!wrap.length) {
-			return;
-		};
-		
-		const win = $(window);
-		const rect = (wrap.get(0) as Element).getBoundingClientRect() as DOMRect;
-		const w = this.getWidth(checkMax, e.pageX - rect.x + 20);
-		
-		$(`#block-${block.id}`).removeClass('isResizing');
-
-		win.off('mousemove.media mouseup.media');
-		keyboard.disableSelection(false);
-		keyboard.setResize(false);
-		
-		this.height = 0;
-
-		C.BlockListSetFields(rootId, [
-			{ blockId: id, fields: { ...fields, width: w } },
-		]);
-	};
-
-	getWidth (checkMax: boolean, v: number): number {
-		const { block } = this.props;
-		const { id, fields } = block;
+	const getWidth = useCallback((checkMax: boolean, v: number): number => {
 		const width = Number(fields.width) || 1;
 		const el = $(`#selectionTarget-${id}`);
 
@@ -343,8 +40,275 @@ const BlockPdf = observer(class BlockPdf extends React.Component<I.BlockComponen
 		const w = Math.min(rect.width, Math.max(160, checkMax ? width * rect.width : v));
 		
 		return Math.min(1, Math.max(0, w / rect.width));
-	};
+	}, [ fields.width, id ]);
 
-});
+	const onKeyDownHandler = useCallback((e: any) => {
+		if (onKeyDown) {
+			onKeyDown(e, '', [], { from: 0, to: 0 }, props);
+		};
+	}, [ onKeyDown, props ]);
+	
+	const onKeyUpHandler = useCallback((e: any) => {
+		if (onKeyUp) {
+			onKeyUp(e, '', [], { from: 0, to: 0 }, props);
+		};
+	}, [ onKeyUp, props ]);
+
+	const onFocus = useCallback(() => {
+		focus.set(block.id, { from: 0, to: 0 });
+	}, [ block.id ]);
+	
+	const onChangeUrl = useCallback((e: any, url: string) => {
+		Action.upload(I.FileType.Pdf, rootId, id, url, '');
+	}, [ rootId, id ]);
+	
+	const onChangeFile = useCallback((e: any, path: string) => {
+		Action.upload(I.FileType.Pdf, rootId, id, '', path);
+	}, [ rootId, id ]);
+
+	const onDocumentLoad = useCallback((result: any) => {
+		setPages(result.numPages);
+	}, []);
+
+	const onPageRender = useCallback(() => {
+		const node = $(nodeRef.current);
+		const wrap = node.find('.wrap');
+
+		heightRef.current = wrap.outerHeight();
+	}, []);
+
+	const onOpenFile = useCallback(() => {
+		Action.openFile(block.getTargetObjectId(), analytics.route.block);
+	}, [ block ]);
+
+	const onOpenObject = useCallback((e: any) => {
+		if (!keyboard.withCommand(e)) {
+			U.Object.openConfig({ id: block.getTargetObjectId(), layout: I.ObjectLayout.Pdf });
+		};
+	}, [ block ]);
+
+	const onResizeInit = useCallback(() => {
+		if (!isMountedRef.current) {
+			return;
+		};
+		
+		const node = $(nodeRef.current);
+		const wrap = node.find('.wrap');
+		
+		if (wrap.length) {
+			wrap.css({ width: (getWidth(true, 0) * 100) + '%' });
+		};
+
+		refMediaRef.current?.resize();
+	}, [ getWidth ]);
+
+	const onResizeStart = useCallback((e: any, checkMax: boolean) => {
+		e.preventDefault();
+		e.stopPropagation();
+		
+		if (!isMountedRef.current) {
+			return;
+		};
+		
+		const selection = S.Common.getRef('selectionProvider');
+		const win = $(window);
+		
+		focus.set(block.id, { from: 0, to: 0 });
+		win.off('mousemove.media mouseup.media');
+		selection?.hide();
+
+		$(`#block-${block.id}`).addClass('isResizing');
+
+		keyboard.setResize(true);
+		keyboard.disableSelection(true);
+		win.on('mousemove.media', e => onResizeMove(e, checkMax));
+		win.on('mouseup.media', e => onResizeEnd(e, checkMax));
+	}, [ block.id ]);
+	
+	const onResizeMove = useCallback((e: any, checkMax: boolean) => {
+		e.preventDefault();
+		e.stopPropagation();
+		
+		if (!isMountedRef.current) {
+			return;
+		};
+		
+		const node = $(nodeRef.current);
+		const wrap = node.find('.wrap');
+		
+		if (!wrap.length) {
+			return;
+		};
+		
+		const rect = (wrap.get(0) as Element).getBoundingClientRect() as DOMRect;
+		const w = getWidth(checkMax, e.pageX - rect.x + 20);
+		
+		wrap.css({ width: (w * 100) + '%' });
+		refMediaRef.current?.resize();
+	}, [ getWidth ]);
+	
+	const onResizeEnd = useCallback((e: any, checkMax: boolean) => {
+		if (!isMountedRef.current) {
+			return;
+		};
+		
+		const node = $(nodeRef.current);
+		const wrap = node.find('.wrap');
+		
+		if (!wrap.length) {
+			return;
+		};
+		
+		const win = $(window);
+		const rect = (wrap.get(0) as Element).getBoundingClientRect() as DOMRect;
+		const w = getWidth(checkMax, e.pageX - rect.x + 20);
+		
+		$(`#block-${block.id}`).removeClass('isResizing');
+
+		win.off('mousemove.media mouseup.media');
+		keyboard.disableSelection(false);
+		keyboard.setResize(false);
+		
+		heightRef.current = 0;
+
+		C.BlockListSetFields(rootId, [
+			{ blockId: id, fields: { ...fields, width: w } },
+		]);
+	}, [ rootId, id, block.id, fields, getWidth ]);
+
+	const rebind = useCallback(() => {
+		if (!isMountedRef.current) {
+			return;
+		};
+		
+		const node = $(nodeRef.current);
+		
+		unbind();
+		node.on('resizeStart', (e: any, oe: any) => onResizeStart(oe, true));
+		node.on('resizeMove', (e: any, oe: any) => onResizeMove(oe, true));
+		node.on('resizeEnd', (e: any, oe: any) => onResizeEnd(oe, true));
+		node.on('resizeInit', (e: any, oe: any) => onResizeInit());
+	}, [ onResizeStart, onResizeMove, onResizeEnd, onResizeInit ]);
+
+	const unbind = useCallback(() => {
+		if (!isMountedRef.current) {
+			return;
+		};
+		
+		const node = $(nodeRef.current);
+		const video = node.find('video');
+		
+		node.off('resizeInit resizeStart resizeMove resizeEnd');
+		video.off('canplay');
+	}, []);
+
+	useEffect(() => {
+		isMountedRef.current = true;
+		rebind();
+
+		return () => {
+			isMountedRef.current = false;
+			unbind();
+		};
+	}, [ rebind, unbind ]);
+
+	useEffect(() => {
+		rebind();
+	});
+
+	useImperativeHandle(ref, () => ({}));
+
+	let element = null;
+	let pager = null;
+
+	if (object.isDeleted) {
+		element = (
+			<div className="deleted">
+				<Icon className="ghost" />
+				<div className="name">{translate('commonDeletedObject')}</div>
+			</div>
+		);
+	} else {
+		switch (state) {
+			default:
+			case I.FileState.Error:
+			case I.FileState.Empty: {
+				element = (
+					<>
+						{state == I.FileState.Error ? <Error text={translate('blockFileError')} /> : ''}
+						<InputWithFile 
+							block={block} 
+							icon="pdf" 
+							textFile={translate('blockPdfUpload')}
+							accept={J.Constant.fileExtension.pdf} 
+							onChangeUrl={onChangeUrl} 
+							onChangeFile={onChangeFile} 
+							readonly={readonly} 
+						/>
+					</>
+				);
+				break;
+			};
+				
+			case I.FileState.Uploading: {
+				element = <Loader />;
+				break;
+			};
+				
+			case I.FileState.Done: {
+				if (pages > 1) {
+					pager = (
+						<Pager 
+							offset={page - 1} 
+							limit={1} 
+							total={pages} 
+							pageLimit={1}
+							isShort={true}
+							onChange={setPage} 
+						/>
+					);
+				};
+
+				element = (
+					<div className={[ 'wrap', 'pdfWrapper', (pager ? 'withPager' : '') ].join(' ')} style={css}>
+						<div className="info" onMouseDown={onOpenObject}>
+							<ObjectName object={object} />
+							<span className="size">{U.File.size(object.sizeInBytes)}</span>
+						</div>
+
+						<MediaPdf 
+							id={`pdf-block-${id}`}
+							ref={refMediaRef}
+							src={S.Common.fileUrl(targetObjectId)}
+							page={page}
+							onDocumentLoad={onDocumentLoad}
+							onPageRender={onPageRender}
+							onClick={onOpenFile}
+						/>
+
+						{pager}
+
+						<Icon className="resize" onMouseDown={e => onResizeStart(e, false)} />
+					</div>
+				);
+				break;
+			};
+		};
+	};
+	
+	return (
+		<div 
+			ref={nodeRef}
+			className={[ 'focusable', 'c' + id ].join(' ')} 
+			tabIndex={0} 
+			onKeyDown={onKeyDownHandler} 
+			onKeyUp={onKeyUpHandler} 
+			onFocus={onFocus}
+		>
+			{element}
+		</div>
+	);
+
+}));
 
 export default BlockPdf;

--- a/src/ts/component/block/media/video.tsx
+++ b/src/ts/component/block/media/video.tsx
@@ -1,302 +1,28 @@
-import * as React from 'react';
+import React, { useRef, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react';
 import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { InputWithFile, Icon, Loader, Error, MediaVideo } from 'Component';
 import { I, C, S, J, translate, focus, Action, keyboard } from 'Lib';
 
-const BlockVideo = observer(class BlockVideo extends React.Component<I.BlockComponent> {
+const BlockVideo = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref) => {
 
-	_isMounted = false;
-	node: any = null;
-	div = 0;
-	speed = 1;
+	const isMountedRef = useRef(false);
+	const nodeRef = useRef<any>(null);
+	const divRef = useRef(0);
+	const speedRef = useRef(1);
 
-	constructor (props: I.BlockComponent) {
-		super(props);
-		
-		this.onKeyDown = this.onKeyDown.bind(this);
-		this.onKeyUp = this.onKeyUp.bind(this);
-		this.onFocus = this.onFocus.bind(this);
-		this.onChangeUrl = this.onChangeUrl.bind(this);
-		this.onChangeFile = this.onChangeFile.bind(this);
-		this.onResizeStart = this.onResizeStart.bind(this);
-		this.onResizeMove = this.onResizeMove.bind(this);
-		this.onResizeEnd = this.onResizeEnd.bind(this);
-		this.onResizeInit = this.onResizeInit.bind(this);
-		this.onPlay = this.onPlay.bind(this);
-		this.onPause = this.onPause.bind(this);
+	const { rootId, block, readonly, onKeyDown, onKeyUp } = props;
+	const { id, fields, content } = block;
+	const { state, targetObjectId } = content;
+	const object = S.Detail.get(rootId, targetObjectId, []);
+	const { width } = fields;
+	const css: any = {};
+
+	if (width) {
+		css.width = (width * 100) + '%';
 	};
 
-	render () {
-		const { rootId, block, readonly } = this.props;
-		const { id, fields, content } = block;
-		const { state, targetObjectId } = content;
-		const object = S.Detail.get(rootId, targetObjectId, []);
-		const { width } = fields;
-		const css: any = {};
-
-		if (width) {
-			css.width = (width * 100) + '%';
-		};
-
-		let element = null;
-		if (object.isDeleted) {
-			element = (
-				<div className="deleted">
-					<Icon className="ghost" />
-					<div className="name">{translate('commonDeletedObject')}</div>
-				</div>
-			);
-		} else {
-			switch (state) {
-				default:
-				case I.FileState.Error:
-				case I.FileState.Empty: {
-					element = (
-						<>
-							{state == I.FileState.Error ? <Error text={translate('blockFileError')} /> : ''}
-							<InputWithFile 
-								block={block} 
-								icon="video" 
-								textFile={translate('blockVideoUpload')} 
-								accept={J.Constant.fileExtension.video} 
-								onChangeUrl={this.onChangeUrl} 
-								onChangeFile={this.onChangeFile} 
-								readonly={readonly} 
-							/>
-						</>
-					);
-					break;
-				};
-					
-				case I.FileState.Uploading: {
-					element = <Loader />;
-					break;
-				};
-					
-				case I.FileState.Done: {
-					element = (
-						<div className="wrap resizable" style={css}>
-							<MediaVideo
-								src={S.Common.fileUrl(targetObjectId)}
-								onPlay={this.onPlay}
-								onPause={this.onPause}
-							/>
-							<Icon className="resize" onMouseDown={e => this.onResizeStart(e, false)} />
-						</div>
-					);
-					break;
-				};
-			};
-		};
-		
-		return (
-			<div 
-				ref={node => this.node = node} 
-				className={[ 'focusable', 'c' + id ].join(' ')} 
-				tabIndex={0} 
-				onKeyDown={this.onKeyDown} 
-				onKeyUp={this.onKeyUp} 
-				onFocus={this.onFocus}
-			>
-				{element}
-			</div>
-		);
-	};
-	
-	componentDidMount () {
-		this._isMounted = true;
-		this.rebind();
-		this.initVideo();
-	};
-	
-	componentDidUpdate () {
-		this.rebind();
-	};
-	
-	componentWillUnmount () {
-		this._isMounted = false;
-		this.unbind();
-	};
-
-	initVideo () {
-		const node = $(this.node);
-		const video = node.find('video');
-
-		if (!video.length) {
-			return;
-		};
-
-		this.div = 16 / 9;
-		this.onResizeInit();
-
-		video.on('canplay', (e: any) => {
-			const el = video.get(0);
-
-			this.div = el.videoWidth / el.videoHeight;
-			this.onResizeInit();
-		});
-	};
-	
-	rebind () {
-		if (!this._isMounted) {
-			return;
-		};
-		
-		this.unbind();
-		
-		const node = $(this.node);
-		node.on('resizeStart', (e: any, oe: any) => this.onResizeStart(oe, true));
-		node.on('resizeMove', (e: any, oe: any) => this.onResizeMove(oe, true));
-		node.on('resizeEnd', (e: any, oe: any) => this.onResizeEnd(oe, true));
-		node.on('resizeInit', (e: any, oe: any) => this.onResizeInit());
-	};
-	
-	unbind () {
-		if (!this._isMounted) {
-			return;
-		};
-		
-		const node = $(this.node);
-		const video = node.find('video');
-		
-		node.off('resizeInit resizeStart resizeMove resizeEnd');
-		video.off('canplay');
-	};
-	
-	onKeyDown (e: any) {
-		const { onKeyDown } = this.props;
-		
-		if (onKeyDown) {
-			onKeyDown(e, '', [], { from: 0, to: 0 }, this.props);
-		};
-	};
-	
-	onKeyUp (e: any) {
-		const { onKeyUp } = this.props;
-
-		if (onKeyUp) {
-			onKeyUp(e, '', [], { from: 0, to: 0 }, this.props);
-		};
-	};
-
-	onFocus () {
-		focus.set(this.props.block.id, { from: 0, to: 0 });
-	};
-	
-	onChangeUrl (e: any, url: string) {
-		const { rootId, block } = this.props;
-		const { id } = block;
-		
-		Action.upload(I.FileType.Video, rootId, id, url, '');
-	};
-	
-	onChangeFile (e: any, path: string) {
-		const { rootId, block } = this.props;
-		const { id } = block;
-		
-		Action.upload(I.FileType.Video, rootId, id, '', path);
-	};
-
-	onPlay () {
-		$(this.node).addClass('isPlaying');
-	};
-
-	onPause () {
-		$(this.node).removeClass('isPlaying');
-	};
-
-	onResizeInit () {
-		if (!this._isMounted) {
-			return;
-		};
-		
-		const node = $(this.node);
-		const wrap = node.find('.wrap');
-		
-		if (!wrap.length) {
-			return;
-		};
-		
-		wrap.css({ width: (this.getWidth(true, 0) * 100) + '%' });
-	};
-
-	onResizeStart (e: any, checkMax: boolean) {
-		e.preventDefault();
-		e.stopPropagation();
-		
-		if (!this._isMounted) {
-			return;
-		};
-		
-		const { block } = this.props;
-		const selection = S.Common.getRef('selectionProvider');
-		const win = $(window);
-		
-		focus.set(block.id, { from: 0, to: 0 });
-		win.off('mousemove.media mouseup.media');
-		
-		selection?.hide();
-
-		keyboard.setResize(true);
-		keyboard.disableSelection(true);
-		$(`#block-${block.id}`).addClass('isResizing');
-		win.on('mousemove.media', e => this.onResizeMove(e, checkMax));
-		win.on('mouseup.media', e => this.onResizeEnd(e, checkMax));
-	};
-	
-	onResizeMove (e: any, checkMax: boolean) {
-		e.preventDefault();
-		e.stopPropagation();
-		
-		if (!this._isMounted) {
-			return;
-		};
-		
-		const node = $(this.node);
-		const wrap = node.find('.wrap');
-		
-		if (!wrap.length) {
-			return;
-		};
-		
-		const rect = (wrap.get(0) as Element).getBoundingClientRect() as DOMRect;
-		const w = this.getWidth(checkMax, e.pageX - rect.x + 20);
-		
-		wrap.css({ width: (w * 100) + '%' });
-	};
-	
-	onResizeEnd (e: any, checkMax: boolean) {
-		if (!this._isMounted) {
-			return;
-		};
-		
-		const { rootId, block } = this.props;
-		const { id } = block;
-		const node = $(this.node);
-		const wrap = node.find('.wrap');
-		
-		if (!wrap.length) {
-			return;
-		};
-		
-		const win = $(window);
-		const rect = (wrap.get(0) as Element).getBoundingClientRect() as DOMRect;
-		const w = this.getWidth(checkMax, e.pageX - rect.x + 20);
-		
-		win.off('mousemove.media mouseup.media');
-		$(`#block-${block.id}`).removeClass('isResizing');
-		keyboard.disableSelection(false);
-		keyboard.setResize(false);
-		
-		C.BlockListSetFields(rootId, [
-			{ blockId: id, fields: { width: w } },
-		]);
-	};
-	
-	getWidth (checkMax: boolean, v: number): number {
-		const { block } = this.props;
-		const { id, fields } = block;
+	const getWidth = useCallback((checkMax: boolean, v: number): number => {
 		const width = Number(fields.width) || 1;
 		const el = $(`#selectionTarget-${id}`);
 
@@ -308,8 +34,251 @@ const BlockVideo = observer(class BlockVideo extends React.Component<I.BlockComp
 		const w = Math.min(rect.width, Math.max(160, checkMax ? width * rect.width : v));
 		
 		return Math.min(1, Math.max(0, w / rect.width));
+	}, [ fields.width, id ]);
+
+	const onPlay = useCallback(() => {
+		$(nodeRef.current).addClass('isPlaying');
+	}, []);
+
+	const onPause = useCallback(() => {
+		$(nodeRef.current).removeClass('isPlaying');
+	}, []);
+
+	const onKeyDownHandler = useCallback((e: any) => {
+		if (onKeyDown) {
+			onKeyDown(e, '', [], { from: 0, to: 0 }, props);
+		};
+	}, [ onKeyDown, props ]);
+	
+	const onKeyUpHandler = useCallback((e: any) => {
+		if (onKeyUp) {
+			onKeyUp(e, '', [], { from: 0, to: 0 }, props);
+		};
+	}, [ onKeyUp, props ]);
+
+	const onFocus = useCallback(() => {
+		focus.set(block.id, { from: 0, to: 0 });
+	}, [ block.id ]);
+	
+	const onChangeUrl = useCallback((e: any, url: string) => {
+		Action.upload(I.FileType.Video, rootId, id, url, '');
+	}, [ rootId, id ]);
+	
+	const onChangeFile = useCallback((e: any, path: string) => {
+		Action.upload(I.FileType.Video, rootId, id, '', path);
+	}, [ rootId, id ]);
+
+	const onResizeInit = useCallback(() => {
+		if (!isMountedRef.current) {
+			return;
+		};
+		
+		const node = $(nodeRef.current);
+		const wrap = node.find('.wrap');
+		
+		if (!wrap.length) {
+			return;
+		};
+		
+		wrap.css({ width: (getWidth(true, 0) * 100) + '%' });
+	}, [ getWidth ]);
+
+	const onResizeStart = useCallback((e: any, checkMax: boolean) => {
+		e.preventDefault();
+		e.stopPropagation();
+		
+		if (!isMountedRef.current) {
+			return;
+		};
+		
+		const selection = S.Common.getRef('selectionProvider');
+		const win = $(window);
+		
+		focus.set(block.id, { from: 0, to: 0 });
+		win.off('mousemove.media mouseup.media');
+		
+		selection?.hide();
+
+		keyboard.setResize(true);
+		keyboard.disableSelection(true);
+		$(`#block-${block.id}`).addClass('isResizing');
+		win.on('mousemove.media', e => onResizeMove(e, checkMax));
+		win.on('mouseup.media', e => onResizeEnd(e, checkMax));
+	}, [ block.id ]);
+	
+	const onResizeMove = useCallback((e: any, checkMax: boolean) => {
+		e.preventDefault();
+		e.stopPropagation();
+		
+		if (!isMountedRef.current) {
+			return;
+		};
+		
+		const node = $(nodeRef.current);
+		const wrap = node.find('.wrap');
+		
+		if (!wrap.length) {
+			return;
+		};
+		
+		const rect = (wrap.get(0) as Element).getBoundingClientRect() as DOMRect;
+		const w = getWidth(checkMax, e.pageX - rect.x + 20);
+		
+		wrap.css({ width: (w * 100) + '%' });
+	}, [ getWidth ]);
+	
+	const onResizeEnd = useCallback((e: any, checkMax: boolean) => {
+		if (!isMountedRef.current) {
+			return;
+		};
+		
+		const node = $(nodeRef.current);
+		const wrap = node.find('.wrap');
+		
+		if (!wrap.length) {
+			return;
+		};
+		
+		const win = $(window);
+		const rect = (wrap.get(0) as Element).getBoundingClientRect() as DOMRect;
+		const w = getWidth(checkMax, e.pageX - rect.x + 20);
+		
+		win.off('mousemove.media mouseup.media');
+		$(`#block-${block.id}`).removeClass('isResizing');
+		keyboard.disableSelection(false);
+		keyboard.setResize(false);
+		
+		C.BlockListSetFields(rootId, [
+			{ blockId: id, fields: { width: w } },
+		]);
+	}, [ rootId, id, block.id, getWidth ]);
+
+	const initVideo = useCallback(() => {
+		const node = $(nodeRef.current);
+		const video = node.find('video');
+
+		if (!video.length) {
+			return;
+		};
+
+		divRef.current = 16 / 9;
+		onResizeInit();
+
+		video.on('canplay', (e: any) => {
+			const el = video.get(0);
+
+			divRef.current = el.videoWidth / el.videoHeight;
+			onResizeInit();
+		});
+	}, [ onResizeInit ]);
+	
+	const rebind = useCallback(() => {
+		if (!isMountedRef.current) {
+			return;
+		};
+		
+		unbind();
+		
+		const node = $(nodeRef.current);
+		node.on('resizeStart', (e: any, oe: any) => onResizeStart(oe, true));
+		node.on('resizeMove', (e: any, oe: any) => onResizeMove(oe, true));
+		node.on('resizeEnd', (e: any, oe: any) => onResizeEnd(oe, true));
+		node.on('resizeInit', (e: any, oe: any) => onResizeInit());
+	}, [ onResizeStart, onResizeMove, onResizeEnd, onResizeInit ]);
+	
+	const unbind = useCallback(() => {
+		if (!isMountedRef.current) {
+			return;
+		};
+		
+		const node = $(nodeRef.current);
+		const video = node.find('video');
+		
+		node.off('resizeInit resizeStart resizeMove resizeEnd');
+		video.off('canplay');
+	}, []);
+
+	useEffect(() => {
+		isMountedRef.current = true;
+		rebind();
+		initVideo();
+
+		return () => {
+			isMountedRef.current = false;
+			unbind();
+		};
+	}, [ rebind, initVideo, unbind ]);
+	
+	useEffect(() => {
+		rebind();
+	});
+
+	useImperativeHandle(ref, () => ({}));
+
+	let element = null;
+	if (object.isDeleted) {
+		element = (
+			<div className="deleted">
+				<Icon className="ghost" />
+				<div className="name">{translate('commonDeletedObject')}</div>
+			</div>
+		);
+	} else {
+		switch (state) {
+			default:
+			case I.FileState.Error:
+			case I.FileState.Empty: {
+				element = (
+					<>
+						{state == I.FileState.Error ? <Error text={translate('blockFileError')} /> : ''}
+						<InputWithFile 
+							block={block} 
+							icon="video" 
+							textFile={translate('blockVideoUpload')} 
+							accept={J.Constant.fileExtension.video} 
+							onChangeUrl={onChangeUrl} 
+							onChangeFile={onChangeFile} 
+							readonly={readonly} 
+						/>
+					</>
+				);
+				break;
+			};
+				
+			case I.FileState.Uploading: {
+				element = <Loader />;
+				break;
+			};
+				
+			case I.FileState.Done: {
+				element = (
+					<div className="wrap resizable" style={css}>
+						<MediaVideo
+							src={S.Common.fileUrl(targetObjectId)}
+							onPlay={onPlay}
+							onPause={onPause}
+						/>
+						<Icon className="resize" onMouseDown={e => onResizeStart(e, false)} />
+					</div>
+				);
+				break;
+			};
+		};
 	};
 	
-});
+	return (
+		<div 
+			ref={nodeRef} 
+			className={[ 'focusable', 'c' + id ].join(' ')} 
+			tabIndex={0} 
+			onKeyDown={onKeyDownHandler} 
+			onKeyUp={onKeyUpHandler} 
+			onFocus={onFocus}
+		>
+			{element}
+		</div>
+	);
+	
+}));
 
 export default BlockVideo;


### PR DESCRIPTION
## Summary
- Convert audio.tsx from class to functional component using forwardRef and observer
- Convert video.tsx from class to functional component using forwardRef and observer  
- Convert pdf.tsx from class to functional component using forwardRef and observer
- Replace lifecycle methods with useEffect hooks
- Replace instance variables with useRef hooks
- Replace class methods with useCallback hooks
- Add proper TypeScript typing with forwardRef<I.BlockRef, I.BlockComponent>
- Maintain all existing functionality and event handling
- Follow established patterns from PR #1554

## Test plan
- [ ] Test audio block upload, playback, and resize functionality
- [ ] Test video block upload, playback, and resize functionality  
- [ ] Test PDF block upload, pagination, and resize functionality
- [ ] Verify keyboard shortcuts work correctly
- [ ] Ensure all media types handle deleted objects properly
- [ ] Test file and URL upload flows for all media types

🤖 Generated with [Claude Code](https://claude.ai/code)