### PR TITLE
Unregister IPC listeners on App unmount and before re-registering

### DIFF
--- a/src/ts/app.tsx
+++ b/src/ts/app.tsx
@@ -145,6 +145,8 @@ const App: FC = () => {
 	};
 
 	const registerIpcEvents = () => {
+		unregisterIpcEvents();
+
 		Renderer.on('init', onInit);
 		Renderer.on('route', (e: any, route: string) => onRoute(route));
 		Renderer.on('popup', onPopup);
@@ -194,6 +196,31 @@ const App: FC = () => {
 		Renderer.on('power-event', (e: any, state: string) => {
 			C.AppSetDeviceState(state == 'suspend' ? I.AppDeviceState.Background : I.AppDeviceState.Foreground);
 		});
+	};
+	
+	const unregisterIpcEvents = () => {
+		Renderer.remove('init');
+		Renderer.remove('route');
+		Renderer.remove('popup');
+		Renderer.remove('update-not-available');
+		Renderer.remove('update-downloaded');
+		Renderer.remove('update-error');
+		Renderer.remove('download-progress');
+		Renderer.remove('spellcheck');
+		Renderer.remove('pin-set');
+		Renderer.remove('pin-remove');
+		Renderer.remove('enter-full-screen');
+		Renderer.remove('leave-full-screen');
+		Renderer.remove('config');
+		Renderer.remove('logout');
+		Renderer.remove('data-path');
+		Renderer.remove('will-close-window');
+		Renderer.remove('shutdownStart');
+		Renderer.remove('zoom');
+		Renderer.remove('native-theme');
+		Renderer.remove('pin-check');
+		Renderer.remove('reload');
+		Renderer.remove('power-event');
 	};
 
 	const onInit = (e: any, data: any) => {
@@ -479,7 +506,13 @@ const App: FC = () => {
 		});
 	};
 
-	useEffect(() => init(), []);
+	useEffect(() => {
+		init();
+
+		return () => {
+			unregisterIpcEvents();
+		};
+	}, []);
 
 	const sidebarLeftRef = useCallback(ref => S.Common.refSet('sidebarLeft', ref), []);
 	


### PR DESCRIPTION
### Motivation
- Prevent duplicated or stale IPC handlers and potential memory leaks when the app re-initializes or unmounts.
- Ensure a single source of truth for IPC lifecycle to avoid unexpected behavior from lingering listeners.
- Make app teardown deterministic by explicitly removing all renderer IPC subscriptions.

### Description
- Added a centralized `unregisterIpcEvents` helper in `src/ts/app.tsx` that calls `Renderer.remove` for all handled channels.
- Call `unregisterIpcEvents()` at the start of `registerIpcEvents` to clear prior listeners before re-registering handlers.
- Invoke `unregisterIpcEvents()` from the cleanup function returned by `useEffect` so listeners are removed on component unmount.

### Testing
- No automated tests were run for this change.
- The change was applied and committed to `src/ts/app.tsx` without running a test suite.
- Manual build/run verification was not requested or performed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697dd6a96d8c8321b64922aae5e05708)