### PR TITLE
Add web mode for browser-based development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,3 +120,7 @@ Anytype is an Electron-based desktop application with TypeScript/React frontend 
 - Use existing utility functions in `lib/util/` before creating new ones
 - Follow existing component patterns in `component/` directory
 - Store updates should trigger UI re-renders automatically via MobX
+
+## Web Mode Development
+
+Run in browser without Electron: `npm run start:web` (starts anytypeHelper + dev server). Use `ANYTYPE_USE_SIDE_SERVER=http://...` to skip helper start. See `src/ts/lib/web/README.md` for details.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ anytypeHelper &       # or ./bin/anytypeHelper
 npm run start:dev     # Windows: npm run start:dev-win
 ```
 
+For browser-based development without Electron, see [Web Mode](./src/ts/lib/web/README.md).
+
 Optional env vars:
 
 | Name         | Purpose                                  |

--- a/dist/index.web.html
+++ b/dist/index.web.html
@@ -2,39 +2,83 @@
 <html>
 	<head>
 		<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-		<title>Anytype</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Anytype Web</title>
 
-		<script type="text/javascript">
-			window.isWebVersion = true;
-			window.serverAddress = 'http://127.0.0.1:57527';
+		<style type="text/css">
+			@keyframes bubble {
+				0%, 100% { transform: scale3d(0.9, 0.9, 1);  }
+				50% { transform: scale3d(1.1, 1.1, 1); }
+			}
 
-			window.Electron = {
-				platform: 'Windows',
-				version: {
-				},
-				getGlobal: () => {},
-			};
-		</script>
+			#bubble-loader {
+				position: absolute; width: 154px; height: 154px; left: 50%; top: 50%; transform: translate3d(-50%, -50%, 0); z-index: 10001;
+				display: flex; align-items: center; justify-content: center; border-radius: 50%; transition: all cubic-bezier(0.5, 0, 0.75, 0) 1s;
+				transform-origin: 50% 50%;
+			}
+			#bubble-loader.small { width: 32px; height: 32px; }
+			#bubble-loader .bubble { animation: bubble ease-in-out infinite 3.2s; border-radius: 50%; width: 100%; height: 100%; background-color: transparent; }
+			#bubble-loader .bubble .img { width: 100%; height: 100%; background-size: 100%; background-image: url('./img/icon/bubble.svg'); transition: opacity cubic-bezier(0.5, 0, 0.75, 0) 1s; }
+			#bubble-loader.inflate { transform: scale3d(20,20,1); }
+			#bubble-loader.inflate .bubble { transition: background-color ease-in-out 1s; animation-play-state: paused; }
+			#bubble-loader.inflate .bubble .img { opacity: 0; }
 
-		<script src="./js/polyfill.js" type="text/javascript"></script>
+			html.themeDark #bubble-loader .bubble .img { background-image: url('./img/theme/dark/icon/bubble.svg'); }
+
+			/* Web mode indicator */
+			.web-mode-indicator {
+				position: fixed;
+				bottom: 10px;
+				right: 10px;
+				padding: 4px 8px;
+				background: rgba(0, 0, 0, 0.6);
+				color: #fff;
+				font-size: 11px;
+				border-radius: 4px;
+				z-index: 99999;
+				font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+			}
+		</style>
 	</head>
-	<body onload="onload();">
+	<body>
+		<div id="bubble-loader">
+			<div class="bubble">
+				<div class="img"></div>
+			</div>
+		</div>
+
 		<div id="root"></div>
-		<script src="./js/run.js" type="text/javascript"></script>
+
+		<div class="web-mode-indicator">Web Mode</div>
+
 		<script type="text/javascript">
-			function onload () {
-				RendererEvents.init(null, {
-					dataPath: '/Users/admin/Library/Application Support/anytype2/dev/data',
-					config: {},
-					isDark: false,
-					isChild: false,
-					route: '',
-					account: null,
-					phrase: '',
-					languages: [],
-					isPinChecked: false,
-				});
-			};
+			// Initialize theme based on user preference
+			(function() {
+				var savedTheme = localStorage.getItem('anytype_config');
+				var theme = '';
+
+				try {
+					if (savedTheme) {
+						var config = JSON.parse(savedTheme);
+						theme = config.theme || '';
+					}
+				} catch (e) {}
+
+				if (!theme) {
+					theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+				}
+
+				function ucFirst(str) {
+					return String(str || '').charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+				}
+
+				if (theme) {
+					document.documentElement.classList.add('theme' + ucFirst(theme));
+				}
+
+				var bgColor = theme === 'dark' ? '#171717' : '#fff';
+				document.body.style.backgroundColor = bgColor;
+			})();
 		</script>
 	</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
 		"prepare": "husky install",
 		"update:locale": "node ./electron/hook/locale.js",
 		"ext:manifest:firefox": "node electron/hook/switch-manifest.js firefox",
-		"ext:manifest:chromium": "node electron/hook/switch-manifest.js chromium"
+		"ext:manifest:chromium": "node electron/hook/switch-manifest.js chromium",
+		"start:web": "node scripts/start-web.js",
+		"start:dev-web": "cross-env WEB_OPEN_BROWSER=1 node scripts/start-web.js",
+		"build:web": "cross-env BUILD_TARGET=web rspack --mode=production --node-env=production --env target=web"
 	},
 	"repository": {
 		"type": "git",

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -216,5 +216,145 @@ module.exports = (env, argv) => {
 		],
 	};
 
-	return [ appConfig,extensionConfig ];
+	// Web config: browser-only mode without Electron
+	const webPort = process.env.WEB_PORT || 9090;
+	const webConfig = {
+		name: 'web',
+		...base,
+
+		entry: {
+			web: {
+				import: './src/ts/entry.web.tsx',
+				filename: 'js/main.js',
+			},
+		},
+
+		output: {
+			path: path.resolve(__dirname, 'dist-web'),
+			publicPath: '/',
+		},
+
+		devServer: {
+			hot: true,
+			static: [
+				{ directory: path.resolve(__dirname, 'dist'), publicPath: '/' },
+				{ directory: path.resolve(__dirname, 'dist-web'), publicPath: '/' },
+			],
+			watchFiles: {
+				paths: ['src'],
+				options: {
+					usePolling: false,
+				},
+			},
+			historyApiFallback: true,
+			host: '0.0.0.0',
+			port: webPort,
+			allowedHosts: 'all',
+			headers: {
+				'Access-Control-Allow-Origin': '*',
+				'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
+				'Access-Control-Allow-Headers': 'X-Requested-With, content-type, Authorization',
+			},
+			client: {
+				progress: false,
+				overlay: {
+					runtimeErrors: (error) => {
+						const allowed = [
+							'ResizeObserver loop completed with undelivered notifications.',
+							'Worker was terminated',
+						];
+						return !allowed.includes(error.message);
+					},
+				},
+			},
+			// File upload proxy for web mode - writes files to temp so backend can access them
+			setupMiddlewares: (middlewares, devServer) => {
+				const fs = require('fs').promises;
+				const fsSync = require('fs');
+				const os = require('os');
+				const uploadDir = path.join(os.tmpdir(), 'anytype-web-uploads');
+				const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB limit
+
+				// Ensure upload directory exists (sync on startup is acceptable)
+				if (!fsSync.existsSync(uploadDir)) {
+					fsSync.mkdirSync(uploadDir, { recursive: true });
+				}
+
+				// Sanitize filename to prevent path traversal
+				const sanitizeFilename = (filename) => {
+					return String(filename || 'file')
+						.replace(/[/\\:\x00]/g, '_')
+						.replace(/^\.+/, '_');
+				};
+
+				devServer.app.post('/api/web-upload', (req, res) => {
+					const chunks = [];
+					let totalSize = 0;
+
+					req.on('data', chunk => {
+						totalSize += chunk.length;
+						if (totalSize > MAX_FILE_SIZE * 1.4) {
+							req.destroy();
+							return;
+						}
+						chunks.push(chunk);
+					});
+
+					req.on('end', async () => {
+						try {
+							const body = JSON.parse(Buffer.concat(chunks).toString());
+							const { filename, content } = body; // content is base64
+
+							if (!filename || !content) {
+								return res.status(400).json({ error: 'Missing filename or content' });
+							}
+
+							// Decode base64 content
+							const buffer = Buffer.from(content, 'base64');
+
+							if (buffer.length > MAX_FILE_SIZE) {
+								return res.status(413).json({ error: 'File too large' });
+							}
+
+							// Generate unique filename with sanitization
+							const safeName = sanitizeFilename(filename);
+							const uniqueName = `${Date.now()}-${Math.random().toString(36).substring(7)}-${safeName}`;
+							const filePath = path.join(uploadDir, uniqueName);
+
+							await fs.writeFile(filePath, buffer);
+							console.log('[Web Upload] File saved:', filePath);
+
+							res.json({ path: filePath });
+						} catch (e) {
+							console.error('[Web Upload] Error:', e);
+							res.status(500).json({ error: e.message });
+						}
+					});
+				});
+
+				return middlewares;
+			},
+		},
+
+		plugins: [
+			...base.plugins,
+			new rspack.DefinePlugin({
+				__IS_WEB__: 'true',
+			}),
+			new rspack.HtmlRspackPlugin({
+				template: path.resolve(__dirname, 'dist/index.web.html'),
+				filename: 'index.html',
+				inject: 'body',
+				scriptLoading: 'blocking',
+			}),
+		],
+	};
+
+	// Return configs based on build target
+	const buildTarget = env?.target || process.env.BUILD_TARGET;
+	if (buildTarget === 'web') {
+		return [ webConfig ];
+	}
+
+	return [ appConfig, extensionConfig ];
 };

--- a/scripts/start-web.js
+++ b/scripts/start-web.js
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+'use strict';
+
+const childProcess = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const stdoutWebProxyPrefix = 'gRPC Web proxy started at: ';
+const winShutdownStdinMessage = 'shutdown\n';
+
+const webPort = process.env.WEB_PORT || 9090;
+const openBrowserAuto = process.env.WEB_OPEN_BROWSER === '1' || process.env.WEB_OPEN_BROWSER === 'true';
+
+// Use the same Application Support / AppData folder as Electron
+function getDefaultDataPath() {
+	const platform = process.platform;
+
+	if (platform === 'darwin') {
+		// macOS: ~/Library/Application Support/anytype/data
+		return path.join(os.homedir(), 'Library', 'Application Support', 'anytype', 'data');
+	} else if (platform === 'win32') {
+		// Windows: %APPDATA%/anytype/data
+		return path.join(process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'), 'anytype', 'data');
+	} else {
+		// Linux: ~/.config/anytype/data
+		return path.join(process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'), 'anytype', 'data');
+	}
+}
+
+const dataPath = process.env.WEB_DATA_PATH || getDefaultDataPath();
+
+let helperProcess = null;
+let rspackProcess = null;
+
+// Ensure data directory exists
+if (!fs.existsSync(dataPath)) {
+	fs.mkdirSync(dataPath, { recursive: true });
+}
+
+const HELPER_STARTUP_TIMEOUT_MS = 30000;
+
+function startHelper() {
+	return new Promise((resolve, reject) => {
+		const sideServer = process.env.ANYTYPE_USE_SIDE_SERVER;
+
+		if (sideServer) {
+			console.log(`[Web] Using external server: ${sideServer}`);
+			resolve(sideServer);
+			return;
+		}
+
+		let binPath = path.join(__dirname, '..', 'dist', 'anytypeHelper');
+
+		// Handle Windows executable extension
+		if (process.platform === 'win32' && !fs.existsSync(binPath)) {
+			binPath += '.exe';
+		}
+
+		if (!fs.existsSync(binPath)) {
+			console.error(`[Web] Error: anytypeHelper not found at ${binPath}`);
+			console.error('[Web] Run ./update.sh to download the middleware first');
+			process.exit(1);
+		}
+
+		console.log('[Web] Starting anytypeHelper...');
+
+		let resolved = false;
+		let timeoutId = null;
+
+		const cleanup = () => {
+			if (timeoutId) {
+				clearTimeout(timeoutId);
+				timeoutId = null;
+			}
+		};
+
+		helperProcess = childProcess.spawn(binPath, ['127.0.0.1:0', '127.0.0.1:0'], {
+			windowsHide: false,
+			env: process.env,
+		});
+
+		// Timeout if helper doesn't start in time
+		timeoutId = setTimeout(() => {
+			if (!resolved) {
+				resolved = true;
+				console.error(`[Web] Timeout: anytypeHelper did not start within ${HELPER_STARTUP_TIMEOUT_MS / 1000}s`);
+				if (helperProcess) {
+					helperProcess.kill('SIGTERM');
+				}
+				reject(new Error('Helper startup timeout'));
+			}
+		}, HELPER_STARTUP_TIMEOUT_MS);
+
+		helperProcess.on('error', (err) => {
+			cleanup();
+			if (!resolved) {
+				resolved = true;
+				console.error('[Web] Failed to start anytypeHelper:', err.toString());
+				reject(err);
+			}
+		});
+
+		helperProcess.stdout.on('data', (data) => {
+			const str = data.toString();
+			process.stdout.write(str);
+
+			if (!resolved && str.indexOf(stdoutWebProxyPrefix) >= 0) {
+				const regex = new RegExp(stdoutWebProxyPrefix + '([^\\n\\s]+)');
+				const match = regex.exec(str);
+				if (match) {
+					resolved = true;
+					cleanup();
+					const address = 'http://' + match[1];
+					console.log(`[Web] gRPC-web proxy ready at: ${address}`);
+					resolve(address);
+				}
+			}
+		});
+
+		helperProcess.stderr.on('data', (data) => {
+			process.stderr.write(data.toString());
+		});
+
+		helperProcess.on('exit', (code) => {
+			cleanup();
+			if (!resolved) {
+				resolved = true;
+				const msg = `anytypeHelper exited unexpectedly with code ${code}`;
+				console.error(`[Web] ${msg}`);
+				reject(new Error(msg));
+			}
+			helperProcess = null;
+		});
+	});
+}
+
+function openBrowser(url) {
+	const platform = process.platform;
+	let cmd;
+
+	if (platform === 'darwin') {
+		cmd = 'open';
+	} else if (platform === 'win32') {
+		cmd = 'start';
+	} else {
+		cmd = 'xdg-open';
+	}
+
+	childProcess.spawn(cmd, [url], {
+		detached: true,
+		stdio: 'ignore',
+		shell: platform === 'win32',
+	}).unref();
+}
+
+// ANSI color codes
+const green = '\x1b[32m';
+const reset = '\x1b[0m';
+
+function startRspack(serverAddress) {
+	return new Promise((resolve, reject) => {
+		const webUrl = `http://127.0.0.1:${webPort}/?server=${encodeURIComponent(serverAddress)}&dataPath=${encodeURIComponent(dataPath)}`;
+
+		console.log(`\n[Web] Web URL: ${green}${webUrl}${reset}\n`);
+
+		// Set env vars for rspack config
+		process.env.BUILD_TARGET = 'web';
+		process.env.WEB_PORT = webPort;
+		process.env.WEB_SERVER_ADDRESS = serverAddress;
+		process.env.WEB_DATA_PATH = dataPath;
+
+		const rspackArgs = [
+			'serve',
+			'--mode=development',
+			'--node-env=development',
+			'--env', 'target=web',
+		];
+
+		rspackProcess = childProcess.spawn('npx', ['rspack', ...rspackArgs], {
+			stdio: ['inherit', 'pipe', 'inherit'],
+			shell: true,
+			env: process.env,
+		});
+
+		let browserOpened = false;
+
+		rspackProcess.stdout.on('data', (data) => {
+			const str = data.toString();
+			process.stdout.write(str);
+
+			// Open browser once webpack is ready
+			if (!browserOpened && str.includes('compiled successfully')) {
+				browserOpened = true;
+				if (openBrowserAuto) {
+					console.log(`\n[Web] Opening browser: ${webUrl}\n`);
+					openBrowser(webUrl);
+				}
+			}
+		});
+
+		rspackProcess.on('error', (err) => {
+			console.error('[Web] Failed to start rspack:', err.toString());
+			reject(err);
+		});
+
+		rspackProcess.on('exit', (code) => {
+			rspackProcess = null;
+			if (code !== null && code !== 0) {
+				console.error(`[Web] rspack exited with code ${code}`);
+			}
+			resolve();
+		});
+	});
+}
+
+function cleanup() {
+	console.log('\n[Web] Shutting down...');
+
+	if (rspackProcess) {
+		rspackProcess.kill('SIGTERM');
+	}
+
+	if (helperProcess) {
+		if (process.platform === 'win32') {
+			helperProcess.stdin.write(winShutdownStdinMessage);
+		} else {
+			helperProcess.kill('SIGTERM');
+		}
+	}
+}
+
+process.on('SIGINT', () => {
+	cleanup();
+	process.exit(0);
+});
+
+process.on('SIGTERM', () => {
+	cleanup();
+	process.exit(0);
+});
+
+async function main() {
+	try {
+		console.log('[Web] Anytype Web Mode');
+		console.log('[Web] ==================');
+
+		const serverAddress = await startHelper();
+		await startRspack(serverAddress);
+	} catch (err) {
+		console.error('[Web] Error:', err);
+		cleanup();
+		process.exit(1);
+	}
+}
+
+main();

--- a/src/ts/entry.web.tsx
+++ b/src/ts/entry.web.tsx
@@ -1,0 +1,63 @@
+/**
+ * Web entry point for running Anytype in a browser.
+ * This initializes the Electron mock before loading the main app.
+ *
+ * IMPORTANT: We use dynamic imports to ensure the Electron mock is set up
+ * BEFORE any other code (like app.tsx) tries to access window.Electron.
+ * Static imports are hoisted and execute before any other code.
+ */
+
+import React from 'react';
+
+// First, set up the Electron mock BEFORE any imports that might use it
+import { electronMock } from './lib/web/electronMock';
+
+// Set up global configuration from URL params or defaults
+const urlParams = new URLSearchParams(window.location.search);
+const serverAddress = urlParams.get('server') ||
+                      localStorage.getItem('anytype_serverAddress') ||
+                      'http://127.0.0.1:31008';
+const dataPath = urlParams.get('dataPath') ||
+                 localStorage.getItem('anytype_dataPath') ||
+                 '';
+
+// Store settings for future use
+localStorage.setItem('anytype_serverAddress', serverAddress);
+if (dataPath) {
+	localStorage.setItem('anytype_dataPath', dataPath);
+}
+
+// Configure the global config object
+(window as any).AnytypeGlobalConfig = {
+	serverAddress,
+	dataPath,
+};
+
+// Set up the Electron mock BEFORE importing app
+(window as any).Electron = electronMock;
+
+// Mark this as web version
+(window as any).isWebVersion = true;
+
+// Request notification permission
+if ('Notification' in window && Notification.permission === 'default') {
+	Notification.requestPermission();
+}
+
+console.log('[Anytype Web] Started with server:', serverAddress);
+console.log('[Anytype Web] Data path:', dataPath || '(default - will be set by backend)');
+console.log('[Anytype Web] To configure, add URL params: ?server=http://HOST:PORT&dataPath=/path/to/data');
+
+// Use dynamic imports to ensure window.Electron is set up first
+async function bootstrap() {
+	const { createRoot } = await import('react-dom/client');
+	const { default: App } = await import('./app');
+
+	const container = document.getElementById('root');
+	if (container) {
+		const root = createRoot(container);
+		root.render(<App />);
+	}
+}
+
+bootstrap().catch(console.error);

--- a/src/ts/lib/web/README.md
+++ b/src/ts/lib/web/README.md
@@ -1,0 +1,91 @@
+# Web Mode
+
+Run anytype-ts in a browser without Electron for development and testing.
+
+## Quick Start
+
+```bash
+# Start web mode (automatically starts anytypeHelper and opens browser)
+npm run start:web
+```
+
+That's it! The script will:
+1. Start `anytypeHelper` with gRPC-web proxy (auto-assigned ports)
+2. Start the webpack dev server on port 9090
+3. Open your browser with the correct URL
+
+## Using External Server
+
+If you're running `anytypeHelper` separately (e.g., for debugging):
+
+```bash
+# Use an external gRPC-web server
+ANYTYPE_USE_SIDE_SERVER=http://127.0.0.1:31008 npm run start:web
+```
+
+## Environment Variables
+
+| Variable                   | Description                        | Default                           |
+|----------------------------|------------------------------------|-----------------------------------|
+| `ANYTYPE_USE_SIDE_SERVER`  | External gRPC-web server URL       | (starts anytypeHelper)            |
+| `WEB_PORT`                 | Dev server port                    | `9090`                            |
+| `WEB_DATA_PATH`            | Data storage path for backend      | OS app data (see below)           |
+
+**Default data paths by OS:**
+- **macOS**: `~/Library/Application Support/anytype/data`
+- **Windows**: `%APPDATA%/anytype/data`
+- **Linux**: `~/.config/anytype/data`
+
+## URL Parameters
+
+The browser URL accepts these parameters (auto-configured by start script):
+
+| Parameter   | Description                          |
+|-------------|--------------------------------------|
+| `server`    | gRPC-web proxy address               |
+| `dataPath`  | Data storage path for backend        |
+
+## Architecture
+
+```
+Browser (localhost:9090)
+    │
+    ├─► React App (entry.web.tsx)
+    │       │
+    │       └─► electronMock.ts (mocks Electron API)
+    │
+    └─► gRPC-web ──► anytypeHelper (auto-assigned port)
+```
+
+## Key Files
+
+- `scripts/start-web.js` - Startup script (starts helper, rspack, opens browser)
+- `src/ts/entry.web.tsx` - Web entry point with dynamic imports
+- `src/ts/lib/web/electronMock.ts` - Mock implementation of Electron API
+- `rspack.config.js` - Web build configuration (webConfig section)
+- `dist/index.web.html` - HTML template for web mode
+
+## File Uploads
+
+In web mode, file uploads work via the dev server middleware:
+
+1. Browser selects file via `showOpenDialog`
+2. File content is read as base64
+3. POST to `/api/web-upload` endpoint
+4. Dev server writes file to temp directory
+5. Real filesystem path returned to app
+6. Backend reads file from that path
+
+## Limitations
+
+- Some Electron-specific features are mocked/no-op
+- File system operations go through temp directory proxy
+- No native OS integrations (tray, menu bar, etc.)
+
+## npm Scripts
+
+| Command                | Description                                    |
+|------------------------|------------------------------------------------|
+| `npm run start:web`    | Start anytypeHelper + dev server               |
+| `npm run start:dev-web`| Same as above + auto-open browser              |
+| `npm run build:web`    | Production build to dist-web/                  |

--- a/src/ts/lib/web/electronMock.ts
+++ b/src/ts/lib/web/electronMock.ts
@@ -1,0 +1,526 @@
+/**
+ * Web-compatible mock of the Electron API for browser mode.
+ * This enables running Anytype in a standard web browser without Electron.
+ */
+
+/**
+ * Upload a file to the dev server and get a real filesystem path.
+ * The dev server writes the file to a temp directory that the backend can access.
+ */
+async function uploadFileToServer(file: File): Promise<string> {
+	// Read file as base64
+	const base64 = await new Promise<string>((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => {
+			const result = reader.result as string;
+			// Remove data URL prefix to get just the base64
+			const base64 = result.split(',')[1] || result;
+			resolve(base64);
+		};
+		reader.onerror = () => reject(new Error('Failed to read file'));
+		reader.readAsDataURL(file);
+	});
+
+	// Upload to dev server
+	const response = await fetch('/api/web-upload', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			filename: file.name,
+			content: base64,
+		}),
+	});
+
+	if (!response.ok) {
+		throw new Error(`Upload failed: ${response.statusText}`);
+	}
+
+	const result = await response.json();
+	console.log('[WebFile] Uploaded:', file.name, '->', result.path);
+	return result.path;
+}
+
+interface MockTab {
+	id: string;
+	data: any;
+	token?: string;
+}
+
+interface MockConfig {
+	theme: string;
+	zoom: number;
+	interfaceLang: string;
+	languages: string[];
+	hideTray: boolean;
+	showMenuBar: boolean;
+	flagsMw: {
+		time: boolean;
+		json: boolean;
+		request: boolean;
+		event: boolean;
+		sync: boolean;
+		file: boolean;
+		subscribe: boolean;
+	};
+}
+
+class WebStorage {
+	private prefix = 'anytype_';
+
+	get(key: string): any {
+		try {
+			const value = localStorage.getItem(this.prefix + key);
+			return value ? JSON.parse(value) : undefined;
+		} catch {
+			return undefined;
+		}
+	}
+
+	set(key: string, value: any): void {
+		try {
+			localStorage.setItem(this.prefix + key, JSON.stringify(value));
+		} catch (e) {
+			console.warn('[WebStorage] Failed to set:', key, e);
+		}
+	}
+
+	delete(key: string): void {
+		localStorage.removeItem(this.prefix + key);
+	}
+}
+
+type ApiHandler = (args: any[]) => any | Promise<any>;
+
+type EventCallback = (...args: any[]) => void;
+
+class ElectronMock {
+	private storage = new WebStorage();
+	private eventListeners: Map<string, Set<EventCallback>> = new Map();
+	private tabId_ = 'web-' + Math.random().toString(36).substring(7);
+	private tabs: MockTab[] = [{ id: this.tabId_, data: {} }];
+	private config: MockConfig;
+	private windowId = 1;
+	private apiHandlers: Map<string, ApiHandler>;
+
+	constructor() {
+		this.config = this.storage.get('config') || this.getDefaultConfig();
+		this.apiHandlers = this.initApiHandlers();
+	}
+
+	private getDefaultConfig(): MockConfig {
+		return {
+			theme: '',
+			zoom: 0,
+			interfaceLang: 'en-US',
+			languages: [],
+			hideTray: false,
+			showMenuBar: true,
+			flagsMw: {
+				time: false,
+				json: false,
+				request: false,
+				event: false,
+				sync: false,
+				file: false,
+				subscribe: false,
+			},
+		};
+	}
+
+	private initApiHandlers(): Map<string, ApiHandler> {
+		const handlers = new Map<string, ApiHandler>();
+
+		// Init & config handlers
+		handlers.set('getInitData', () => ({
+			id: this.windowId,
+			dataPath: this.userPath(),
+			config: this.config,
+			isDark: this.config.theme === 'dark' ||
+				(this.config.theme === '' && window.matchMedia('(prefers-color-scheme: dark)').matches),
+			isChild: false,
+			route: '',
+			isPinChecked: true,
+			languages: navigator.languages,
+			css: '',
+			activeIndex: 0,
+			isSingleTab: true,
+		}));
+
+		handlers.set('setConfig', (args) => {
+			Object.assign(this.config, args[0]);
+			this.storage.set('config', this.config);
+			return true;
+		});
+
+		handlers.set('setTheme', (args) => {
+			this.config.theme = args[0];
+			this.storage.set('config', this.config);
+			document.body.classList.remove('themeDark', 'themeLight');
+			if (args[0] === 'dark') {
+				document.body.classList.add('themeDark');
+			} else if (args[0] === 'light') {
+				document.body.classList.add('themeLight');
+			}
+			return true;
+		});
+
+		handlers.set('setZoom', (args) => {
+			this.config.zoom = args[0];
+			this.storage.set('config', this.config);
+			return true;
+		});
+
+		// URL & path handlers
+		handlers.set('openUrl', (args) => {
+			window.open(args[0], '_blank');
+			return true;
+		});
+
+		handlers.set('openPath', (args) => {
+			console.log('[Web] openPath not supported:', args[0]);
+			return true;
+		});
+
+		// Keytar handlers (credential storage)
+		handlers.set('keytarGet', (args) => this.storage.get('keytar_' + args[0]) || null);
+		handlers.set('keytarSet', (args) => {
+			this.storage.set('keytar_' + args[0], args[1]);
+			return true;
+		});
+		handlers.set('keytarDelete', (args) => {
+			this.storage.delete('keytar_' + args[0]);
+			return true;
+		});
+
+		// Tab handlers
+		handlers.set('getTabs', () => ({
+			tabs: this.tabs.map(t => ({ id: t.id, data: t.data })),
+			id: this.tabId_,
+			isVisible: false,
+		}));
+
+		handlers.set('getTab', (args) => {
+			const tab = this.tabs.find(t => t.id === args[0]);
+			return tab ? { id: tab.id, data: tab.data, token: tab.token } : null;
+		});
+
+		handlers.set('updateTab', (args) => {
+			const tabToUpdate = this.tabs.find(t => t.id === args[0]);
+			if (tabToUpdate) {
+				tabToUpdate.data = { ...tabToUpdate.data, ...args[1] };
+				if (args[1].token) {
+					tabToUpdate.token = args[1].token;
+				}
+			}
+			return true;
+		});
+
+		// Download & file handlers
+		handlers.set('download', (args) => {
+			const link = document.createElement('a');
+			link.href = args[0];
+			link.download = args[1]?.filename || 'download';
+			link.click();
+			return true;
+		});
+
+		handlers.set('checkDiskSpace', () => ({
+			free: 100 * 1024 * 1024 * 1024,
+			size: 500 * 1024 * 1024 * 1024,
+		}));
+
+		// Notification handler
+		handlers.set('notification', (args) => {
+			if ('Notification' in window && Notification.permission === 'granted') {
+				new Notification(args[0]?.title || '', { body: args[0]?.text || '' });
+			}
+			return true;
+		});
+
+		// Window handlers
+		handlers.set('reload', () => {
+			window.location.reload();
+			return true;
+		});
+
+		handlers.set('focusWindow', () => {
+			window.focus();
+			return true;
+		});
+
+		handlers.set('setBadge', (args) => {
+			document.title = args[0] ? `(${args[0]}) Anytype` : 'Anytype';
+			return true;
+		});
+
+		// Session handlers
+		handlers.set('logout', () => this.clearStorageAndReload());
+		handlers.set('exit', () => this.clearStorageAndReload());
+		handlers.set('shutdown', () => this.clearStorageAndReload());
+
+		// Clipboard handler
+		handlers.set('paste', async () => {
+			if (navigator.clipboard) {
+				const text = await navigator.clipboard.readText();
+				document.execCommand('insertText', false, text);
+			}
+			return true;
+		});
+
+		// Config persistence handlers
+		const configHandler = (args: any[]) => {
+			this.config = { ...this.config, ...args[0] };
+			this.storage.set('config', this.config);
+			return true;
+		};
+		handlers.set('setUserDataPath', configHandler);
+		handlers.set('setChannel', configHandler);
+		handlers.set('setInterfaceLang', configHandler);
+
+		// No-op handlers that return true
+		const noopTrue = () => true;
+		['minimize', 'maximize', 'close', 'toggleFullScreen'].forEach(cmd => {
+			handlers.set(cmd, () => {
+				console.log('[Web] Window command not supported:', cmd);
+				return true;
+			});
+		});
+
+		['setPinChecked', 'pinCheck', 'pinSet', 'pinRemove'].forEach(cmd => handlers.set(cmd, noopTrue));
+		['setSpellingLang', 'spellcheckAdd'].forEach(cmd => handlers.set(cmd, noopTrue));
+		['updateCheck', 'updateDownload', 'updateConfirm', 'updateCancel'].forEach(cmd => {
+			handlers.set(cmd, () => {
+				console.log('[Web] Updates not supported in web mode');
+				return true;
+			});
+		});
+
+		['menu', 'initMenu', 'setHideTray', 'setMenuBarVisibility', 'setHardwareAcceleration'].forEach(cmd => {
+			handlers.set(cmd, () => {
+				console.log('[Web] Menu/system command not supported:', cmd);
+				return true;
+			});
+		});
+
+		['createTab', 'openTab', 'openWindow', 'setActiveTab', 'removeTab', 'closeOtherTabs',
+			'reorderTabs', 'setTabsDimmer', 'winCommand', 'setAlwaysShowTabs'].forEach(cmd => {
+			handlers.set(cmd, () => {
+				console.log('[Web] Tab command not supported:', cmd);
+				return true;
+			});
+		});
+
+		['showChallenge', 'hideChallenge'].forEach(cmd => {
+			handlers.set(cmd, () => {
+				console.log('[Web] Challenge not supported:', cmd);
+				return true;
+			});
+		});
+
+		handlers.set('payloadBroadcast', noopTrue);
+
+		// No-op handlers that return empty object
+		['systemInfo', 'linuxDistro', 'shortcutExport', 'shortcutImport'].forEach(cmd => {
+			handlers.set(cmd, () => ({}));
+		});
+
+		handlers.set('moveNetworkConfig', () => ({ error: 'Not supported in web mode' }));
+
+		return handlers;
+	}
+
+	private clearStorageAndReload(): true {
+		Object.keys(localStorage).forEach(key => {
+			if (key.startsWith('anytype_')) {
+				localStorage.removeItem(key);
+			}
+		});
+		window.location.reload();
+		return true;
+	}
+
+	version = {
+		app: '0.0.0-web',
+		os: `${navigator.platform} (Web)`,
+		system: navigator.userAgent,
+		device: 'Web Browser',
+	};
+
+	platform = 'web';
+	arch = 'web';
+	isPackaged = false;
+
+	storeGet = (key: string) => this.storage.get(key);
+	storeSet = (key: string, value: any) => this.storage.set(key, value);
+	storeDelete = (key: string) => this.storage.delete(key);
+
+	// Get data path from URL params, localStorage, or window config
+	// This path must be writable by the anytypeHelper backend
+	private getDataPath = (): string => {
+		// Check URL params first
+		const urlParams = new URLSearchParams(window.location.search);
+		const urlDataPath = urlParams.get('dataPath');
+		if (urlDataPath) {
+			return urlDataPath;
+		}
+
+		// Check localStorage
+		const storedPath = localStorage.getItem('anytype_dataPath');
+		if (storedPath) {
+			return storedPath;
+		}
+
+		// Check window config
+		if ((window as any).AnytypeGlobalConfig?.dataPath) {
+			return (window as any).AnytypeGlobalConfig.dataPath;
+		}
+
+		// Default: use a path in user's home directory
+		// This will be resolved by the backend based on OS
+		return '';
+	};
+
+	userPath = () => this.getDataPath();
+	tmpPath = () => '/tmp';
+	downloadPath = () => this.getDataPath() ? `${this.getDataPath()}/downloads` : '/tmp/anytype-web/downloads';
+	logPath = () => this.getDataPath() ? `${this.getDataPath()}/logs` : '/tmp/anytype-web/logs';
+	defaultPath = () => this.getDataPath();
+
+	dirName = (fp: string) => fp.substring(0, fp.lastIndexOf('/'));
+	filePath = (...args: string[]) => args.join('/');
+	fileName = (fp: string) => fp.substring(fp.lastIndexOf('/') + 1);
+	fileMime = (_fp: string) => 'application/octet-stream';
+	fileExt = (fp: string) => {
+		const idx = fp.lastIndexOf('.');
+		return idx >= 0 ? fp.substring(idx + 1) : '';
+	};
+	fileSize = (_fp: string) => 0;
+	isDirectory = (_fp: string) => false;
+
+	getTheme = () => this.config.theme || '';
+	getBgColor = () => this.config.theme === 'dark' ? '#171717' : '#fff';
+
+	tabId = () => this.tabId_;
+
+	currentWindow = () => ({
+		windowId: this.windowId,
+		isFocused: () => document.hasFocus(),
+		isFullScreen: () => !!document.fullscreenElement,
+	});
+
+	isFocused = () => document.hasFocus();
+	isFullScreen = () => !!document.fullscreenElement;
+
+	focus = () => window.focus();
+
+	getGlobal = (key: string) => {
+		if (key === 'serverAddress') {
+			// Get gRPC-web proxy address from window config or env
+			// Note: anytypeHelper starts gRPC on port X and gRPC-web proxy on port X+1
+			return (window as any).AnytypeGlobalConfig?.serverAddress ||
+				(window as any).GRPC_SERVER_ADDRESS ||
+				'http://127.0.0.1:31008';
+		}
+		return null;
+	};
+
+	showOpenDialog = async (options: any) => {
+		// Use the File System Access API if available
+		if ('showOpenFilePicker' in window) {
+			try {
+				const handles = await (window as any).showOpenFilePicker({
+					multiple: options?.properties?.includes('multiSelections'),
+					types: options?.filters?.map((f: any) => ({
+						description: f.name,
+						accept: { '*/*': f.extensions?.map((e: string) => '.' + e) || ['*'] },
+					})),
+				});
+				const files: File[] = await Promise.all(handles.map((h: any) => h.getFile()));
+
+				// Upload files to server to get real filesystem paths
+				const filePaths = await Promise.all(files.map(f => uploadFileToServer(f)));
+
+				return {
+					canceled: false,
+					filePaths,
+					files
+				};
+			} catch (e) {
+				console.log('[showOpenDialog] Canceled or error:', e);
+				return { canceled: true, filePaths: [] };
+			}
+		}
+
+		// Fallback to input element
+		return new Promise((resolve) => {
+			const input = document.createElement('input');
+			input.type = 'file';
+			input.multiple = options?.properties?.includes('multiSelections');
+			input.onchange = async () => {
+				const files = Array.from(input.files || []);
+				if (files.length === 0) {
+					resolve({ canceled: true, filePaths: [], files: [] });
+					return;
+				}
+
+				try {
+					// Upload files to server to get real filesystem paths
+					const filePaths = await Promise.all(files.map(f => uploadFileToServer(f)));
+					resolve({
+						canceled: false,
+						filePaths,
+						files
+					});
+				} catch (e) {
+					console.error('[showOpenDialog] Upload error:', e);
+					resolve({ canceled: true, filePaths: [], files: [] });
+				}
+			};
+			input.click();
+		});
+	};
+
+	webFilePath = (file: File) => file.name;
+
+	fileWrite = (name: string, data: any, _options?: any) => {
+		// Create a blob and download it
+		const blob = new Blob([data]);
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = name;
+		a.click();
+		URL.revokeObjectURL(url);
+		return name;
+	};
+
+	on = (event: string, callback: EventCallback) => {
+		if (!this.eventListeners.has(event)) {
+			this.eventListeners.set(event, new Set());
+		}
+		this.eventListeners.get(event)!.add(callback);
+	};
+
+	removeAllListeners = (event: string) => {
+		this.eventListeners.delete(event);
+	};
+
+	emit = (event: string, ...args: any[]) => {
+		const listeners = this.eventListeners.get(event);
+		if (listeners) {
+			listeners.forEach(cb => cb(null, ...args));
+		}
+	};
+
+	Api = async (_id: number, cmd: string, args: any[] = []): Promise<any> => {
+		const handler = this.apiHandlers.get(cmd);
+		if (handler) {
+			return handler(args);
+		}
+		console.log('[Web] Unknown API command:', cmd, args);
+		return null;
+	};
+}
+
+export const electronMock = new ElectronMock();
+export default electronMock;


### PR DESCRIPTION
- Add electronMock.ts to mock Electron API in browser
- Add entry.web.tsx as web entry point with dynamic imports
- Add start-web.js script to auto-start anytypeHelper
- Add npm scripts: start:web, start:dev-web, build:web
- Support ANYTYPE_USE_SIDE_SERVER env var to use external server
- File uploads via /api/web-upload middleware
- Data stored in OS app data folder (~/Library/Application Support/anytype/data)
