### PR TITLE
make membership/tiers fetch async

### DIFF
--- a/src/ts/component/page/auth/setup.tsx
+++ b/src/ts/component/page/auth/setup.tsx
@@ -70,7 +70,7 @@ const PageAuthSetup = observer(forwardRef<{}, I.PageComponent>((props, ref) => {
 					].forEach(it => Survey.check(it));
 
 					const cb1 = () => {
-						U.Data.getMembershipStatus(membership => {
+						U.Data.getMembershipStatus(false, membership => {
 							if (membership.status == I.MembershipStatus.Finalization) {
 								S.Popup.open('membershipFinalization', { 
 									onClose: cb2,

--- a/src/ts/component/page/main/membership.tsx
+++ b/src/ts/component/page/main/membership.tsx
@@ -19,7 +19,7 @@ const PageMainMembership = observer(forwardRef<I.PageRef, I.PageComponent>((prop
 
 		let newTier = data.tier;
 
-		U.Data.getMembershipStatus((membership: I.Membership) => {
+		U.Data.getMembershipStatus(true, (membership: I.Membership) => {
 			if (!membership || membership.isNone) {
 				setError(translate('pageMainMembershipError'));
 				return;
@@ -49,7 +49,7 @@ const PageMainMembership = observer(forwardRef<I.PageRef, I.PageComponent>((prop
 
 	const finalise = () => {
 		S.Popup.closeAll(null, () => {
-			U.Data.getMembershipStatus((membership: I.Membership) => {
+			U.Data.getMembershipStatus(true, (membership: I.Membership) => {
 				const { status, tier } = membership;
 
 				if (status == I.MembershipStatus.Finalization) {

--- a/src/ts/component/popup/membership/finalization.tsx
+++ b/src/ts/component/popup/membership/finalization.tsx
@@ -79,15 +79,13 @@ const PopupMembershipFinalization = observer(forwardRef<{}, I.Popup>((props, ref
 				return;
 			};
 
-			U.Data.getMembershipTiers(true, () => {
-				U.Data.getMembershipStatus((membership) => {
-					if (!membership || membership.isNone) {
-						setError(translate('pageMainMembershipError'));
-						return;
-					};
+			U.Data.getMembershipStatus(true, (membership) => {
+				if (!membership || membership.isNone) {
+					setError(translate('pageMainMembershipError'));
+					return;
+				};
 
-					S.Popup.replace('membershipFinalization', 'membership', { data: { tier: membership.tier, success: true } });
-				});
+				S.Popup.replace('membershipFinalization', 'membership', { data: { tier: membership.tier, success: true } });
 			});
 		});
 	};

--- a/src/ts/component/popup/page/membership/current.tsx
+++ b/src/ts/component/popup/page/membership/current.tsx
@@ -90,7 +90,7 @@ const PopupMembershipPageCurrent = observer(forwardRef<{}, Props>((props, ref) =
 				return;
 			};
 
-			U.Data.getMembershipStatus();
+			U.Data.getMembershipStatus(true);
 			S.Popup.updateData('membership', { success: true, emailVerified: true });
 			position();
 		});

--- a/src/ts/component/popup/page/membership/paid.tsx
+++ b/src/ts/component/popup/page/membership/paid.tsx
@@ -157,15 +157,13 @@ const PopupMembershipPagePaid = observer(forwardRef<{}, I.Popup>((props, ref) =>
 				return;
 			};
 
-			U.Data.getMembershipTiers(true, () => {
-				U.Data.getMembershipStatus((membership) => {
-					if (!membership || membership.isNone) {
-						setError(translate('pageMainMembershipError'));
-						return;
-					};
+			U.Data.getMembershipStatus(true, (membership) => {
+				if (!membership || membership.isNone) {
+					setError(translate('pageMainMembershipError'));
+					return;
+				};
 
-					S.Popup.replace('membershipFinalization', 'membership', { data: { tier: membership.tier, success: true } });
-				});
+				S.Popup.replace('membershipFinalization', 'membership', { data: { tier: membership.tier, success: true } });
 			});
 		});
 	};

--- a/src/ts/lib/api/dispatcher.ts
+++ b/src/ts/lib/api/dispatcher.ts
@@ -948,7 +948,11 @@ class Dispatcher {
 
 				case 'MembershipUpdate': {
 					S.Auth.membershipUpdate(mapped.membership);
-					U.Data.getMembershipTiers(true);
+					break;
+				};
+
+				case 'membershipTiersUpdate': {
+					S.Common.membershipTiersListSet(mapped.tiers);
 					break;
 				};
 

--- a/src/ts/lib/api/mapper.ts
+++ b/src/ts/lib/api/mapper.ts
@@ -1211,8 +1211,9 @@ export const Mapper = {
 			if (v == V.NOTIFICATIONUPDATE)			 t = 'NotificationUpdate';
 
 			if (v == V.PAYLOADBROADCAST)			 t = 'PayloadBroadcast';
-			
+
 			if (v == V.MEMBERSHIPUPDATE)			 t = 'MembershipUpdate';
+			if (v == V.MEMBERSHIPTIERSUPDATE)		 t = 'membershipTiersUpdate';
 
 			if (v == V.PROCESSNEW)					 t = 'ProcessNew';
 			if (v == V.PROCESSUPDATE)				 t = 'ProcessUpdate';
@@ -1660,6 +1661,12 @@ export const Mapper = {
 		MembershipUpdate: (obj: Events.Event.Membership.Update) => {
 			return {
 				membership: Mapper.From.Membership(obj.getData()),
+			};
+		},
+
+		membershipTiersUpdate: (obj: Events.Event.Membership.TiersUpdate) => {
+			return {
+				tiers: (obj.getTiersList() || []).map(Mapper.From.MembershipTierData),
 			};
 		},
 

--- a/src/ts/lib/util/data.ts
+++ b/src/ts/lib/util/data.ts
@@ -360,7 +360,7 @@ class UtilData {
 			};
 		});
 
-		this.getMembershipTiers(noTierCache, () => this.getMembershipStatus());
+		this.getMembershipTiers(false, () => this.getMembershipStatus(false));
 		U.Subscription.createGlobal(() => {
 			Storage.clearDeletedSpaces(false);
 			Storage.clearDeletedSpaces(true);
@@ -864,14 +864,15 @@ class UtilData {
 
 	/**
 	 * Gets the membership status for the current account.
+	 * @param {boolean} [noCache] - Whether to skip cache (default: false).
 	 * @param {(membership: I.Membership) => void} [callBack] - Optional callback with the membership object.
 	 */
-	getMembershipStatus (callBack?: (membership: I.Membership) => void) {
+	getMembershipStatus (noCache?: boolean, callBack?: (membership: I.Membership) => void) {
 		if (!this.isAnytypeNetwork()) {
 			return;
 		};
 
-		C.MembershipGetStatus(true, (message: any) => {
+		C.MembershipGetStatus(noCache || false, (message: any) => {
 			if (!message.membership) {
 				return;
 			};


### PR DESCRIPTION
App startup can be slow with poor network connectivity due to blocking membership status/tier API calls.

  ### Solution
  Middleware now returns cached data immediately (even if empty) when `noCache = false`, then sends async updates via events (only if changed)

  ### Changes

  **Core API (`lib/util/data.ts`)**
  - `getMembershipStatus()` now accepts optional `noCache` parameter (default: `false`)
  - Initial auth calls use `noCache: false` for instant response

  **Event System (`lib/api/mapper.ts`, `lib/api/dispatcher.ts`)**
  - Added `membershipTiersUpdate` event type mapping
  - Added event handler to update tier cache: `S.Common.membershipTiersListSet()`
  - Removed explicit `getMembershipTiers(true)` call from `MembershipUpdate` handler

  **UI Components - `noCache: true` (explicit cache bypass)**
  - `component/popup/membership/finalization.tsx` - after finalization
  - `component/popup/page/membership/paid.tsx` - after code redemption
  - `component/popup/page/membership/current.tsx` - after email verification
  - `component/page/main/membership.tsx` - after Stripe callback

  **UI Components - `noCache: false` (use cache)**
  - `component/page/auth/setup.tsx` - initial auth/setup flow

  ### Behavior
  - **Startup**: Uses cache (fast, even offline)
  - **Updates**: Async via `membershipUpdate` and `membershipTiersUpdate` events
  - **Explicit refresh**: Only after payment callbacks, finalization, or verification
  - **Tier fetching**: Never bypasses cache - always event-driven