### PR TITLE
fix: Chinese IME input before formatted content leads to style change

### DIFF
--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -1255,11 +1255,15 @@ const BlockText = observer(class BlockText extends React.Component<Props> {
 			this.refEditable.placeholderHide();
 		};
 	};
-	
+
 	onCompositionEnd = (e: any, value: string, range: I.TextRange) => {
 		// Use provided value and range if available, fallback to current
 		const v = value !== undefined ? value : this.getValue();
 		const r = range !== undefined ? range : this.getRange();
+		
+		// Populate marks before setValue to prevent formatting issue
+		this.marks = this.getMarksFromHtml().marks;
+		this.setValue(v, r);
 	};
 
 	onBeforeInput = (e: any) => {

--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -1260,8 +1260,6 @@ const BlockText = observer(class BlockText extends React.Component<Props> {
 		// Use provided value and range if available, fallback to current
 		const v = value !== undefined ? value : this.getValue();
 		const r = range !== undefined ? range : this.getRange();
-
-		this.setValue(v, r);
 	};
 
 	onBeforeInput = (e: any) => {


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR fixes https://github.com/anyproto/anytype-ts/issues/1542, by removing the `this.setValue` in `onCompositionEnd` event under `/src/ts/component/block/text.tsx` > BlockText.
I've tested, removing `this.setValue` in `onCompositionEnd` can be a workaround fix, which not breaking normal text editing behavior. 

The bug is causing by wrong html is generated when `this.setValue()` is called from `onCompositionEnd`.
`[start, end)` stored in `this.marks` is not being updated after new characters are composited:
```js
	setValue (v: string, restoreRange?: I.TextRange) {
		// Only apply unicode replacements if not composing IME
		if (block.isTextCode()) {
			...
		} else {
			if (!keyboard.isComposition && !ignored) {
				const parsed = Mark.fromUnicode(html, this.marks, false);

				html = parsed.text;
				this.marks = parsed.marks;
			};

			html = Mark.toHtml(html, this.marks);  // Wrong html is generated
		};

		html = html.replace(/\n/g, '<br/>');
		if (this.refEditable) {
			this.refEditable.setValue(html);    // This line set wrong html

			// Restore cursor position if provided
			if (restoreRange) {
				this.refEditable.setRange(restoreRange);
			};
		};
                ...
```


### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://github.com/anyproto/anytype-ts/issues/1542

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
