### PR TITLE
Bugfix/JS-7497: Inline code problems

### DIFF
--- a/src/ts/lib/mark.ts
+++ b/src/ts/lib/mark.ts
@@ -899,13 +899,12 @@ class Mark {
 	 * @returns {boolean} True if needs break.
 	 */
 	needsBreak (t: I.MarkType): boolean {
-		return [ 
-			I.MarkType.Link, 
-			I.MarkType.Object, 
-			I.MarkType.Search, 
-			I.MarkType.Change, 
-			I.MarkType.Highlight, 
-			I.MarkType.Code,
+		return [
+			I.MarkType.Link,
+			I.MarkType.Object,
+			I.MarkType.Search,
+			I.MarkType.Change,
+			I.MarkType.Highlight,
 		].includes(t);
 	};
 


### PR DESCRIPTION
## Summary
- Fixed space handling in inline code marks
- Removed Code mark from needsBreak list to allow typing spaces inside
- Spaces now remain inside the inline code mark instead of breaking it

## Note
The cursor navigation issues at mark boundaries (can't move cursor before inline code at line beginning, or after at line end) require more complex contenteditable handling with cursor anchors. This fix addresses the primary space input issue.

## Test plan
- [ ] Create inline code using backticks: \`code\`
- [ ] Place cursor inside the code mark
- [ ] Press space - verify space is added INSIDE the code (not breaking the mark)
- [ ] Verify links still break on space at end (expected behavior for links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)