### PR TITLE
Bugfix/JS-6450: Creating an account in different windows

### DIFF
--- a/electron/js/api.js
+++ b/electron/js/api.js
@@ -20,6 +20,7 @@ const KEYTAR_SERVICE = 'Anytype';
 class Api {
 
 	isPinChecked = false;
+	isAuthInProgress = false;
 	lastActivityTime = Date.now();
 	notificationCallbacks = new Map();
 	shownNotificationIds = new Set();
@@ -53,6 +54,24 @@ class Api {
 
 	logout (win) {
 		WindowManager.sendToAll('logout');
+	};
+
+	authStart (win) {
+		if (this.isAuthInProgress) {
+			return false;
+		};
+		this.isAuthInProgress = true;
+		WindowManager.sendToAllTabs('auth-in-progress', true);
+		return true;
+	};
+
+	authEnd (win) {
+		this.isAuthInProgress = false;
+		WindowManager.sendToAllTabs('auth-in-progress', false);
+	};
+
+	getAuthStatus (win) {
+		return this.isAuthInProgress;
 	};
 
 	pinCheck (win) {

--- a/src/json/text.json
+++ b/src/json/text.json
@@ -550,6 +550,7 @@
 
 	"pageAuthLoginInvalidPhrase": "Invalid Key",
 	"pageAuthLoginShortPhrase": "Key is too short",
+	"pageAuthLoginInProgress": "Authentication is already in progress in another window",
 
 	"pageAuthDeletedAccountDeletionTitle": "This vault is planned for deletion in %s",
 

--- a/src/ts/store/auth.ts
+++ b/src/ts/store/auth.ts
@@ -7,7 +7,7 @@ interface NetworkConfig {
 };
 
 class AuthStore {
-	
+
 	public accountItem: I.Account = null;
 	public accountList: I.Account[] = [];
 	public token = '';
@@ -15,18 +15,29 @@ class AuthStore {
 	public appKey = '';
 	public startingId: Map<string, string> = new Map();
 	public syncStatusMap: Map<string, I.SyncStatus> = new Map();
-	
+	public authInProgress = false;
+
 	constructor () {
 		makeObservable(this, {
 			accountItem: observable,
 			accountList: observable,
+			authInProgress: observable,
 			accounts: computed,
 			account: computed,
 			accountAdd: action,
 			accountSet: action,
 			clearAll: action,
 			logout: action,
+			setAuthInProgress: action,
 		});
+	};
+
+	/**
+	 * Sets the auth in progress state.
+	 * @param {boolean} v - The auth in progress value.
+	 */
+	setAuthInProgress (v: boolean) {
+		this.authInProgress = v;
 	};
 
 	get accounts (): I.Account[] {


### PR DESCRIPTION
## Summary
- Added auth-in-progress tracking mechanism in Electron main process
- Broadcasts auth status to all windows/tabs when auth starts/ends
- Auth pages now check and listen for auth-in-progress state
- Shows error message when another window is already authenticating

## Test plan
- [ ] Open multiple Anytype windows on the login screen
- [ ] Start creating an account in one window
- [ ] Verify other windows show "Authentication is already in progress in another window" error
- [ ] Verify login is blocked in other windows during auth
- [ ] Verify auth works normally after previous auth completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)