### PR TITLE
Feature/JS-8375: Skip survey popup in extension mode, add clearSurvey method

### DIFF
--- a/src/ts/lib/action.ts
+++ b/src/ts/lib/action.ts
@@ -1107,7 +1107,7 @@ class Action {
 
 	finalizeMembership (product: any, route: string, callBack?: () => void) {
 		const showSurveyPopup = () => {
-			if (Survey.isComplete(I.SurveyType.Cta)) {
+			if (window.isExtension || Survey.isComplete(I.SurveyType.Cta)) {
 				S.Popup.close('membershipFinalization');
 				callBack?.();
 				return;

--- a/src/ts/lib/action.ts
+++ b/src/ts/lib/action.ts
@@ -1107,7 +1107,7 @@ class Action {
 
 	finalizeMembership (product: any, route: string, callBack?: () => void) {
 		const showSurveyPopup = () => {
-			if (window.isExtension || Survey.isComplete(I.SurveyType.Cta)) {
+			if (Survey.isComplete(I.SurveyType.Cta)) {
 				S.Popup.close('membershipFinalization');
 				callBack?.();
 				return;

--- a/src/ts/lib/storage.ts
+++ b/src/ts/lib/storage.ts
@@ -582,6 +582,16 @@ class Storage {
 	};
 
 	/**
+	 * Clears the survey state for a survey type.
+	 * @param {I.SurveyType} type - The survey type.
+	 */
+	clearSurvey (type: I.SurveyType) {
+		const obj = this.get('survey', this.isLocal('survey')) || {};
+		delete obj[type];
+		this.set('survey', obj, this.isLocal('survey'));
+	};
+
+	/**
 	 * Checks if an array is valid (non-empty).
 	 * @param {any} a - The array to check.
 	 * @returns {boolean} True if valid.

--- a/src/ts/lib/survey.ts
+++ b/src/ts/lib/survey.ts
@@ -47,6 +47,10 @@ class Survey {
 	 * @param {I.SurveyType} type - The survey type.
 	 */
 	onConfirm (type: I.SurveyType) {
+		if (window.isExtension) {
+			return;
+		};
+
 		const { account } = S.Auth;
 		const t = I.SurveyType[type].toLowerCase();
 		const param: any = {};
@@ -72,6 +76,10 @@ class Survey {
 	 * @param {I.SurveyType} type - The survey type.
 	 */
 	onSkip (type: I.SurveyType) {
+		if (window.isExtension) {
+			return;
+		};
+
 		const param: any = {};
 
 		switch (type) {


### PR DESCRIPTION
Prevent silent Survey.onConfirm call when membership finalization runs in extension mode, where confirm popups auto-fire without user consent. Add Storage.clearSurvey() to allow resetting survey state.

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
