### PR TITLE
Bugfix/JS-8626: When changing the RTL/LTR language in a block, the first character is deleted

### DIFF
--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -809,7 +809,9 @@ const BlockText = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 		textRef.current = value;
 
 		U.Data.blockSetText(rootId, block.id, value, marks, update, message => {
-			U.Data.setRtl(rootId, block, U.String.checkRtl(value));
+			if (value.length > 1) {
+				U.Data.setRtl(rootId, block, U.String.checkRtl(value));
+			};
 			callBack?.();
 		});
 	};


### PR DESCRIPTION
## Summary
- Fixed first character deletion when switching between RTL and LTR
- Delay RTL state change until text has more than one character
- Prevents race condition between text update and alignment change commands

## Test plan
- [ ] Create a block with RTL text (Arabic or Hebrew)
- [ ] Create a new block by pressing Enter
- [ ] Start typing English text
- [ ] Verify the first character is NOT deleted
- [ ] Verify alignment changes correctly after the second character

🤖 Generated with [Claude Code](https://claude.com/claude-code)