### PR TITLE
Added support for Helium browser

### DIFF
--- a/electron/js/lib/installNativeMessagingHost.js
+++ b/electron/js/lib/installNativeMessagingHost.js
@@ -127,6 +127,12 @@ const installToWindows = () => {
 	);
 
 	createWindowsRegistry(
+		'HKCU\\SOFTWARE\\net.imput.helium',
+		`HKCU\\SOFTWARE\\net.imput.helium\\NativeMessagingHosts\\${APP_NAME}`,
+		chromeManifestPath
+	);
+
+	createWindowsRegistry(
 		'HKCU\\SOFTWARE\\Mozilla',
 		`HKCU\\SOFTWARE\\Mozilla\\NativeMessagingHosts\\${APP_NAME}`,
 		firefoxManifestPath
@@ -186,6 +192,7 @@ const getLinuxDirectory = () => {
 		'Chromium': path.join(home, 'chromium'),
 		'Brave': path.join(home, 'BraveSoftware', 'Brave-Browser'),
 		'BraveFlatpak': path.join('.var', 'app', 'com.brave.Browser', 'config', 'BraveSoftware', 'Brave-Browser'),
+		'Helium': path.join(home, 'net.imput.helium'),
 		'Firefox': path.join(getHomeDir(), '.mozilla'),
 	};
 };
@@ -202,6 +209,7 @@ const getDarwinDirectory = () => {
 		'Chrome Dev': path.join(home, 'Google', 'Chrome Dev'),
 		'Chrome Canary': path.join(home, 'Google', 'Chrome Canary'),
 		'Chromium': path.join(home, 'Chromium'),
+		'Helium': path.join(home, 'net.imput.helium'),
 		'Microsoft Edge': path.join(home, 'Microsoft Edge'),
 		'Microsoft Edge Beta': path.join(home, 'Microsoft Edge Beta'),
 		'Microsoft Edge Dev': path.join(home, 'Microsoft Edge Dev'),


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

Add support for installing native messaging hosts for the [Helium](https://github.com/imputnet/helium) browser as well.

Helium is a growing Chromium-based browser by [wukko](https://x.com/uwukko). It’s getting some traction ([GitHub stars](https://github.com/imputnet/helium), [X followers](https://x.com/heliumbrowser), [YouTube coverage](https://youtu.be/jxsA_185lMI?t=106)), so it’d be nice if Anytype worked with it out of the box instead of users having to hack around it manually.

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?

Tested only on macos but pretty sure it's gonna work everywhere.

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
