### PR TITLE
Handle undefined ORIGINAL_XDG_CURRENT_DESKTOP

### DIFF
--- a/electron/js/menu.js
+++ b/electron/js/menu.js
@@ -552,7 +552,7 @@ class MenuManager {
 			icon = path.join('icons', '256x256.ico');
 		} else 
 		if (is.linux) {
-			const env = process.env.ORIGINAL_XDG_CURRENT_DESKTOP;
+			const env = process.env.ORIGINAL_XDG_CURRENT_DESKTOP || '';
 			const panelAlwaysDark = env.includes('GNOME') || (env == 'Unity'); // for GNOME shell env, including ubuntu -- the panel is always dark
 
             if (panelAlwaysDark) {


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

This PR fixes a fatal `TypeError`, whereby the application hangs on startup on Linux systems where the environment variable `ORIGINAL_XDG_CURRENT_DESKTOP` is unset, as is the case on my NixOS system with Hyprland as the DE.

The error trace in question:
```
(node:7546) UnhandledPromiseRejectionWarning: TypeError: Cannot read properties of undefined (reading 'includes')
    at MenuManager.getTrayIcon (/nix/store/1m4hzb0w58hkvndzn0vv3zqadz2gwfij-anytype-0.52.4/lib/anytype/electron/js/menu.js:566:32)
    at MenuManager.initTray (/nix/store/1m4hzb0w58hkvndzn0vv3zqadz2gwfij-anytype-0.52.4/lib/anytype/electron/js/menu.js:424:21)
    at createWindow (/nix/store/1m4hzb0w58hkvndzn0vv3zqadz2gwfij-anytype-0.52.4/lib/anytype/electron.js:180:14)
    at /nix/store/1m4hzb0w58hkvndzn0vv3zqadz2gwfij-anytype-0.52.4/lib/anytype/electron.js:127:3
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

The current implementation omits a null check, which is added in this PR.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

### Mobile & Desktop Screenshots/Recordings

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?

