### PR TITLE
GO-1234 feat: limit linux build targets to AppImage to support ARM64

### DIFF
--- a/package.json
+++ b/package.json
@@ -798,10 +798,7 @@
 			"icon": "electron/img/icons",
 			"category": "Utility",
 			"target": [
-				"AppImage",
-				"deb",
-				"rpm",
-				"tar.gz"
+				"AppImage"
 			],
 			"description": "Anytype",
 			"publish": [


### PR DESCRIPTION
This PR limits the default linux build targets to AppImage. This avoids build failures on ARM64 systems where fpm (required for deb/rpm) is only available as an x86 binary. Related to https://github.com/anyproto/anytype-ts/issues/83