### PR TITLE
Bugfix/JS-6955: Undo fails in large code blocks after using heading shortcut

### DIFF
--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -867,7 +867,7 @@ const EditorPage = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 			keyboard.shortcut('search', e, () => keyboard.onSearchPopup(analytics.route.shortcut));
 		};
 
-		if (!isInsideTable && block.isText()) {
+		if (!isInsideTable && block.isText() && !block.isTextCode()) {
 			for (const item of styleParam) {
 				let style = null;
 


### PR DESCRIPTION
## Summary
- Disabled heading shortcuts (Cmd+Alt+1, Cmd+Alt+2, etc.) when inside code blocks
- Prevents accidental conversion of code block content to headings
- Fixes undo functionality breaking in large code blocks after using heading shortcuts

## Test plan
- [ ] Create a code block with 100+ lines of text
- [ ] Press Cmd+1 (or Cmd+Alt+1) inside the code block
- [ ] Verify nothing happens (no conversion to heading)
- [ ] Verify Cmd+Z (undo) still works correctly
- [ ] Verify heading shortcuts still work in regular text blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)