### PR TITLE
Preserve groups on view duplication

### DIFF
--- a/src/ts/component/block/dataview/controls.tsx
+++ b/src/ts/component/block/dataview/controls.tsx
@@ -75,7 +75,7 @@ const Controls = observer(forwardRef<ControlsRefProps, Props>((props, ref) => {
 		const object = getTarget();
 		const sources = getSources();
 
-		C.BlockDataviewViewCreate(rootId, block.id, { ...view, name: view.name }, sources, (message: any) => {
+		Dataview.duplicateView(rootId, block.id, { ...view, name: view.name }, sources, (message: any) => {
 			onViewSwitch({ id: message.viewId, type: view.type });
 
 			analytics.event('DuplicateView', {

--- a/src/ts/component/menu/dataview/view/settings.tsx
+++ b/src/ts/component/menu/dataview/view/settings.tsx
@@ -330,7 +330,7 @@ const MenuViewSettings = observer(class MenuViewSettings extends React.Component
 
 			switch (item.id) {
 				case 'copy': {
-					C.BlockDataviewViewCreate(rootId, blockId, { ...view, name: this.getViewName(view.name) }, sources, (message: any) => {
+					Dataview.duplicateView(rootId, blockId, { ...view, name: this.getViewName(view.name) }, sources, (message: any) => {
 						if (onSave) {
 							onSave();
 						};


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

Small QOL improvement - copy selected groups when duplicating the view.

This annoys me personally, because I expect view settings like selected groups to be preserved on duplication, but I haven't found anyone talking about this on the forum. If you don't think this is a good idea - feel free to close the PR.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

Old:

https://github.com/user-attachments/assets/03a8407e-8923-4a40-8a9f-01df9c0b0f7b

New:

https://github.com/user-attachments/assets/66e602af-2595-4e66-bff6-b306498985a7


<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
