### PR TITLE
Add ctrl-n, ctrl-p navigation option

### DIFF
--- a/src/ts/component/menu/index.tsx
+++ b/src/ts/component/menu/index.tsx
@@ -89,6 +89,8 @@ interface State {
 const ARROW_WIDTH = 17;
 const ARROW_HEIGHT = 8;
 
+const isMac = U.Common.isPlatformMac();
+
 const Components: any = {
 
 	help:					 MenuHelp,
@@ -767,7 +769,9 @@ const Menu = observer(class Menu extends React.Component<I.Menu, State> {
 		const inputRef = this.getInputRef();
 		const shortcutClose = [ 'escape' ];
 		const shortcutSelect = [ 'tab', 'enter' ];
-		
+		const shortcutPrev = isMac ? 'arrowup, ctrl+p' : 'arrowup';
+		const shortcutNext = isMac ? 'arrowdown, ctrl+n' : 'arrowdown';
+			
 		let index = this.getIndex();
 		let ret = false;
 
@@ -775,7 +779,7 @@ const Menu = observer(class Menu extends React.Component<I.Menu, State> {
 			if (inputRef.isFocused() && (index < 0)) {
 				keyboard.shortcut('arrowleft, arrowright', e, () => ret = true);
 
-				keyboard.shortcut('arrowdown, ctrl+n', e, () => {
+				keyboard.shortcut(shortcutNext, e, () => {
 					inputRef.blur();
 
 					this.setIndex(0);
@@ -797,7 +801,7 @@ const Menu = observer(class Menu extends React.Component<I.Menu, State> {
 					});
 				};
 
-				keyboard.shortcut('arrowup, ctrl+p', e, () => {
+				keyboard.shortcut(shortcutPrev, e, () => {
 					if (!this.ref.getItems) {
 						return;
 					};
@@ -809,7 +813,7 @@ const Menu = observer(class Menu extends React.Component<I.Menu, State> {
 					ret = true;
 				});
 			} else {
-				keyboard.shortcut('arrowup, ctrl+p', e, () => {
+				keyboard.shortcut(shortcutPrev, e, () => {
 					if (index < 0) {
 						inputRef?.focus();
 
@@ -881,12 +885,12 @@ const Menu = observer(class Menu extends React.Component<I.Menu, State> {
 			};
 		};
 
-		keyboard.shortcut('arrowup, ctrl+p', e, () => {
+		keyboard.shortcut(shortcutPrev, e, () => {
 			e.preventDefault();
 			onArrow(-1);
 		});
 
-		keyboard.shortcut('arrowdown, ctrl+n', e, () => {
+		keyboard.shortcut(shortcutNext, e, () => {
 			e.preventDefault();
 			onArrow(1);
 		});

--- a/src/ts/component/popup/search.tsx
+++ b/src/ts/component/popup/search.tsx
@@ -10,6 +10,8 @@ const HEIGHT_SMALL = 38;
 const HEIGHT_ITEM = 60;
 const LIMIT_HEIGHT = 15;
 
+const isMac = U.Common.isPlatformMac();
+
 const PopupSearch = observer(forwardRef<{}, I.Popup>((props, ref) => {
 
 	const { param, storageGet, storageSet, getId, close } = props;
@@ -71,9 +73,9 @@ const PopupSearch = observer(forwardRef<{}, I.Popup>((props, ref) => {
 		const cmd = keyboard.cmdKey();
 		const filter = getFilter();
 		const item = items[nRef.current];
-
+		const shortcutPrev = isMac ? 'arrowup, ctrl+p' : 'arrowup';
+		const shortcutNext = isMac ? 'arrowdown, ctrl+n' : 'arrowdown';
 		keyboard.disableMouse(true);
-
 		keyboard.shortcut('escape', e, () => {
 			if (backlinkRef.current) {
 				onClearSearch();
@@ -91,7 +93,7 @@ const PopupSearch = observer(forwardRef<{}, I.Popup>((props, ref) => {
 			};
 		});
 
-		keyboard.shortcut('arrowup, arrowdown, ctrl+p, ctrl+n', e, (pressed: string) => {
+		keyboard.shortcut(`${shortcutPrev}, ${shortcutNext}` , e, (pressed: string) => {
 			const dir = [ 'arrowup', 'ctrl+p' ].includes(pressed) ? -1 : 1;
 			onArrow(dir);
 		});


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

Adding ctrl+n, ctrl+p navigation for dropdowns and selections. This is popular alternative to the arrow keys supported by a lot of apps - Chrome, raycast, pretty much all code editors, obsidian, opencode, github website etc

It's already working in the editor, this PR intended to add support for ctrl-n, ctrl-p to dropdowns and popups.

This closes this feature request from the forum - https://community.anytype.io/t/can-i-use-ctrl-n-p-to-choose-a-pop-up-menu-option/23681

It's mostly useful on mac because on other platforms keybinding conflict with printing the page and creating new note. In case of conflict we can just prefer print/create like browsers do.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
