### PR TITLE
Bugfix/JS-7255: The focus behind the RTL text is moving in a different direction

### DIFF
--- a/src/ts/component/form/input.tsx
+++ b/src/ts/component/form/input.tsx
@@ -286,6 +286,13 @@ const Input = forwardRef<InputRef, Props>(({
 			callWithTimeout(() => {
 				focus(preventScroll);
 				inputRef.current?.setSelectionRange(range.from, range.to);
+
+				if (inputRef.current) {
+					const style = window.getComputedStyle(inputRef.current);
+					if (style.direction === 'rtl') {
+						inputRef.current.scrollLeft = 0;
+					};
+				};
 			});
 		},
 		getRange: (): I.TextRange | null => rangeRef.current,

--- a/src/ts/lib/focus.ts
+++ b/src/ts/lib/focus.ts
@@ -118,7 +118,15 @@ class Focus {
 		el.focus({ preventScroll: true });
 
 		if (node.hasClass('input')) {
-			window.setTimeout(() => (el as HTMLInputElement).setSelectionRange(range.from, range.to));
+			window.setTimeout(() => {
+				const input = el as HTMLInputElement;
+				input.setSelectionRange(range.from, range.to);
+
+				const style = window.getComputedStyle(input);
+				if (style.direction === 'rtl') {
+					input.scrollLeft = 0;
+				};
+			});
 		} else
 		if (node.hasClass('editable')) {
 			keyboard.setFocus(true);


### PR DESCRIPTION
## Summary
- Fixed scroll direction for RTL (right-to-left) text in input fields
- After setting selection range, check if the input has RTL direction
- Reset scrollLeft to 0 for RTL inputs to keep cursor visible at the correct edge
- Applied fix to both focus.ts and Input component

## Test plan
- [ ] Enable RTL language input (Arabic or Hebrew)
- [ ] Type long RTL text in an input field (e.g., search or block title)
- [ ] Verify the text scrolls correctly and cursor remains visible at left edge
- [ ] Verify LTR text still scrolls normally (cursor visible at right edge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)