### PR TITLE
Bugfix/JS-8598: Using 'Paste' in the Block's content menu causes a jump to the end of Page

### DIFF
--- a/src/ts/component/menu/block/action.tsx
+++ b/src/ts/component/menu/block/action.tsx
@@ -510,7 +510,11 @@ const MenuBlockAction = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 
 			case 'clipboardPaste': {
 				close();
-				window.setTimeout(() => Renderer.send('paste'), J.Constant.delay.menu);
+				window.setTimeout(() => {
+					focus.set(blockId, range);
+					focus.apply();
+					window.setTimeout(() => Renderer.send('paste'), 50);
+				}, J.Constant.delay.menu);
 				return;
 			};
 


### PR DESCRIPTION
## Summary
- Fixed paste from context menu jumping to end of page instead of cursor position
- Ensure focus is properly set AFTER menu closes but BEFORE paste executes
- Re-apply focus.set() and focus.apply() after the menu close delay
- Add small delay between focus application and paste to ensure DOM updates

## Test plan
- [ ] Copy some content to clipboard
- [ ] Click in the middle of a page at an empty line
- [ ] Right-click to open block context menu
- [ ] Select "Paste" from the menu
- [ ] Verify content is pasted at the cursor position (not at end of page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)