### PR TITLE
Graph View in Inline Queries now respects the pageLimit setting

### DIFF
--- a/src/scss/block/dataview/view/graph.scss
+++ b/src/scss/block/dataview/view/graph.scss
@@ -13,6 +13,9 @@
 	}
 
 	.block.blockDataview.isInline {
-		.viewContent.viewGraph { height: 500px; }
+		.viewContent.viewGraph { 
+			min-height: 300px;
+			/* Height is now dynamically set based on pageLimit */
+		}
 	}
 }

--- a/src/ts/component/block/dataview/view/graph.tsx
+++ b/src/ts/component/block/dataview/view/graph.tsx
@@ -98,7 +98,7 @@ const ViewGraph = observer(class ViewGraph extends React.Component<I.ViewCompone
 	};
 
 	resize () {
-		const { isPopup, isInline } = this.props;
+		const { isPopup, isInline, getView } = this.props;
 		const node = $(this.node);
 
 		if (!node || !node.length) {
@@ -116,6 +116,17 @@ const ViewGraph = observer(class ViewGraph extends React.Component<I.ViewCompone
 			const { top } = node.offset();
 
 			node.css({ width: cw, height: Math.max(600, ch - top - 2), marginLeft: -margin - 2 });
+		} else {
+			// For inline views: use pageLimit to determine height
+			// Same logic as Grid View: 40px per row for inline
+			const view = getView();
+			const pageLimit = view?.pageLimit || 50;
+			const rowHeight = 40; // Same as Grid View inline
+			const headerHeight = 120; // More space for controls/header
+			const footerHeight = 44; // Space for FootRow (aggregation row)
+			const height = Math.max(200, headerHeight + (pageLimit * rowHeight) + footerHeight);
+			
+			node.css({ height });
 		};
 
 		if (this.refGraph) {


### PR DESCRIPTION
- Graph View in Inline Queries now respects the pageLimit setting like Grid View does
- Height calculation uses same row height (40px) as Grid View
- Removes fixed 500px height for inline Graph Views
- Users can now control Graph View size through Settings > Layout > Page limit