### PR TITLE
Bugfix/JS-7256: RTL text is entered on the left when changing the style of the next block

### DIFF
--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -44,7 +44,7 @@ const BlockText = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 	const root = S.Block.getLeaf(rootId, rootId);
 	const cn = [ 'flex' ];
 	const cv = [ 'value', 'focusable', `c${id}` ];
-	const checkRtl = U.String.checkRtl(text);
+	const checkRtl = U.String.checkRtl(text) || fields.isRtlDetected;
 	const nodeRef = useRef(null);
 	const langRef = useRef(null);
 	const editableRef = useRef(null);


### PR DESCRIPTION
## Summary
- Fixed RTL text direction preservation when changing block styles
- Include fields.isRtlDetected flag in RTL check along with text content check
- Ensures RTL direction is preserved even when text is empty after style change

## Test plan
- [ ] Enter a numbered list with RTL text (Arabic or Hebrew)
- [ ] Change the block style to Bulleted using the menu
- [ ] Press Enter to create a new block
- [ ] Start typing RTL text
- [ ] Verify text appears on the right side (RTL direction preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)