### PR TITLE
Feature/JS-7037: Images in message bubble

### DIFF
--- a/src/scss/block/chat/attachment.scss
+++ b/src/scss/block/chat/attachment.scss
@@ -93,6 +93,14 @@
 		.icon.syncStatus { width: 72px; height: 72px; margin: -36px 0px 0px -36px; }
 	}
 
+	.attachment.isImage.withBlur {
+		.imgWrapper { min-width: 100px; min-height: 100px; display: flex; align-items: center; justify-content: center; position: relative; overflow: hidden; }
+		.imgWrapper {
+			.blur { width: 100%; height: 100%; position: absolute; z-index: 0; left: 0px; top: 0px; background-size: cover; -webkit-filter: blur(5px); }
+			.image { width: unset; height: unset; border-radius: 0px; position: relative; z-index: 1; }
+		}
+	}
+
 	.attachment.isVideo { width: 72px; height: 72px; min-width: unset; display: flex; align-items: center; justify-content: center; }
 	.attachment.isVideo {
 		.mediaVideo { border-radius: inherit; overflow: hidden; width: 100%; height: 100%; }

--- a/src/scss/block/chat/message.scss
+++ b/src/scss/block/chat/message.scss
@@ -208,4 +208,16 @@
 			.bubble { background-color: var(--color-bg-ice) !important;}
 		}
 	}
+
+	&.attachmentsLayout1 {
+		.bubble { max-width: 360px; }
+	}
+
+	&.withText {
+		.attachments.isSingle {
+			.attachment.isImage.withBlur {
+				.imgWrapper { width: 352px; }
+			}
+		}
+	}
 }

--- a/src/ts/component/block/chat/attachment/index.tsx
+++ b/src/ts/component/block/chat/attachment/index.tsx
@@ -63,8 +63,14 @@ const ChatAttachment = observer(class ChatAttachment extends React.Component<Pro
 								break;
 							};
 
+							let withBlur = false;
+
 							cn.push('isImage');
-							content = this.renderImage();
+							if (object.widthInPixels < 360) {
+								withBlur = true;
+								cn.push('withBlur');
+							};
+							content = this.renderImage(withBlur);
 							break;
 						};
 					};
@@ -77,8 +83,14 @@ const ChatAttachment = observer(class ChatAttachment extends React.Component<Pro
 					break;
 				};
 
+				let withBlur = false;
+
 				cn.push('isImage');
-				content = this.renderImage();
+				if (object.widthInPixels < 360) {
+					withBlur = true;
+					cn.push('withBlur');
+				};
+				content = this.renderImage(withBlur);
 				break;
 
 			case I.ObjectLayout.Video: {
@@ -193,9 +205,8 @@ const ChatAttachment = observer(class ChatAttachment extends React.Component<Pro
 		);
 	};
 
-	renderImage () {
+	renderImage (withBlur?: boolean) {
 		const { object, scrollToBottom } = this.props;
-		const status = object.syncStatus ? object.syncStatus : I.SyncStatusObject.Syncing;
 
 		if (!this.src) {
 			if (object.isTmp && object.file) {
@@ -209,8 +220,14 @@ const ChatAttachment = observer(class ChatAttachment extends React.Component<Pro
 			};
 		};
 
+		let blur: any = null;
+		if (withBlur) {
+			blur = <div className="blur" style={{ backgroundImage: `url(${this.src})` }} />;
+		};
+
 		return (
 			<div className="imgWrapper" onClick={this.onPreview}>
+				{blur}
 				<img
 					id="image"
 					className="image"

--- a/src/ts/component/block/chat/message/index.tsx
+++ b/src/ts/component/block/chat/message/index.tsx
@@ -70,6 +70,10 @@ const ChatMessage = observer(class ChatMessage extends React.Component<I.ChatMes
 			};
 		};
 
+		if (hasAttachments) {
+			cn.push(`attachmentsLayout${hasAttachments}`);
+		};
+
 		if (hasAttachments == 1) {
 			ca.push('isSingle');
 		};


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
