### PR TITLE
Feature/JS-8642: Add tab drag between windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ Anytype is an Electron-based desktop application with TypeScript/React frontend 
 - Custom block-based editor system
 - gRPC for backend communication
 - Electron for desktop app packaging
+- CSS supports native nesting - use nested selectors instead of flat/inline selectors
 
 ### Important Patterns
 - All UI text should use `translate()` function for i18n

--- a/dist/css/tabs.css
+++ b/dist/css/tabs.css
@@ -145,3 +145,12 @@ html.themeDark {
 		.icon.window-close { background-image: url('../img/theme/dark/icon/window/close.svg'); }
 	}
 }
+
+/* Tab drag outside window visual feedback */
+body.draggingOutside {
+	#tabs { opacity: 0.6; }
+	#marker { opacity: 0.6; }
+}
+
+/* Drop target highlight for receiving window */
+#tabs.dropTarget { outline: 2px dashed var(--color-shape-primary); outline-offset: -2px; }

--- a/electron/js/api.js
+++ b/electron/js/api.js
@@ -647,6 +647,132 @@ class Api {
 		Util.send(win, 'set-tabs-dimmer', show);
 	};
 
+	getWindowBounds (win) {
+		return WindowManager.getBounds(win);
+	};
+
+	getCursorScreenPoint (win) {
+		const { screen } = require('electron');
+		return screen.getCursorScreenPoint();
+	};
+
+	/**
+	 * Detaches a tab from its window, either creating a new window or moving to an existing one
+	 * @param {BrowserWindow} win - Source window
+	 * @param {Object} param - Parameters { tabId, mouseX, mouseY }
+	 */
+	detachTab (win, param) {
+		const { tabId, mouseX, mouseY } = param || {};
+
+		if (!tabId || !win || !win.views) {
+			return;
+		};
+
+		// Don't detach if this is the only tab
+		if (win.views.length <= 1) {
+			return;
+		};
+
+		// Find the tab to detach
+		const tab = win.views.find(it => it.id == tabId);
+		if (!tab) {
+			return;
+		};
+
+		// Get tab data before removing
+		const tabData = { ...tab.data };
+
+		// Check if there's another window at the mouse position
+		const targetWin = this.getWindowAtPoint(mouseX, mouseY, win);
+
+		if (targetWin) {
+			// Transfer tab to existing window
+			this.transferTabToWindow(win, targetWin, tabId, tabData);
+		} else {
+			// Create new window with this tab
+			this.createWindowFromTab(win, tabId, tabData, mouseX, mouseY);
+		};
+	};
+
+	/**
+	 * Finds a window at the given screen coordinates, excluding a specific window
+	 * @param {number} x - Screen X coordinate
+	 * @param {number} y - Screen Y coordinate
+	 * @param {BrowserWindow} excludeWin - Window to exclude from search
+	 * @returns {BrowserWindow|null}
+	 */
+	getWindowAtPoint (x, y, excludeWin) {
+		for (const win of WindowManager.list) {
+			if (win === excludeWin || win.isDestroyed() || win.isChallenge) {
+				continue;
+			};
+
+			const bounds = WindowManager.getBounds(win);
+			if (!bounds) {
+				continue;
+			};
+
+			if (x >= bounds.x && x <= bounds.x + bounds.width &&
+				y >= bounds.y && y <= bounds.y + bounds.height) {
+				return win;
+			};
+		};
+
+		return null;
+	};
+
+	/**
+	 * Transfers a tab from source window to target window
+	 * @param {BrowserWindow} sourceWin - Source window
+	 * @param {BrowserWindow} targetWin - Target window
+	 * @param {string} tabId - Tab ID to transfer
+	 * @param {Object} tabData - Tab data
+	 */
+	transferTabToWindow (sourceWin, targetWin, tabId, tabData) {
+		// Create tab in target window first
+		WindowManager.createTab(targetWin, tabData, { setActive: true });
+
+		// Remove tab from source window after target is ready
+		setTimeout(() => {
+			WindowManager.removeTab(sourceWin, tabId, true);
+			// Focus target window once after removal is done
+			if (targetWin && !targetWin.isDestroyed()) {
+				targetWin.focus();
+			};
+		}, 100);
+	};
+
+	/**
+	 * Creates a new window from a detached tab
+	 * @param {BrowserWindow} sourceWin - Source window
+	 * @param {string} tabId - Tab ID to detach
+	 * @param {Object} tabData - Tab data
+	 * @param {number} mouseX - Mouse X screen coordinate
+	 * @param {number} mouseY - Mouse Y screen coordinate
+	 */
+	createWindowFromTab (sourceWin, tabId, tabData, mouseX, mouseY) {
+		// Get source window size
+		const sourceBounds = WindowManager.getBounds(sourceWin);
+		const width = sourceBounds?.width;
+		const height = sourceBounds?.height;
+
+		// Create new window first, then remove tab from source (to avoid race conditions)
+		const newWin = WindowManager.createMain({
+			isChild: true,
+			initialBounds: { x: mouseX - 50, y: mouseY - 20, width, height },
+			initialTabData: tabData,
+		});
+
+		// Remove tab from source window after new window is created
+		setTimeout(() => {
+			WindowManager.removeTab(sourceWin, tabId, true);
+			// Focus new window once after removal is done
+			if (newWin && !newWin.isDestroyed()) {
+				newWin.focus();
+			};
+		}, 100);
+	};
+
 	notification (win, param) {
 		const { id, title, text, cmd, payload } = param || {};
 

--- a/electron/js/window.js
+++ b/electron/js/window.js
@@ -57,10 +57,16 @@ class WindowManager {
 			MenuManager.setWindow(win);
 
 			// Restore focus to active tab's webContents when window regains focus
-			const activeView = Util.getActiveView(win);
-			if (activeView && activeView.webContents && !activeView.webContents.isDestroyed()) {
-				activeView.webContents.focus();
-			};
+			// Use setImmediate to avoid focus race conditions when multiple windows exist
+			setImmediate(() => {
+				if (win.isDestroyed() || !win.isFocused()) {
+					return;
+				};
+				const activeView = Util.getActiveView(win);
+				if (activeView && activeView.webContents && !activeView.webContents.isDestroyed()) {
+					activeView.webContents.focus();
+				};
+			});
 		});
 
 		win.on('enter-full-screen', () => Util.send(win, 'enter-full-screen'));
@@ -79,7 +85,7 @@ class WindowManager {
 	};
 
 	createMain (options) {
-		const { isChild } = options;
+		const { isChild, initialBounds, initialTabData } = options;
 		const image = nativeImage.createFromPath(path.join(Util.imagePath(), 'icons', '512x512.png'));
 
 		let state = {};
@@ -125,6 +131,14 @@ class WindowManager {
 			} catch (e) {
 				console.error('[WindowManager] Failed to restore window state:', e);
 			};
+		} else if (initialBounds) {
+			// Use provided bounds for detached tab windows
+			param = Object.assign(param, {
+				x: initialBounds.x,
+				y: initialBounds.y,
+				width: initialBounds.width || DEFAULT_WIDTH,
+				height: initialBounds.height || DEFAULT_HEIGHT,
+			});
 		} else {
 			const { width, height } = this.getScreenSize();
 
@@ -160,32 +174,38 @@ class WindowManager {
 			};
 		});
 
-		// Try to restore saved tabs, or create a single tab if none saved
-		const savedState = this.loadTabs();
-		if (savedState && savedState.tabs && savedState.tabs.length > 0) {
-			const activeIndex = savedState.activeIndex || 0;
-
-			// Create all tabs from saved state with lazy loading for non-active tabs
-			for (let i = 0; i < savedState.tabs.length; i++) {
-				const tabData = savedState.tabs[i];
-				const isActiveTab = i === activeIndex;
-
-				// Defer loading for non-active tabs, don't auto-activate
-				this.createTab(win, tabData.data || {}, {
-					deferLoad: !isActiveTab,
-					setActive: false,
-				});
-			};
-
-			// Set the active tab (this will trigger loading for the active tab)
-			if (win.views && win.views[activeIndex]) {
-				this.setActiveTab(win, win.views[activeIndex].id);
-			};
-
-			// Clear saved tabs after restoration
-			this.clearSavedTabs();
+		// Handle tab creation
+		if (initialTabData) {
+			// Create window from detached tab with provided data
+			this.createTab(win, initialTabData, { setActive: true });
 		} else {
-			this.createTab(win, {}, { setActive: true });
+			// Try to restore saved tabs, or create a single tab if none saved
+			const savedState = this.loadTabs();
+			if (savedState && savedState.tabs && savedState.tabs.length > 0) {
+				const activeIndex = savedState.activeIndex || 0;
+
+				// Create all tabs from saved state with lazy loading for non-active tabs
+				for (let i = 0; i < savedState.tabs.length; i++) {
+					const tabData = savedState.tabs[i];
+					const isActiveTab = i === activeIndex;
+
+					// Defer loading for non-active tabs, don't auto-activate
+					this.createTab(win, tabData.data || {}, {
+						deferLoad: !isActiveTab,
+						setActive: false,
+					});
+				};
+
+				// Set the active tab (this will trigger loading for the active tab)
+				if (win.views && win.views[activeIndex]) {
+					this.setActiveTab(win, win.views[activeIndex].id);
+				};
+
+				// Clear saved tabs after restoration
+				this.clearSavedTabs();
+			} else {
+				this.createTab(win, {}, { setActive: true });
+			};
 		};
 
 		return win;


### PR DESCRIPTION
## Summary
- Dragging a tab outside window bounds creates a new window with that tab at cursor position
- Dragging a tab into another window transfers the tab to that window
- New window inherits size from source window
- Single-tab windows are protected (cannot detach the only tab)
- Fix window focus race condition that caused flickering when multiple windows exist

## Test plan
- [ ] Create window with 2+ tabs, drag one tab outside window bounds → new window appears
- [ ] Drag tab from one window into another → tab transfers
- [ ] Verify single-tab protection (cannot detach only tab)
- [ ] Open multiple windows, switch apps and back → no flickering

🤖 Generated with [Claude Code](https://claude.com/claude-code)