### PR TITLE
Replace jQuery window resize bindings with useResizeObserver hook

### DIFF
--- a/src/ts/component/block/cover.tsx
+++ b/src/ts/component/block/cover.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, useRef, useState, useEffect } from 'react';
 import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { Icon, DragHorizontal, Cover, Loader, Label } from 'Component';
-import { I, C, S, U, J, focus, translate, keyboard, analytics } from 'Lib';
+import { I, C, S, U, J, H, focus, translate, keyboard, analytics } from 'Lib';
 import ControlButtons from 'Component/page/elements/head/controlButtons';
 
 const BlockCover = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref) => {
@@ -33,11 +33,6 @@ const BlockCover = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref
 
 		if (nodeRef.current) {
 			U.Common.renderLinks($(nodeRef.current));
-		};
-		$(window).off('resize.cover').on('resize.cover', () => resize());
-
-		return () => {
-			$(window).off('resize.cover');
 		};
 	}, []);
 	
@@ -194,7 +189,11 @@ const BlockCover = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref
 			el.src = S.Common.imageUrl(coverId, I.ImageSize.Large);
 		};
 	};
-	
+
+	const onResize = H.useDebounceCallback(resize, 50);
+
+	H.useResizeObserver({ ref: nodeRef, onResize });
+
 	const onDragStart = (e: any) => {
 		e.preventDefault();
 		

--- a/src/ts/component/block/dataview.tsx
+++ b/src/ts/component/block/dataview.tsx
@@ -6,7 +6,7 @@ import { arrayMove } from '@dnd-kit/sortable';
 import { observer } from 'mobx-react';
 import { set } from 'mobx';
 import { LayoutPlug } from 'Component';
-import { I, C, S, U, J, analytics, Dataview, keyboard, Onboarding, Relation, focus, translate, Action, Storage } from 'Lib';
+import { I, C, S, U, J, H, analytics, Dataview, keyboard, Onboarding, Relation, focus, translate, Action, Storage } from 'Lib';
 
 import Controls from './dataview/controls';
 import Selection from './dataview/selection';
@@ -133,7 +133,7 @@ const BlockDataview = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 	};
 
 	const unbind = () => {
-		const events = [ 'resize', 'sidebarResize', 'updateDataviewData', 'setDataviewSource', 'selectionEnd', 'selectionClear', 'selectionSet' ];
+		const events = [ 'updateDataviewData', 'setDataviewSource', 'selectionEnd', 'selectionClear', 'selectionSet' ];
 		const ns = block.id + U.Common.getEventNamespace(isPopup);
 
 		$(window).off(events.map(it => `${it}.${ns}`).join(' '));
@@ -145,7 +145,6 @@ const BlockDataview = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 
 		unbind();
 
-		win.on(`resize.${ns} sidebarResize.${ns}`, () => resize());
 		win.on(`updateDataviewData.${ns}`, () => loadData(getView().id, 0, true));
 		win.on(`setDataviewSource.${ns}`, () => onSourceSelect(`#block-head-${block.id} #value`, { offsetY: 36 }));
 		win.on(`selectionEnd.${ns} selectionClear.${ns} selectionSet.${ns}`, () => onSelectEnd());
@@ -1462,6 +1461,10 @@ const BlockDataview = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 			};
 		});
 	};
+
+	const onResize = H.useDebounceCallback(resize, 50);
+
+	H.useResizeObserver({ ref: nodeRef, onResize });
 
 	const getPageContainer = () => {
 		return U.Common.getCellContainer(isPopup ? 'popup' : 'page');

--- a/src/ts/component/block/embed.tsx
+++ b/src/ts/component/block/embed.tsx
@@ -7,7 +7,7 @@ import Prism from 'prismjs';
 import { instance as viz } from '@viz-js/viz';
 import { observer } from 'mobx-react';
 import { Icon, Label, Editable, Dimmer, Select, Error, MediaMermaid, MediaExcalidraw } from 'Component';
-import { I, C, S, U, J, keyboard, focus, Action, translate } from 'Lib';
+import { I, C, S, U, J, H, keyboard, focus, Action, translate } from 'Lib';
 
 const katex = require('katex');
 const pako = require('pako');
@@ -108,15 +108,13 @@ const BlockEmbed = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref
 			container.on(`scroll.${block.id}`, () => onScroll());
 		};
 
-		win.on(`resize.${block.id}`, () => resize());
-
 		node.on('resizeMove', (e: any, oe: any) => onResizeMove(oe, true));
 		node.on('edit', e => onEdit(e));
 	};
 
 	const unbind = () => {
 		const container = U.Common.getScrollContainer(isPopup);
-		const events = [ 'mousedown', 'mouseup', 'online', 'offline', 'resize' ];
+		const events = [ 'mousedown', 'mouseup', 'online', 'offline' ];
 
 		$(window).off(events.map(it => `${it}.${block.id}`).join(' '));
 		container.off(`scroll.${block.id}`);
@@ -748,6 +746,10 @@ const BlockEmbed = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref
 	const resize = () => {
 		onScroll();
 	};
+
+	const onResize = H.useDebounceCallback(resize, 50);
+
+	H.useResizeObserver({ ref: nodeRef, onResize });
 
 	let select = null;
 	let source = null;

--- a/src/ts/component/block/table.tsx
+++ b/src/ts/component/block/table.tsx
@@ -4,7 +4,7 @@ import raf from 'raf';
 import { observer } from 'mobx-react';
 import { throttle } from 'lodash';
 import { Icon } from 'Component';
-import { I, C, S, U, J, keyboard, focus, Mark, Action, translate } from 'Lib';
+import { I, C, S, U, J, H, keyboard, focus, Mark, Action, translate } from 'Lib';
 import Row from './table/row';
 
 const PADDING = 46;
@@ -51,17 +51,13 @@ const BlockTable = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref
 
 		$(scrollRef.current).scrollLeft(scrollX.current);
 	});
-	
+
 	const unbind = () => {
-		$(window).off(`resize.${block.id}`);
 		$(nodeRef.current).off('resizeInit resizeMove');
 	};
 
 	const rebind = () => {
-		const win = $(window);
-
 		unbind();
-		win.on(`resize.${block.id}`, () => raf(() => resize()));
 		$(nodeRef.current).on('resizeInit resizeMove', e => resize());
 	};
 
@@ -1385,6 +1381,10 @@ const BlockTable = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref
 			};
 		});
 	};
+
+	const onResize = H.useDebounceCallback(resize, 50);
+
+	H.useResizeObserver({ ref: nodeRef, onResize });
 
 	const buttons = [
 		{ id: 'v', className: 'vertical', onClick: onPlusV },

--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -4,7 +4,7 @@ import raf from 'raf';
 import { observer } from 'mobx-react';
 import { throttle } from 'lodash';
 import { Icon, Deleted, DropTarget, EditorControls } from 'Component';
-import { I, C, S, U, J, Key, Preview, Mark, keyboard, Storage, Action, translate, analytics, Renderer, focus } from 'Lib';
+import { I, C, S, U, J, H, Key, Preview, Mark, keyboard, Storage, Action, translate, analytics, Renderer, focus } from 'Lib';
 import PageHeadEditor from 'Component/page/elements/head/editor';
 import Children from 'Component/page/elements/children';
 import TableOfContents from 'Component/page/elements/tableOfContents';
@@ -226,7 +226,7 @@ const EditorPage = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 	const unbind = () => {
 		const ns = `editor${U.Common.getEventNamespace(isPopup)}`;
 		const container = U.Common.getScrollContainer(isPopup);
-		const events = [ 'keydown', 'mousemove', 'paste', 'resize', 'focus' ];
+		const events = [ 'keydown', 'mousemove', 'paste', 'focus' ];
 		const selection = S.Common.getRef('selectionProvider');
 
 		$(window).off(events.map(it => `${it}.${ns}`).join(' '));
@@ -271,7 +271,6 @@ const EditorPage = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 			};
 		});
 
-		win.on(`resize.${ns} sidebarResize.${ns}`, () => resizePage());
 		container.on(`scroll.${ns}`, () => onScroll());
 
 		Renderer.on(`commandEditor`, (e: any, cmd: string, arg: any) => onCommand(cmd, arg));
@@ -2390,6 +2389,10 @@ const EditorPage = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 			callBack?.();
 		});
 	};
+
+	const onResize = H.useDebounceCallback(() => resizePage(), 50);
+
+	H.useResizeObserver({ ref: nodeRef, onResize });
 
 	const focusSet = (id: string, from: number, to: number, scroll: boolean) => {
 		window.setTimeout(() => {

--- a/src/ts/component/menu/index.tsx
+++ b/src/ts/component/menu/index.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react';
 import $ from 'jquery';
 import raf from 'raf';
 import { Dimmer, Icon, Title } from 'Component';
-import { I, S, U, J, keyboard, analytics, Storage } from 'Lib';
+import { I, S, U, J, H, keyboard, analytics, Storage } from 'Lib';
 
 import MenuHelp from './help';
 import MenuOnboarding from './onboarding';
@@ -317,18 +317,16 @@ const Menu = observer(forwardRef<RefProps, I.Menu>((props, ref) => {
 		const container = U.Common.getScrollContainer(keyboard.isPopup());
 
 		unbind();
-		$(window).on(`resize.${id} sidebarResize.${id}`, () => position());
 		container.on(`scroll.${id}`, () => {
 			raf.cancel(framePosition.current);
 			framePosition.current = raf(() => position());
 		});
 	};
-	
+
 	const unbind = () => {
 		const id = getId();
 		const container = U.Common.getScrollContainer(keyboard.isPopup());
 
-		$(window).off(`resize.${id} sidebarResize.${id}`);
 		container.off(`scroll.${id}`);
 	};
 	
@@ -607,6 +605,10 @@ const Menu = observer(forwardRef<RefProps, I.Menu>((props, ref) => {
 			};
 		});
 	};
+
+	const onResize = H.useDebounceCallback(position, 50);
+
+	H.useResizeObserver({ ref: nodeRef, onResize });
 
 	const close = (callBack?: () => void) => {
 		S.Menu.close(props.id, () => {

--- a/src/ts/component/page/elements/head/controlButtons.tsx
+++ b/src/ts/component/page/elements/head/controlButtons.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, useEffect, useRef, useState, useImperativeHandle } f
 import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { Icon } from 'Component';
-import { I, S, U, J, translate, analytics, focus, Renderer, Relation, Action, Onboarding, keyboard } from 'Lib';
+import { I, S, U, J, H, translate, analytics, focus, Renderer, Relation, Action, Onboarding, keyboard } from 'Lib';
 
 interface Props {
 	rootId: string;
@@ -38,15 +38,6 @@ const ControlButtons = observer(forwardRef<ControlButtonsRef, Props>((props, ref
 	const check = U.Data.checkDetails(rootId);
 	const nodeRef = useRef(null);
 	const timeout = useRef(0);
-
-	const rebind = () => {
-		unbind();
-		$(window).on('resize.controlButtons', () => resize());
-	};
-
-	const unbind = () => {
-		$(window).off('resize.controlButtons');
-	};
 
 	const onIconHandler = (e: any) => {
 		e.preventDefault();
@@ -194,17 +185,15 @@ const ControlButtons = observer(forwardRef<ControlButtonsRef, Props>((props, ref
 		$(nodeRef.current).toggleClass('small', ww <= 900);
 	};
 
+	const onResize = H.useDebounceCallback(resize, 50);
+
+	H.useResizeObserver({ ref: nodeRef, onResize });
+
 	const { allowedIcon, allowedLayout, allowedCover, allowedDescription } = getAllowedButtons();
 
 	useEffect(() => {
 		if (allowedDescription) {
 			Onboarding.start('objectDescriptionButton', keyboard.isPopup());
-		};
-
-		rebind();
-
-		return () => {
-			unbind();
 		};
 	}, []);
 

--- a/src/ts/component/page/elements/tableOfContents.tsx
+++ b/src/ts/component/page/elements/tableOfContents.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, useImperativeHandle, useRef, useEffect, useMemo, use
 import $ from 'jquery';
 import raf from 'raf';
 import { observer } from 'mobx-react';
-import { I, S, U, J, keyboard } from 'Lib';
+import { I, S, U, J, H, keyboard } from 'Lib';
 
 interface TableOfContentsRefProps {
 	setBlock: (v: string) => void;
@@ -23,15 +23,6 @@ const TableOfContents = observer(forwardRef<TableOfContentsRefProps, I.BlockComp
 	const ns = `tableOfContents${U.Common.getEventNamespace(isPopup)}`;
 	const rightSidebar = S.Common.getRightSidebarState(isPopup);
 	const isOpen = rightSidebar.page == 'object/tableOfContents';
-
-	const rebind = () => {
-		unbind();
-		$(window).on(`resize.${ns} sidebarResize.${ns}`, () => resize());
-	};
-
-	const unbind = () => {
-		$(window).off(`resize.${ns} sidebarResize.${ns}`);
-	};
 
 	const setBlock = (id: string) => {
 		const node = $(nodeRef.current);
@@ -144,8 +135,11 @@ const TableOfContents = observer(forwardRef<TableOfContentsRefProps, I.BlockComp
 		});
 	};
 
+	const onResize = H.useDebounceCallback(resize, 50);
+
+	H.useResizeObserver({ ref: nodeRef, onResize });
+
 	useEffect(() => {
-		rebind();
 		resize();
 
 		if (isPopup) {
@@ -153,7 +147,6 @@ const TableOfContents = observer(forwardRef<TableOfContentsRefProps, I.BlockComp
 		};
 
 		return () => {
-			unbind();
 			raf.cancel(frame.current);
 		};
 	}, []);

--- a/src/ts/component/page/index.tsx
+++ b/src/ts/component/page/index.tsx
@@ -3,7 +3,7 @@ import $ from 'jquery';
 import raf from 'raf';
 import { observer } from 'mobx-react';
 import { Label, Frame, SidebarRight } from 'Component';
-import { I, S, U, J, Onboarding, Storage, analytics, keyboard, sidebar, Preview, Highlight, translate } from 'Lib';
+import { I, S, U, J, H, Onboarding, Storage, analytics, keyboard, sidebar, Preview, Highlight, translate } from 'Lib';
 
 import PageAuthSelect from './auth/select';
 import PageAuthLogin from './auth/login';
@@ -69,6 +69,7 @@ const PageIndex = observer(forwardRef<{}, I.PageComponent>((props, ref) => {
 	const { account } = S.Auth;
 	const { isFullScreen, singleTab, vaultIsMinimal } = S.Common;
 	const ns = U.Common.getEventNamespace(isPopup);
+	const pageFlexRef = useRef(null);
 	const childRef = useRef(null);
 	const match = keyboard.getMatch(isPopup);
 	const { page, action, id } = match.params;
@@ -125,27 +126,10 @@ const PageIndex = observer(forwardRef<{}, I.PageComponent>((props, ref) => {
 			keyboard.setBodyClass();
 		};
 
-		rebind();
 		Onboarding.start(U.String.toCamelCase([ page, action ].join('-')), isPopup);
 		Highlight.showAll();
 
 		analytics.event('page', { params: match.params });
-	};
-
-	const rebind = () => {
-		const { history } = U.Router;
-		const ns = U.Common.getEventNamespace(isPopup);
-		const key = String(history?.location?.key || '');
-
-		unbind();
-		$(window).on(`resize.page${ns}${key}`, () => resize());
-	};
-
-	const unbind = () => {
-		const { history } = U.Router;
-		const key = String(history?.location?.key || '');
-
-		$(window).off(`resize.page${ns}${key}`);
 	};
 
 	const resize = () => {
@@ -153,13 +137,15 @@ const PageIndex = observer(forwardRef<{}, I.PageComponent>((props, ref) => {
 		sidebar.resizePage(isPopup, null, null, false);
 	};
 
+	const onResize = H.useDebounceCallback(resize, 50);
+
+	H.useResizeObserver({ ref: pageFlexRef, onResize });
+
 	useEffect(() => {
 		init();
 		resize();
 
 		return () => {
-			unbind();
-
 			if (!isPopup) {
 				S.Popup.closeAll();
 			};
@@ -181,8 +167,9 @@ const PageIndex = observer(forwardRef<{}, I.PageComponent>((props, ref) => {
 	};
 
 	return (
-		<div 
-			id="pageFlex" 
+		<div
+			ref={pageFlexRef}
+			id="pageFlex"
 			className={[ 'pageFlex', U.Common.getContainerClassName(isPopup) ].join(' ')}
 		>
 			{!isPopup ? <div id="sidebarDummyLeft" className="sidebarDummy" /> : ''}

--- a/src/ts/component/popup/index.tsx
+++ b/src/ts/component/popup/index.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, useEffect, useRef } from 'react';
 import $ from 'jquery';
 import raf from 'raf';
-import { I, S, U, analytics, Storage, Preview, translate, sidebar, Renderer } from 'Lib';
+import { I, S, U, H, analytics, Storage, Preview, translate, sidebar, Renderer } from 'Lib';
 import { Dimmer } from 'Component';
 import { observer } from 'mobx-react';
 import DimmerWithGraph from './dimmerWithGraph';
@@ -74,18 +74,6 @@ const Popup = observer(forwardRef<{}, I.Popup>((props, ref) => {
 		};
 	};
 
-	const rebind = () => {
-		unbind();
-
-		if (!param.preventResize) {
-			$(window).on(`resize.popup${id}`, () => position());
-		};
-	};
-
-	const unbind = () => {
-		$(window).off(`resize.popup${id}`);
-	};
-
 	const animate = () => {
 		window.setTimeout(() => {
 			if (isAnimatingRef.current) {
@@ -124,6 +112,14 @@ const Popup = observer(forwardRef<{}, I.Popup>((props, ref) => {
 		});
 	};
 
+	const onResize = H.useDebounceCallback(() => {
+		if (!param.preventResize) {
+			position();
+		};
+	}, 50);
+
+	H.useResizeObserver({ ref: nodeRef, onResize });
+
 	const getContext = () => ({
 		getChildRef: () => childRef.current,
 		close,
@@ -136,15 +132,10 @@ const Popup = observer(forwardRef<{}, I.Popup>((props, ref) => {
 			position();
 		};
 
-		rebind();
 		animate();
 		onOpen?.(getContext());
 
 		analytics.event('popup', { params: { id } });
-
-		return () => {
-			unbind();
-		};
 	}, []);
 
 	const { className } = param;

--- a/src/ts/component/sidebar/preview.tsx
+++ b/src/ts/component/sidebar/preview.tsx
@@ -3,7 +3,7 @@ import $ from 'jquery';
 import raf from 'raf';
 import { observer } from 'mobx-react';
 import { Title, Label, Checkbox, Icon, IconObject, EmptyNodes, LayoutPlug } from 'Component';
-import { I, S, U, J, Relation, translate, sidebar } from 'Lib';
+import { I, S, U, J, H, Relation, translate, sidebar } from 'Lib';
 
 interface RefProps {
 	update: (object: any) => void;
@@ -110,22 +110,9 @@ const SidebarLayoutPreview = observer(forwardRef<RefProps, I.SidebarPageComponen
 		};
 	};
 
-	const unbind = () => {
-		$(window).off(`resize.${ns} sidebarResize.${ns}`);
-	};
+	const onResize = H.useDebounceCallback(resize, 50);
 
-	const rebind = () => {
-		unbind();
-		$(window).on(`resize.${ns} sidebarResize.${ns}`, () => resize());
-	};
-
-	useEffect(() => {
-		rebind();
-
-		return () => {
-			unbind();
-		};
-	}, []);
+	H.useResizeObserver({ ref: nodeRef, onResize });
 
 	useEffect(() => {
 		resize();	

--- a/src/ts/component/util/deleted.tsx
+++ b/src/ts/component/util/deleted.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, useRef, useEffect, useLayoutEffect } from 'react';
 import $ from 'jquery';
 import { Icon, Label, Button } from 'Component';
-import { I, S, U, translate, Action } from 'Lib';
+import { I, S, U, H, translate, Action } from 'Lib';
 
 interface Props {
 	className?: string;
@@ -40,14 +40,6 @@ const Deleted = forwardRef<HTMLDivElement, Props>(({
 	};
 	const textButton = isPopup ? translate('commonClose') : translate('utilDeletedBackToDashboard');
 
-	const unbind = () => {
-		$(window).off('resize.deleted');
-	};
-
-	const rebind = () => {
-		$(window).on('resize.deleted', () => resize());
-	};
-
 	const resize = () => {
 		const node = $(nodeRef.current);
 		const container = isPopup ? $('#popupPage-innerWrap') : $(window);
@@ -55,11 +47,12 @@ const Deleted = forwardRef<HTMLDivElement, Props>(({
 		node.css({ height: container.height() });
 	};
 
-	useEffect(() => {
-		rebind();
-		resize();
+	const onResize = H.useDebounceCallback(resize, 50);
 
-		return () => unbind();
+	H.useResizeObserver({ ref: nodeRef, onResize });
+
+	useEffect(() => {
+		resize();
 	});
 
 	useLayoutEffect(() => resize());

--- a/src/ts/component/util/frame.tsx
+++ b/src/ts/component/util/frame.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, useRef, useEffect, useLayoutEffect, useImperativeHandle } from 'react';
 import $ from 'jquery';
 import raf from 'raf';
-import { U } from 'Lib';
+import { U, H } from 'Lib';
 
 interface Props {
 	children?: React.ReactNode;
@@ -22,34 +22,26 @@ const Frame = forwardRef<FrameRefProps, Props>(({
 	const nodeRef = useRef<HTMLDivElement | null>(null);
 	const cn = [ 'frame', className ];
 
-	const unbind = () => {
-		$(window).off('resize.frame');
-	};
-
-	const rebind = () => {
-		unbind();
-		$(window).on('resize.frame', () => resize());
-	};
-
 	const resize = () => {
 		raf(() => {
 			if (!nodeRef.current) {
 				return;
 			};
-			
+
 			const node = $(nodeRef.current);
-			node.css({ 
+			node.css({
 				marginTop: -node.outerHeight() / 2,
 				marginLeft: -node.outerWidth() / 2
 			});
 		});
 	};
 
-	useEffect(() => {
-		rebind();
-		resize();
+	const onResize = H.useDebounceCallback(resize, 50);
 
-		return () => unbind();
+	H.useResizeObserver({ ref: nodeRef, onResize });
+
+	useEffect(() => {
+		resize();
 	});
 
 	useLayoutEffect(() => resize());


### PR DESCRIPTION
## Summary
- Migrated 13 components from jQuery `$(window).on('resize')` bindings to the `useResizeObserver` hook
- Uses `useDebounceCallback` with 50ms debounce for consistent behavior
- Removes legacy rebind/unbind patterns in favor of native React hook lifecycle
- Net reduction of ~59 lines of code

## Components Updated
- `block/cover.tsx`
- `block/dataview.tsx`
- `block/embed.tsx`
- `block/table.tsx`
- `editor/page.tsx`
- `menu/index.tsx`
- `page/elements/head/controlButtons.tsx`
- `page/elements/tableOfContents.tsx`
- `page/index.tsx`
- `popup/index.tsx`
- `sidebar/preview.tsx`
- `util/deleted.tsx`
- `util/frame.tsx`

## Test plan
- [ ] Verify resize behavior works correctly on all affected components
- [ ] Test window resizing in popups and menus
- [ ] Test sidebar resize interactions
- [ ] Verify cover image repositioning still works during resize
- [ ] Test table and dataview resize behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)