### PR TITLE
Fix back/forward mouse button press handling for Logitech mice on MacOS

### DIFF
--- a/electron/js/window.js
+++ b/electron/js/window.js
@@ -67,6 +67,22 @@ class WindowManager {
 		win.on('enter-full-screen', () => Util.send(win, 'enter-full-screen'));
 		win.on('leave-full-screen', () => Util.send(win, 'leave-full-screen'));
 
+    // Logitech software binds dedicated forward/back mouse buttons to the legacy
+    // three-finger swipe gestures on MacOS by default. The system will NOT fire mouse events
+    // for forward/back mouse button presses when this is the case. The electron swipe event is
+    // MacOS-specific, and won't interfere with Windows/Linux event handling.
+    // https://www.electronjs.org/docs/latest/api/browser-window#event-swipe-macos
+    win.on('swipe', (_e, direction) => {
+      switch (direction) {
+        case 'left':
+          Util.send(win, 'macosMouseNavigation', 'back');
+          break;
+        case 'right':
+          Util.send(win, 'macosMouseNavigation', 'forward');
+          break;
+      }
+    });
+
 		win.webContents.setWindowOpenHandler(({ url }) => {
 			Api.openUrl(win, url);
 			return { action: 'deny' };

--- a/src/ts/lib/keyboard.ts
+++ b/src/ts/lib/keyboard.ts
@@ -76,6 +76,20 @@ class Keyboard {
 
 		Renderer.remove('commandGlobal');
 		Renderer.on('commandGlobal', (e: any, cmd: string, arg: any) => this.onCommand(cmd, arg));
+
+    Renderer.remove('macosMouseNavigation');
+    Renderer.on('macosMouseNavigation', (_e: any, direction: 'back' | 'forward') => {
+      if (!this.isNavigationDisabled) {
+        switch (direction) {
+          case 'back':
+            this.onBack();
+            break;
+          case 'forward':
+            this.onForward();
+            break;
+        }
+      };
+    });
 	};
 
 	/**


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

**This PR fixes an issue where the Forward and Back mouse buttons were completely ignored on MacOS when using a mouse configured with Logi Options (+).** This happens because Logitech software on MacOS maps Forward/Back to the legacy three-finger left/right swipe gestures instead of a mouse event. To reiterate, when Logi Options is installed, pressing Forward/Back on a mouse will NOT fire a mouse event; It will only fire a swipe gesture event. Since a mouse event is never fired, the existing `onMouseDown()` handler (which checks for specific button codes) is rendered useless.

This fix is MacOS-specific. Forward/Back already fire proper the proper events on Windows as expected.

There are weirdly few references to this in the wild:
- <https://news.ycombinator.com/item?id=42457468>
- See the ["Technical Notes" section here](https://sensible-side-buttons.archagon.net/) - looks like someone made a tool to solve the same system-wide years ago.

Electron has a [MacOS-specific handler for these swipe events](https://www.electronjs.org/docs/latest/api/browser-window#event-swipe-macos), so it won't conflict with event handlers on other systems. Also, since Forward/Back presses don't fire a mouse event, the `onBack()` and `onForward()` navigation functions will never be double-fired.

This had to be handled [at the BrowserWindow level](https://www.electronjs.org/docs/latest/api/browser-window#event-swipe-macos) because the swipe gesture event is never (as far as I can tell) fired as a DOM event or a [webContent "before-mouse-event"](https://www.electronjs.org/docs/latest/api/web-contents#event-before-mouse-event).

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

Just to be clear, this does NOT solve <https://github.com/anyproto/anytype-ts/issues/832>. That issue would require more granular handling of the modern two-finger touch events instead of the "legacy" swipe event this solution had to use.

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->

None
