### PR TITLE
Improve workaround for Wayland window background color

### DIFF
--- a/electron/js/api.js
+++ b/electron/js/api.js
@@ -85,7 +85,13 @@ class Api {
 	};
 
 	setBackground (win, theme) {
-		BrowserWindow.getAllWindows().forEach(win => win && !win.isDestroyed() && win.setBackgroundColor(Util.getBgColor(theme)));
+		var bgColor;
+		if (is.linux && (process.env.XDG_SESSION_TYPE === 'wayland')) {
+			bgColor = '#00000000'; // ARGB, transparent (Wayland workaround)
+		} else {
+			bgColor = Util.getBgColor(theme);
+		};
+		BrowserWindow.getAllWindows().forEach(win => win && !win.isDestroyed() && win.setBackgroundColor(bgColor));
 	};
 
 	setZoom (win, zoom) {

--- a/electron/js/util.js
+++ b/electron/js/util.js
@@ -65,10 +65,6 @@ class Util {
 	};
 
 	getBgColor (theme) {
-		if (is.linux && !!process.env.XDG_SESSION_TYPE && (process.env.XDG_SESSION_TYPE.toLowerCase() == 'wayland')) {
-			return '#00000000'; // ARGB, transparent on Wayland
-		};
-
 		theme = String(theme || '');
 
 		const bg = {


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

This is an improvement of #1724: it avoids creating a transparent "ghost" frame upon Anytype startup on Wayland.

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
