### PR TITLE
Prevent unnecessary scroll in large blocks

### DIFF
--- a/src/ts/lib/focus.ts
+++ b/src/ts/lib/focus.ts
@@ -124,11 +124,20 @@ class Focus {
 		const container = U.Common.getScrollContainer(isPopup);
 		const ch = container.height();
 		const no = node.offset().top;
+		const nh = node.outerHeight();
 		const hh = J.Size.header;
 		const o = J.Size.lastBlock + hh;
 		const st = container.scrollTop();
 		const y = no - container.offset().top + st;
-
+		
+		const topViewport = st + hh;
+		const bottomViewport = st + ch - o;
+		
+		// If block intersects the visible area - don't scroll
+		if ((y + nh > topViewport) && (y < bottomViewport)) {
+			return;
+		}
+		
 		if ((y >= st) && (y <= st + ch - o)) {
 			return;
 		};
@@ -138,4 +147,4 @@ class Focus {
 
 };
 
- export const focus: Focus = new Focus();
+export const focus: Focus = new Focus();


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

This is fix for #1761 ([forum link](https://community.anytype.io/t/ui-scroll-position-jumps-when-pasting-into-long-code-blocks/27658))

`focus.scroll()` is called on every paste, which seems reasonable, so I've tried to improve the scroll implementation.

However, it's very possible that somewhere in the app we call `focus.scroll()` expecting it to move us to the top of the block even if it's already visible. I haven't found any usages like this though.

An alternative solution is probably to check the number of inserted blocks on `onPaste()`, and if it's equal to 1, we don't need to scroll. But then we need to fix undo behavior separately.

off topic:
The most annoying issue with the current focus implementation is that it still can only scrolls to the top of the block instead of the caret position. Because of this pasting large blocks of text results in losing the caret somewhere below the viewport. 

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
