### PR TITLE
Fix caret position in code blocks

### DIFF
--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -487,10 +487,26 @@ const BlockText = observer(class BlockText extends React.Component<Props> {
 				return;
 			};
 
-			let pd = true;
+			// Handle enter manually in the code blocks to keep caret and new lines in sync
 			if (block.isTextCode() && (pressed == 'enter')) {
-				pd = false;
+				e.preventDefault();
+
+				const insert = '\n';
+				const newRange = U.Common.stringInsert(value, insert, range.from, range.to);
+				const caret = range.from + insert.length;
+
+				U.Data.blockSetText(rootId, block.id, newRange, this.marks, true, () => {
+					const caretRange = { from: caret, to: caret };
+					focus.set(block.id, caretRange);
+					focus.apply();
+					onKeyDown(e, newRange, this.marks, caretRange, this.props);
+				});
+
+				ret = true;
+				return;
 			};
+
+			let pd = true;
 			if (block.isText() && !block.isTextCode() && pressed.match('shift')) {
 				pd = false;
 			};


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description


Pressing enter after pasting text containing new lines in the code block causes weird desync in caret and input position. This PR is attempt to fix it by handling enter manually. I am not sure that it's the correct way, but it works.

https://github.com/user-attachments/assets/6a04c22f-72b3-4a10-9abd-c1a0268cd5a4

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
