### PR TITLE
Refactor color palette variables from Figma design system

### DIFF
--- a/src/scss/_vars.scss
+++ b/src/scss/_vars.scss
@@ -12,10 +12,10 @@
 
 	/* Shape */
 
-	--color-shape-primary: #e3e3e3;
+	--color-shape-primary: var(--color-light-grey);
 	--color-shape-secondary: #ebebeb;
 	--color-shape-secondary-inversion: #292929;
-	--color-shape-tertiary: #f2f2f2;
+	--color-shape-tertiary: var(--color-very-light-grey);
 
 	--color-shape-highlight-dark: rgba(0, 0, 0, 0.11);
 	--color-shape-highlight-medium: rgba(0, 0, 0, 0.05);
@@ -40,16 +40,6 @@
 	--color-bg-primary-90: rgba(255,255,255,0.9);
 	--color-bg-primary-inversion: #171717;
 	--color-bg-loader: rgba(255,255,255,0.7);
-	--color-bg-yellow: #fcf8d6;
-	--color-bg-orange: #fff2d7;
-	--color-bg-red: #fee7e0;
-	--color-bg-pink: #fbdff2;
-	--color-bg-purple: #f3e7f8;
-	--color-bg-blue: #e4e8fc;
-	--color-bg-ice: #ddf1fc;
-	--color-bg-teal: #d9f6f4;
-	--color-bg-lime: #e5f8d6;
-
 	/* System */
 
 	--color-system-accent-125: #105aef;
@@ -61,15 +51,55 @@
 
 	/* Color */
 
+	--color-very-light-yellow: #fcf8d6;
+	--color-light-yellow: #f4eb91;
 	--color-yellow: #ecd91b;
+	--color-dark-yellow: #afa100;
+
+	--color-very-light-orange: #fff2d7;
+	--color-light-orange: #fcdc9c;
 	--color-orange: #ffb522;
+	--color-dark-orange: #c38400;
+
+	--color-very-light-red: #fee7e0;
+	--color-light-red: #fcd1c3;
 	--color-red: #f55522;
+	--color-dark-red: #e9410b;
+
+	--color-very-light-pink: #fbdff2;
+	--color-light-pink: #f8c2e5;
 	--color-pink: #e51ca0;
+	--color-dark-pink: #d20d8f;
+
+	--color-very-light-purple: #f3e7f8;
+	--color-light-purple: #e8d0f1;
 	--color-purple: #ab50cc;
+	--color-dark-purple: #9f43c1;
+
+	--color-very-light-blue: #e4e8fc;
+	--color-light-blue: #cbd2fa;
 	--color-blue: #3e58eb;
+	--color-dark-blue: #3e58eb;
+
+	--color-very-light-ice: #ddf1fc;
+	--color-light-ice: #b2dff9;
 	--color-ice: #2aa7ee;
+	--color-dark-ice: #188dcf;
+
+	--color-very-light-teal: #d9f6f4;
+	--color-light-teal: #a9ebe6;
 	--color-teal: #0fc8ba;
+	--color-dark-teal: #0ba599;
+
+	--color-very-light-lime: #e5f8d6;
+	--color-light-lime: #c5efa3;
 	--color-lime: #5dd400;
+	--color-dark-lime: #4dae00;
+
+	--color-very-light-grey: #f2f2f2;
+	--color-light-grey: #e3e3e3;
+	--color-grey: #949494;
+	--color-dark-grey: #949494;
 
 	/* Tag */
 
@@ -79,21 +109,10 @@
 	--color-tag-red: #e2400c;
 	--color-tag-pink: #ca1b8e;
 	--color-tag-purple: #9e30c4;
-	--color-tag-blue: #3e58eb;
+	--color-tag-blue: var(--color-blue);
 	--color-tag-ice: #1c8bca;
 	--color-tag-teal: #0caaa3;
 	--color-tag-lime: #64b90f;
-
-	--color-bg-tag-grey: #e3e3e3;
-	--color-bg-tag-yellow: #f4eb91;
-	--color-bg-tag-orange: #fcdc9c;
-	--color-bg-tag-red: #fcd1c3;
-	--color-bg-tag-pink: #f8c2e5;
-	--color-bg-tag-purple: #e8d0f1;
-	--color-bg-tag-blue: #cbd2fa;
-	--color-bg-tag-ice: #b2dff9;
-	--color-bg-tag-teal: #a9ebe6;
-	--color-bg-tag-lime: #c5efa3;
 
 	/* Font */
 

--- a/src/scss/block/chat/message.scss
+++ b/src/scss/block/chat/message.scss
@@ -207,7 +207,7 @@
 
 	&.highlight {
 		.bubbleInner {
-			.bubble { background-color: var(--color-bg-ice) !important;}
+			.bubble { background-color: var(--color-very-light-ice) !important;}
 		}
 	}
 

--- a/src/scss/color.scss
+++ b/src/scss/color.scss
@@ -12,28 +12,28 @@
 .textColor-lime { color: var(--color-lime) !important; }
 
 .bgColor-grey { background: var(--color-shape-tertiary) !important; }
-.bgColor-yellow { background: var(--color-bg-yellow) !important; }
-.bgColor-orange { background: var(--color-bg-orange) !important; }
-.bgColor-red { background: var(--color-bg-red) !important; }
-.bgColor-pink { background: var(--color-bg-pink) !important; }
-.bgColor-purple { background: var(--color-bg-purple) !important; }
-.bgColor-blue { background: var(--color-bg-blue) !important; }
-.bgColor-ice { background: var(--color-bg-ice) !important; }
-.bgColor-teal { background: var(--color-bg-teal) !important; }
-.bgColor-lime { background: var(--color-bg-lime) !important; }
+.bgColor-yellow { background: var(--color-very-light-yellow) !important; }
+.bgColor-orange { background: var(--color-very-light-orange) !important; }
+.bgColor-red { background: var(--color-very-light-red) !important; }
+.bgColor-pink { background: var(--color-very-light-pink) !important; }
+.bgColor-purple { background: var(--color-very-light-purple) !important; }
+.bgColor-blue { background: var(--color-very-light-blue) !important; }
+.bgColor-ice { background: var(--color-very-light-ice) !important; }
+.bgColor-teal { background: var(--color-very-light-teal) !important; }
+.bgColor-lime { background: var(--color-very-light-lime) !important; }
 
 .isMultiSelect.archive { color: var(--color-text-secondary); background: var(--color-shape-tertiary); }
 .isMultiSelect.tagColor-default { color: var(--color-text-primary) !important; background: var(--color-bg-primary) !important; box-shadow: 0px 0px 0px 1px var(--color-shape-secondary) inset; }
-.isMultiSelect.tagColor-grey { color: var(--color-tag-grey) !important; background: var(--color-bg-tag-grey) !important; }
-.isMultiSelect.tagColor-yellow { color: var(--color-tag-yellow) !important; background: var(--color-bg-tag-yellow) !important; }
-.isMultiSelect.tagColor-orange { color: var(--color-tag-orange) !important; background: var(--color-bg-tag-orange) !important; }
-.isMultiSelect.tagColor-red { color: var(--color-tag-red) !important; background: var(--color-bg-tag-red) !important; }
-.isMultiSelect.tagColor-pink { color: var(--color-tag-pink) !important; background: var(--color-bg-tag-pink) !important; }
-.isMultiSelect.tagColor-purple { color: var(--color-tag-purple) !important; background: var(--color-bg-tag-purple) !important; }
-.isMultiSelect.tagColor-blue { color: var(--color-tag-blue) !important; background: var(--color-bg-tag-blue) !important; }
-.isMultiSelect.tagColor-ice { color: var(--color-tag-ice) !important; background: var(--color-bg-tag-ice) !important; }
-.isMultiSelect.tagColor-teal { color: var(--color-tag-teal) !important; background: var(--color-bg-tag-teal) !important; }
-.isMultiSelect.tagColor-lime { color: var(--color-tag-lime) !important; background: var(--color-bg-tag-lime) !important; }
+.isMultiSelect.tagColor-grey { color: var(--color-tag-grey) !important; background: var(--color-light-grey) !important; }
+.isMultiSelect.tagColor-yellow { color: var(--color-tag-yellow) !important; background: var(--color-light-yellow) !important; }
+.isMultiSelect.tagColor-orange { color: var(--color-tag-orange) !important; background: var(--color-light-orange) !important; }
+.isMultiSelect.tagColor-red { color: var(--color-tag-red) !important; background: var(--color-light-red) !important; }
+.isMultiSelect.tagColor-pink { color: var(--color-tag-pink) !important; background: var(--color-light-pink) !important; }
+.isMultiSelect.tagColor-purple { color: var(--color-tag-purple) !important; background: var(--color-light-purple) !important; }
+.isMultiSelect.tagColor-blue { color: var(--color-tag-blue) !important; background: var(--color-light-blue) !important; }
+.isMultiSelect.tagColor-ice { color: var(--color-tag-ice) !important; background: var(--color-light-ice) !important; }
+.isMultiSelect.tagColor-teal { color: var(--color-tag-teal) !important; background: var(--color-light-teal) !important; }
+.isMultiSelect.tagColor-lime { color: var(--color-tag-lime) !important; background: var(--color-light-lime) !important; }
 
 .isSelect.tagColor-default { color: var(--color-text-primary) !important; }
 .isSelect.tagColor-black { color: var(--color-text-primary) !important; }

--- a/src/scss/component/banner.scss
+++ b/src/scss/component/banner.scss
@@ -18,7 +18,7 @@
 		width: 20px !important; height: 20px !important;
 	}
 }
-.banner.green { background-color: var(--color-bg-lime); }
+.banner.green { background-color: var(--color-very-light-lime); }
 
 .banner.sidebarUpdateBanner { width: 288px; left: 12px; }
 .banner.sidebarUpdateBanner {

--- a/src/scss/component/upsell.scss
+++ b/src/scss/component/upsell.scss
@@ -4,7 +4,7 @@
     display: flex; justify-content: space-between; align-items: center; background: var(--color-system-selection);
     padding: 16px; border-radius: 8px; gap: 0px 8px;
 }
-.upsellBanner.isRed { background: linear-gradient(90deg, var(--color-bg-red) 0%, #fff6f3 100%)}
+.upsellBanner.isRed { background: linear-gradient(90deg, var(--color-very-light-red) 0%, #fff6f3 100%)}
 
 .upsellBanner {
     .label { margin-bottom: 0px; display: inline; }

--- a/src/scss/menu/syncStatus.scss
+++ b/src/scss/menu/syncStatus.scss
@@ -35,13 +35,13 @@
 				.icon.p2p { background: url('~img/icon/sync/p2p/connected.svg'); }
 			}
 			.iconWrapper.connectedSlow {
-				.iconBg { background: var(--color-bg-orange); }
+				.iconBg { background: var(--color-very-light-orange); }
 				.label { color: var(--color-orange); }
 				.icon.network,
 				.icon.self { background: url('~img/icon/sync/upgrade.svg'); }
 			}
 			.iconWrapper.error {
-				.iconBg { background: var(--color-bg-red); }
+				.iconBg { background: var(--color-very-light-red); }
 				.label { color: var(--color-red); }
 				.icon.network,
 				.icon.self { background: url('~img/icon/sync/error.svg'); }

--- a/src/scss/page/main/settings.scss
+++ b/src/scss/page/main/settings.scss
@@ -465,8 +465,8 @@
                 .bar {
                     .fill { border-radius: 8px; }
                     .fill.current { background-color: var(--color-orange); min-width: 32px; }
-                    .fill.other { background-color: var(--color-bg-tag-orange); }
-                    .fill.empty { background-color: var(--color-bg-tag-grey); }
+                    .fill.other { background-color: var(--color-light-orange); }
+                    .fill.empty { background-color: var(--color-light-grey); }
                 }
             }
 
@@ -483,8 +483,8 @@
 
                     .item:before { content: ''; width: 24px; height: 4px; border-radius: 100px; }
                     .item.current::before { background: var(--color-orange); }
-                    .item.other::before { background: var(--color-bg-tag-orange); }
-                    .item.free::before { background: var(--color-bg-tag-grey); }
+                    .item.other::before { background: var(--color-light-orange); }
+                    .item.free::before { background: var(--color-light-grey); }
                 }
             }
 
@@ -492,7 +492,7 @@
                 .progressBar {
                     .bar {
                         .fill.current { background: var(--color-red); }
-                        .fill.other { background: var(--color-bg-tag-red); }
+                        .fill.other { background: var(--color-light-red); }
                         .fill.empty { display: none; }
                     }
                 }

--- a/src/scss/popup/shortcut.scss
+++ b/src/scss/popup/shortcut.scss
@@ -39,16 +39,16 @@
 				.item.canEdit:not(.isEditing) {
 					&:hover, &.hover {
 						.symbols {
-							.label { background-color: var(--color-bg-blue); }
+							.label { background-color: var(--color-very-light-blue); }
 						}
 
 						.label.grey { color: var(--color-blue); }
 					}
 				}
-				.item.hasError { background: var(--color-bg-red); }
+				.item.hasError { background: var(--color-very-light-red); }
 				.item.hasError {
 					.symbols {
-						.label { background-color: var(--color-bg-tag-red); }
+						.label { background-color: var(--color-light-red); }
 					}
 				}
 

--- a/src/scss/theme/dark/common.scss
+++ b/src/scss/theme/dark/common.scss
@@ -35,15 +35,15 @@ html.themeDark {
 	--color-bg-secondary: #191919;
 	--color-bg-loader: rgba(0,0,0,0.7);
 	--color-bg-grey: #232323;
-	--color-bg-yellow: #242317;
-	--color-bg-orange: #262117;
-	--color-bg-red: #2d1d18;
-	--color-bg-pink: #2d1926;
-	--color-bg-purple: #281c2c;
-	--color-bg-blue: #1e2131;
-	--color-bg-ice: #17252d;
-	--color-bg-teal: #162827;
-	--color-bg-lime: #202919;
+	--color-very-light-yellow: #242317;
+	--color-very-light-orange: #262117;
+	--color-very-light-red: #2d1d18;
+	--color-very-light-pink: #2d1926;
+	--color-very-light-purple: #281c2c;
+	--color-very-light-blue: #1e2131;
+	--color-very-light-ice: #17252d;
+	--color-very-light-teal: #162827;
+	--color-very-light-lime: #202919;
 
 	/* Tag */
 
@@ -58,16 +58,16 @@ html.themeDark {
 	--color-tag-teal: var(--color-teal);
 	--color-tag-lime: var(--color-lime);
 
-	--color-bg-tag-grey: #3c3c3c;
-	--color-bg-tag-yellow: #55500d;
-	--color-bg-tag-orange: #5f430a;
-	--color-bg-tag-red: #74321e;
-	--color-bg-tag-pink: #712055;
-	--color-bg-tag-purple: #542663;
-	--color-bg-tag-blue: #20295c;
-	--color-bg-tag-ice: #19465f;
-	--color-bg-tag-teal: #16534e;
-	--color-bg-tag-lime: #36551d;
+	--color-light-grey: #3c3c3c;
+	--color-light-yellow: #55500d;
+	--color-light-orange: #5f430a;
+	--color-light-red: #74321e;
+	--color-light-pink: #712055;
+	--color-light-purple: #542663;
+	--color-light-blue: #20295c;
+	--color-light-ice: #19465f;
+	--color-light-teal: #16534e;
+	--color-light-lime: #36551d;
 
 	/* System */
 


### PR DESCRIPTION
## Summary
- Add full color variants (very-light, light, pure, dark) for all 10 colors based on Figma design system
- Remove duplicate `--color-bg-tag-*` variables, use `--color-light-*` directly
- Remove duplicate `--color-bg-{color}` variables, use `--color-very-light-*` directly
- Update dark theme to override new variable names

## Test plan
- [ ] Verify light theme colors render correctly
- [ ] Verify dark theme colors render correctly
- [ ] Check tag backgrounds in multi-select fields
- [ ] Check background colors on blocks and banners

🤖 Generated with [Claude Code](https://claude.com/claude-code)