### PR TITLE
JS-7505, JS-8616: fix inline LaTeX caret position and corruption bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,3 +136,17 @@ Anytype is an Electron-based desktop application with TypeScript/React frontend 
 ## Web Mode Development
 
 Run in browser without Electron: `npm run start:web` (starts anytypeHelper + dev server). Use `ANYTYPE_USE_SIDE_SERVER=http://...` to skip helper start. See `src/ts/lib/web/README.md` for details.
+
+## Linear API Integration
+
+Use the `LINEAR_API_KEY` environment variable to fetch issue details from Linear.
+
+**Fetch issue by ID:**
+```bash
+curl -s -X POST "https://api.linear.app/graphql" \
+  --header "Content-Type: application/json" \
+  --header "Authorization: $(printenv LINEAR_API_KEY)" \
+  --data '{"query":"query{issue(id:\"JS-1234\"){title description state{name}priority labels{nodes{name}}comments{nodes{body createdAt}}}}"}' | jq .
+```
+
+**Important:** Use `$(printenv LINEAR_API_KEY)` instead of `$LINEAR_API_KEY` directly in curl commands to avoid shell expansion issues.

--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -826,9 +826,21 @@ const BlockText = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 		keyboard.setFocus(true);
 		onFocus?.(e);
 
-		// Workaround for focus issue and Latex rendering
+		// Calculate correct caret position accounting for rendered LaTeX elements
 		window.setTimeout(() => {
-			const range = getRange();
+			const selection = window.getSelection();
+			let range = getRange();
+
+			if (selection && selection.rangeCount > 0) {
+				const selRange = selection.getRangeAt(0);
+				const editable = editableRef.current?.getNode()?.find('.editable').get(0);
+
+				if (editable && editable.contains(selRange.startContainer)) {
+					const from = U.Common.getSelectionOffsetWithLatex(editable, selRange.startContainer, selRange.startOffset);
+					const to = selRange.collapsed ? from : U.Common.getSelectionOffsetWithLatex(editable, selRange.endContainer, selRange.endOffset);
+					range = { from, to };
+				};
+			};
 
 			setValue(block.getText());
 			focus.set(block.id, range);

--- a/src/ts/lib/mark.ts
+++ b/src/ts/lib/mark.ts
@@ -476,6 +476,16 @@ class Mark {
 		});
 
 		obj.find(this.getTag(I.MarkType.Emoji)).removeAttr('class').html(' ');
+
+		// Restore original LaTeX from rendered markuplatex elements
+		obj.find(this.getTag(I.MarkType.Latex)).each((i: number, item: any) => {
+			item = $(item);
+			const original = item.attr('data-latex');
+			if (original) {
+				item.replaceWith(U.String.fromHtmlSpecialChars(original).replace(/&#36;/g, '$'));
+			};
+		});
+
 		return obj;
 	};
 	


### PR DESCRIPTION
## Summary
Fixes two related inline LaTeX bugs:

**JS-7505: Wrong caret position after clicking blocks with inline LaTeX**
- When clicking on text blocks containing rendered LaTeX, the caret was incorrectly positioned because the selection offset was calculated based on DOM text content rather than the original text.

**JS-8616: Clicking on inline math randomly converts into basic text**
- When reading text from DOM with rendered LaTeX, the visible content (Greek letters, etc.) was returned instead of the original `$...$` source, causing LaTeX to be corrupted when saved.

## Changes
- Store original LaTeX expression in `data-latex` attribute when rendering
- Store original LaTeX length in `data-latex-length` attribute for offset calculation
- Add `getSelectionOffsetWithLatex` utility to calculate correct text offset accounting for LaTeX elements
- Update `cleanHtml` to restore original LaTeX from `markuplatex` elements
- Update `onFocusHandler` to use the new utility function

## Test plan
- [ ] Create a text block with inline LaTeX (e.g., `$\mathrm E \times \mathrm V$`)
- [ ] Click at various positions around the LaTeX expression
- [ ] Verify caret is positioned correctly at the clicked location
- [ ] Click directly on rendered LaTeX - caret should position at end of expression
- [ ] Click from external window directly onto inline LaTeX - verify it doesn't corrupt
- [ ] Verify undo (Ctrl+Z) works correctly after clicking on LaTeX

Fixes: 
- https://linear.app/anytype/issue/JS-7505
- https://linear.app/anytype/issue/JS-8616

🤖 Generated with [Claude Code](https://claude.ai/code)