### PR TITLE
Fix displaying empty relations

### DIFF
--- a/src/ts/component/cell/index.tsx
+++ b/src/ts/component/cell/index.tsx
@@ -45,7 +45,10 @@ const Cell = observer(forwardRef<I.CellRef, Props>((props, ref) => {
 		};
 
 		if ([ I.RelationType.Select, I.RelationType.MultiSelect ].includes(relation.format)) {
-			return !!Relation.getOptions(record[relation.relationKey]).length;
+			const options = Relation.getOptions(record[relation.relationKey])
+				.filter(it => !it._empty_ && !it.isArchived && !it.isDeleted);
+			
+			return !!options.length;
 		};
 
 		return Relation.checkRelationValue(relation, record[relation.relationKey]);


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---



### Description

Fix for rendering empty selects which remain after object is deleted.

How to reproduce the bug with empty relations:
1. Add an object to the select on multiple notes
2. Delete the object completely
3. It will disappear only from the note you were in when deleting the object


At first seems like a backend bug, relation is not removed from all other objects. But looking at backend looks like it's intentional so just hiding the select then.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<details>
<summary>video on how to reproduce the bug</summary>

https://github.com/user-attachments/assets/92bcbb67-dce5-4672-8cb2-64d52431545f

</details>

<img width="362" height="371" alt="Screenshot 2025-11-21 at 1 33 44 AM" src="https://github.com/user-attachments/assets/67d0dc00-f77c-441d-bd96-e05d59c2309d" />
<img width="362" height="371" alt="Screenshot 2025-11-21 at 1 33 59 AM" src="https://github.com/user-attachments/assets/b7951d49-5fe9-4a32-9d13-7563a1560b3a" />


<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
