### PR TITLE
Move pin-code timeout to main process

### DIFF
--- a/src/ts/lib/keyboard.ts
+++ b/src/ts/lib/keyboard.ts
@@ -3,12 +3,11 @@ import raf from 'raf';
 import { I, C, S, U, J, Storage, focus, history as historyPopup, analytics, Renderer, sidebar, Preview, Action, translate } from 'Lib';
 
 class Keyboard {
-	
-	mouse: any = { 
+
+	mouse: any = {
 		page: { x: 0, y: 0 },
 		client: { x: 0, y: 0 },
 	};
-	timeoutPin = 0;
 	timeoutSidebarHide = 0;
 	source: any = null;
 	selection: any = null;
@@ -76,7 +75,6 @@ class Keyboard {
 			S.Common.windowIsFocusedSet(false);
 			S.Menu.closeAll([ 'blockContext' ]);
 
-			window.clearTimeout(this.timeoutPin);
 			$('.dropTarget.isOver').removeClass('isOver');
 		});
 
@@ -1564,7 +1562,8 @@ class Keyboard {
 		};
 
 		this.isPinChecked = v;
-		Renderer.send('setPinChecked', v);
+		// Pass pin timeout to main process so it can start the centralized timer
+		Renderer.send('setPinChecked', v, v ? S.Common.pinTime : 0);
 	};
 
 	/**
@@ -1600,42 +1599,23 @@ class Keyboard {
 	};
 
 	/**
-	 * Initializes pin check logic.
+	 * Reports user activity to the main process for centralized pin timeout tracking.
+	 * The main process manages a single timer for all tabs/windows.
 	 */
 	initPinCheck () {
 		const { account } = S.Auth;
-		const { windowIsFocused } = S.Common;
+		const { pin, windowIsFocused } = S.Common;
 
-		const check = () => {
-			const { pin } = S.Common;
-			if (!pin) {
-				this.setPinChecked(true);
-				return false;
-			};
-			return true;
-		};
-
-		if (!account || !check()) {
+		if (!account || !pin) {
 			return;
 		};
 
 		if (!windowIsFocused) {
-			window.clearTimeout(this.timeoutPin);
 			return;
 		};
 
-		window.clearTimeout(this.timeoutPin);
-		this.timeoutPin = window.setTimeout(() => {
-			if (!check() || this.isAuthPinCheck()) {
-				return;
-			};
-
-			if (this.isMain()) {
-				S.Common.redirectSet(U.Router.getRoute());
-			};
-
-			Renderer.send('pinCheck');
-		}, S.Common.pinTime);
+		// Report activity to main process to reset the centralized timer
+		Renderer.send('resetPinTimer');
 	};
 
 	/**

--- a/src/ts/store/common.ts
+++ b/src/ts/store/common.ts
@@ -547,6 +547,11 @@ class CommonStore {
 		this.pinTimeId = Number(v) || J.Constant.default.pinTime;
 
 		Storage.set('pinTime', this.pinTimeId);
+
+		// Update the centralized timer in main process with new timeout
+		if (keyboard.isPinChecked && this.pin) {
+			Renderer.send('startPinTimer', this.pinTime);
+		};
 	};
 
 	/**
@@ -577,6 +582,7 @@ class CommonStore {
 	pinRemove () {
 		this.pinValue = null;
 		Renderer.send('keytarDelete', this.pinId());
+		Renderer.send('stopPinTimer');
 		Renderer.send('pinRemove');
 	};
 


### PR DESCRIPTION
## Summary
- Centralizes the pin timeout timer in the main Electron process instead of each renderer tab managing its own timer
- Prevents the issue where one tab's timer expiring would lock all tabs/windows even when the user is active in another tab
- Activity in any tab now resets the single shared timer in the main process

## Test plan
- [ ] Enable pin code in settings with a short timeout (e.g., 60 seconds)
- [ ] Open multiple tabs/windows
- [ ] Work in one tab and verify that activity resets the timeout for all tabs
- [ ] Let the timeout expire and verify all tabs are locked simultaneously
- [ ] Verify changing pin timeout in settings updates the active timer
- [ ] Verify disabling pin code stops the timer
- [ ] Verify logout stops the timer

🤖 Generated with [Claude Code](https://claude.com/claude-code)