### PR TITLE
Fix block paste handling logic at cursor position 0 (Raycast Paste)

### DIFF
--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -1966,8 +1966,20 @@ const EditorPage = observer(class EditorPage extends React.Component<Props, Stat
 		let to = 0;
 
 		keyboard.disablePaste(true);
+		
+		// Determine if we should treat this as part of the block
+		// For external content (data.anytype.range.to = 0), preserve block type when:
+		// - Pasting at beginning of block (range.from = 0)
+		// - Not replacing a selection (range.from === range.to)
+		// - Block exists and can contain text content
 
-		C.BlockPaste(rootId, focused, range, selection?.get(I.SelectType.Block, true) || [], data.anytype.range.to > 0, { ...data, anytype: data.anytype.blocks }, '', (message: any) => {
+		const isExternalContent = data.anytype.range.to === 0;
+		const isPastingAtStart = range.from === 0;
+		const isNotSelection = range.from === range.to;
+		const hasValidBlock = block && (block.isText() || block.canHaveChildren());
+		const isPartOfBlock = data.anytype.range.to > 0 || (isExternalContent && isPastingAtStart && isNotSelection && hasValidBlock);
+		
+		C.BlockPaste(rootId, focused, range, selection?.get(I.SelectType.Block, true) || [], isPartOfBlock, { ...data, anytype: data.anytype.blocks }, '', (message: any) => {
 			keyboard.disablePaste(false);
 
 			if (message.error.code) {


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

Based on my bug report on the [forum](https://community.anytype.io/t/pasting-from-raycast-into-an-the-beginning-of-a-bullet-line-removes-bullet/28751/), I worked with GPT 4.1 to author and test a fix. I tested the fix, it's working perfectly on hot-reload development mode and fixes both my bug report, and one from a year ago linked [here](https://community.anytype.io/t/emoji-insertion-issues-in-titles-using-raycast-emoji-picker/16210). I doubt I have perfectly contributed to Anytype's standards, however the code changes are miniscule, and simply involves adding extra logic to check cursor position in the `onPaste` function before C.BlockPaste() is called. 

Please let me know if there is anything I can do to make this contribution up to this repo's standards. I apologize if I have misunderstood any of the contribution rules.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://community.anytype.io/t/pasting-from-raycast-into-an-the-beginning-of-a-bullet-line-removes-bullet/28751
https://community.anytype.io/t/emoji-insertion-issues-in-titles-using-raycast-emoji-picker/16210

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?

None

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->