### PR TITLE
Bugfix/JS-7512: The problem with autolinking in the chat

### DIFF
--- a/src/ts/component/block/chat/form.tsx
+++ b/src/ts/component/block/chat/form.tsx
@@ -347,9 +347,7 @@ const ChatForm = observer(forwardRef<RefProps, Props>((props, ref) => {
 			updateMarkup(value, { from: to, to });
 		};
 
-		/*
 		keyboard.shortcut('space', e, () => checkUrls());
-		*/
 
 		checkSendButton();
 		removeBookmarks();


### PR DESCRIPTION
## Summary
- Re-enabled URL detection on space key press in chat
- Uncommented checkUrls() call that was previously disabled
- URLs are now properly detected and linked when user types space after them

## Test plan
- [ ] Open a chat in Anytype
- [ ] Type a URL like "example.com "
- [ ] Press space after the URL
- [ ] Continue typing more text after the space
- [ ] Verify the link ends at the URL and doesn't extend to include subsequent text

🤖 Generated with [Claude Code](https://claude.com/claude-code)