### PR TITLE
Added auto-focus for bookmark input field

### DIFF
--- a/src/ts/component/menu/block/add.tsx
+++ b/src/ts/component/menu/block/add.tsx
@@ -704,6 +704,14 @@ const MenuBlockAdd = observer(class MenuBlockAdd extends React.Component<I.Menu>
 							if (param.type == I.BlockType.File) {
 								element.find(`.fileWrap`).trigger('mousedown');
 							};
+
+							// Auto-focus bookmark input field
+							if (param.type == I.BlockType.Bookmark) {
+								const urlToggle = element.find('.urlToggle');
+								if (urlToggle.length) {
+									urlToggle.trigger('click');
+								}
+							};
 						}, S.Menu.getTimeout());
 					});
 				};


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

This implements the following feature request - https://community.anytype.io/t/place-cursor-automatically-inside-the-field-after-creating-bookmark/9700

<img width="993" height="138" alt="image" src="https://github.com/user-attachments/assets/4097ed18-2194-4c75-ae5b-f05268a1e36c" />


### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?

no


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
