### PR TITLE
Genearlize `isCut` for future support of Copy As Reference

### DIFF
--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -555,7 +555,7 @@ const EditorPage = observer(class EditorPage extends React.Component<Props, Stat
 
 		// Copy/Cut
 		keyboard.shortcut(`${cmd}+c, ${cmd}+x`, e, (pressed: string) => {
-			this.onCopy(e, pressed.match('x') ? true : false);
+			this.onCopy(e, pressed.match('x') ? I.ClipboardMode.Cut : I.ClipboardMode.Copy);
 
 			ret = true;
 		});
@@ -855,7 +855,7 @@ const EditorPage = observer(class EditorPage extends React.Component<Props, Stat
 
 			// Copy/Cut
 			keyboard.shortcut(`${cmd}+c, ${cmd}+x`, e, (pressed: string) => {
-				this.onCopy(e, pressed.match('x') ? true : false);
+				this.onCopy(e, pressed.match('x') ? I.ClipboardMode.Cut : I.ClipboardMode.Copy);
 			});
 
 			// Undo
@@ -1846,13 +1846,13 @@ const EditorPage = observer(class EditorPage extends React.Component<Props, Stat
 		Preview.previewHide(false);
 	};
 	
-	onCopy (e: any, isCut: boolean) {
+	onCopy (e: any, mode: I.ClipboardMode) {
 		const { rootId } = this.props;
 		const selection = S.Common.getRef('selectionProvider');
 		const readonly = this.isReadonly();
 		const root = S.Block.getLeaf(rootId, rootId);
 		const { focused, range } = focus.state;
-
+		const isCut = mode == I.ClipboardMode.Cut;
 		if (!root || (readonly && isCut)) {
 			return;
 		};
@@ -1877,7 +1877,7 @@ const EditorPage = observer(class EditorPage extends React.Component<Props, Stat
 			this.focus(focused, range.from, range.from, false);
 		};
 
-		Action.copyBlocks(rootId, ids, isCut);
+		Action.copyBlocks(rootId, ids, mode);
 	};
 
 	onPasteEvent (e: any, props: any, data?: any) {

--- a/src/ts/component/menu/block/action.tsx
+++ b/src/ts/component/menu/block/action.tsx
@@ -613,12 +613,12 @@ class MenuBlockAction extends React.Component<I.Menu, State> {
 
 		switch (item.itemId) {
 			case 'clipboardCopy': {
-				Action.copyBlocks(rootId, ids, false);
+				Action.copyBlocks(rootId, ids, I.ClipboardMode.Copy);
 				break;
 			};
 
 			case 'clipboardCut': {
-				Action.copyBlocks(rootId, ids, true);
+				Action.copyBlocks(rootId, ids, I.ClipboardMode.Cut);
 				break;
 			};
 

--- a/src/ts/component/page/main/history.tsx
+++ b/src/ts/component/page/main/history.tsx
@@ -50,7 +50,7 @@ const PageMainHistory = observer(forwardRef<I.PageRef, I.PageComponent>((props, 
 		};
 		ids = ids.concat(S.Block.getLayoutIds(rootId, ids));
 
-		Action.copyBlocks(rootId, ids, false);
+		Action.copyBlocks(rootId, ids, I.ClipboardMode.Copy);
 	};
 
 	const renderDiff = (previousId: string, diff: any[]) => {

--- a/src/ts/interface/block/index.ts
+++ b/src/ts/interface/block/index.ts
@@ -86,7 +86,7 @@ export interface BlockComponent {
 	onMouseLeave?(e: any): void;
 	onFocus?(e: any): void;
 	onBlur?(e: any): void;
-	onCopy?(e: any, cut: boolean): void;
+	onCopy?(e: any, mode: I.ClipboardMode): void;
 	onPaste?(e: any, props: any): void;
 	onUpdate?(): void;
 	getWrapperWidth?(): number;

--- a/src/ts/interface/common.ts
+++ b/src/ts/interface/common.ts
@@ -405,3 +405,8 @@ export interface StickyScrollbarRef {
 	unbind: () => void;
 	sync: (element: JQuery<HTMLElement>, isSyncing: boolean) => boolean;
 };
+
+export enum ClipboardMode {
+	Copy		= 0,
+	Cut			= 1,
+}

--- a/src/ts/lib/action.ts
+++ b/src/ts/lib/action.ts
@@ -607,9 +607,9 @@ class Action {
 	 * Copies or cuts blocks to the clipboard.
 	 * @param {string} rootId - The root object ID.
 	 * @param {string[]} ids - The block IDs to copy or cut.
-	 * @param {boolean} isCut - Whether to cut (true) or copy (false).
+	 * @param {I.ClipboardMode} mode - Whether to copy or cut.
 	 */
-	copyBlocks (rootId: string, ids: string[], isCut: boolean) {
+	copyBlocks (rootId: string, ids: string[], mode: I.ClipboardMode) {
 		const root = S.Block.getLeaf(rootId, rootId);
 		if (!root) {
 			return;
@@ -622,6 +622,7 @@ class Action {
 		};
 
 		const range = U.Common.objectCopy(focus.state.range);
+		const isCut = mode == I.ClipboardMode.Cut;
 		const cmd = isCut ? 'BlockCut' : 'BlockCopy';
 		const tree = S.Block.wrapTree(rootId, rootId);
 


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

Change from an `isCut` bool to an enum with `Copy` and `Cut` options. This does not change anything else, but
- makes the code a bit more legible
- supports new copy modes, such as "Copy As Reference", which might be a possible interface for supporting transclusions / sync blocks.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
