### PR TITLE
Feature/JS-8859: Add short filter condition labels for dataview filter pills

### DIFF
--- a/src/json/text.json
+++ b/src/json/text.json
@@ -2030,6 +2030,14 @@
 	"filterConditionInArray": "Contains any",
 	"filterConditionNotInArray": "Contains none",
 
+	"filterConditionShortNot": "Not",
+	"filterConditionShortAll": "All",
+	"filterConditionShortNotEmpty": "isn't empty",
+	"filterConditionShortAfter": "After",
+	"filterConditionShortBefore": "Before",
+	"filterConditionShortFrom": "From",
+	"filterConditionShortUntil": "Until",
+
 	"filterOperatorOr": "Or",
 	"filterOperatorAnd": "And",
 

--- a/src/ts/component/block/dataview/filters/item.tsx
+++ b/src/ts/component/block/dataview/filters/item.tsx
@@ -147,6 +147,10 @@ const DataviewFilterItem = observer(forwardRef<{}, Props>((props, ref) => {
 		cn.push('isActive');
 	};
 
+	const hasShort = conditionOption.short !== undefined;
+	const displayName = (withValue && hasShort && conditionOption.colon) ? `${name}:` : name;
+	const conditionText = (withValue && hasShort) ? conditionOption.short : conditionOption.name;
+
 	return (
 		<div
 			id={`item-${id}`}
@@ -158,12 +162,12 @@ const DataviewFilterItem = observer(forwardRef<{}, Props>((props, ref) => {
 			<Icon className={`filterIcon ${getFilterRelationIcon(relation.format)}`} />
 
 			<div className="content">
-				<Label className="name" text={name} />
+				<Label className="name" text={displayName} />
 
 				{withValue ? (
 					<>
-						<Label className="condition" text={conditionOption.name} />
-						<div className="value">{v}</div>
+						{conditionText ? <Label className="condition" text={conditionText} /> : null}
+						{v !== null ? <div className="value">{v}</div> : null}
 					</>
 				) : ''}
 			</div>

--- a/src/ts/lib/relation.ts
+++ b/src/ts/lib/relation.ts
@@ -75,7 +75,7 @@ class Relation {
 	/**
 	 * Returns available filter conditions for a relation type.
 	 * @param {I.RelationType} type - The relation type.
-	 * @returns {Array<{id: I.FilterCondition, name: string}>} The filter conditions.
+	 * @returns {Array<{id: I.FilterCondition, name: string, short?: string, colon?: boolean}>} The filter conditions.
 	 */
 	public filterConditionsByType (type: I.RelationType, value?: any): { id: I.FilterCondition, name: string, short?: string, colon?: boolean }[] {
 		value = this.formatValue({ format: type }, value, false);
@@ -256,7 +256,7 @@ class Relation {
 
 	/**
 	 * Returns filter conditions for dictionary relations.
-	 * @returns {Array<{id: I.FilterCondition, name: string}>} The filter conditions.
+	 * @returns {Array<{id: I.FilterCondition, name: string, short?: string, colon?: boolean}>} The filter conditions.
 	 */
 	public filterConditionsDictionary () {
 		return [

--- a/src/ts/lib/relation.ts
+++ b/src/ts/lib/relation.ts
@@ -77,10 +77,10 @@ class Relation {
 	 * @param {I.RelationType} type - The relation type.
 	 * @returns {Array<{id: I.FilterCondition, name: string}>} The filter conditions.
 	 */
-	public filterConditionsByType (type: I.RelationType, value?: any): { id: I.FilterCondition, name: string}[] {
+	public filterConditionsByType (type: I.RelationType, value?: any): { id: I.FilterCondition, name: string, short?: string, colon?: boolean }[] {
 		value = this.formatValue({ format: type }, value, false);
 
-		let ret: { id: I.FilterCondition, name: string }[] = [];
+		let ret: { id: I.FilterCondition, name: string, short?: string, colon?: boolean }[] = [];
 
 		switch (type) {
 			case I.RelationType.ShortText:
@@ -89,12 +89,12 @@ class Relation {
 			case I.RelationType.Email:
 			case I.RelationType.Phone: {
 				ret = [
-					{ id: I.FilterCondition.Like,		 name: translate('filterConditionLike') },
-					{ id: I.FilterCondition.NotLike,	 name: translate('filterConditionNotLike') },
+					{ id: I.FilterCondition.Like,		 name: translate('filterConditionLike'), short: '', colon: true },
+					{ id: I.FilterCondition.NotLike,	 name: translate('filterConditionNotLike'), short: translate('filterConditionShortNot'), colon: true },
 					{ id: I.FilterCondition.Equal,		 name: translate('filterConditionEqual') },
 					{ id: I.FilterCondition.NotEqual,	 name: translate('filterConditionNotEqual') },
 					{ id: I.FilterCondition.Empty,		 name: translate('filterConditionEmpty') },
-					{ id: I.FilterCondition.NotEmpty,	 name: translate('filterConditionNotEmpty') },
+					{ id: I.FilterCondition.NotEmpty,	 name: translate('filterConditionNotEmpty'), short: translate('filterConditionShortNotEmpty') },
 				];
 				break;
 			};
@@ -105,13 +105,12 @@ class Relation {
 			case I.RelationType.MultiSelect: {
 				const length = value.length;
 
-
 				ret = [
-					{ id: I.FilterCondition.In,			 name: length > 1 ? translate('filterConditionInArray') : translate('filterConditionLike') },
-					length > 1 ? { id: I.FilterCondition.AllIn,		 name: translate('filterConditionAllIn') } : null,
-					{ id: I.FilterCondition.NotIn,		 name: translate('filterConditionNotInArray') },
+					{ id: I.FilterCondition.In,			 name: length > 1 ? translate('filterConditionInArray') : translate('filterConditionLike'), short: '', colon: true },
+					length > 1 ? { id: I.FilterCondition.AllIn, name: translate('filterConditionAllIn'), short: translate('filterConditionShortAll'), colon: true } : null,
+					{ id: I.FilterCondition.NotIn,		 name: translate('filterConditionNotInArray'), short: translate('filterConditionShortNot'), colon: true },
 					{ id: I.FilterCondition.Empty,		 name: translate('filterConditionEmpty') },
-					{ id: I.FilterCondition.NotEmpty,	 name: translate('filterConditionNotEmpty') },
+					{ id: I.FilterCondition.NotEmpty,	 name: translate('filterConditionNotEmpty'), short: translate('filterConditionShortNotEmpty') },
 				];
 				break;
 			};
@@ -125,21 +124,21 @@ class Relation {
 					{ id: I.FilterCondition.GreaterOrEqual,	 name: '≥' },
 					{ id: I.FilterCondition.LessOrEqual,	 name: '≤' },
 					{ id: I.FilterCondition.Empty,		 name: translate('filterConditionEmpty') },
-					{ id: I.FilterCondition.NotEmpty,	 name: translate('filterConditionNotEmpty') },
+					{ id: I.FilterCondition.NotEmpty,	 name: translate('filterConditionNotEmpty'), short: translate('filterConditionShortNotEmpty') },
 				];
 				break;
 			};
 
 			case I.RelationType.Date: {
 				ret = [
-					{ id: I.FilterCondition.Equal,			 name: translate('filterConditionEqual') },
-					{ id: I.FilterCondition.Greater,		 name: translate('filterConditionGreaterDate') },
-					{ id: I.FilterCondition.Less,			 name: translate('filterConditionLessDate') },
-					{ id: I.FilterCondition.GreaterOrEqual,	 name: translate('filterConditionGreaterOrEqualDate') },
-					{ id: I.FilterCondition.LessOrEqual,	 name: translate('filterConditionLessOrEqualDate') },
-					{ id: I.FilterCondition.In,				 name: translate('filterConditionInDate') },
+					{ id: I.FilterCondition.Equal,			 name: translate('filterConditionEqual'), short: '', colon: true },
+					{ id: I.FilterCondition.Greater,		 name: translate('filterConditionGreaterDate'), short: translate('filterConditionShortAfter'), colon: true },
+					{ id: I.FilterCondition.Less,			 name: translate('filterConditionLessDate'), short: translate('filterConditionShortBefore'), colon: true },
+					{ id: I.FilterCondition.GreaterOrEqual,	 name: translate('filterConditionGreaterOrEqualDate'), short: translate('filterConditionShortFrom'), colon: true },
+					{ id: I.FilterCondition.LessOrEqual,	 name: translate('filterConditionLessOrEqualDate'), short: translate('filterConditionShortUntil'), colon: true },
+					{ id: I.FilterCondition.In,				 name: translate('filterConditionInDate'), short: '', colon: true },
 					{ id: I.FilterCondition.Empty,			 name: translate('filterConditionEmpty') },
-					{ id: I.FilterCondition.NotEmpty,		 name: translate('filterConditionNotEmpty') },
+					{ id: I.FilterCondition.NotEmpty,		 name: translate('filterConditionNotEmpty'), short: translate('filterConditionShortNotEmpty') },
 				];
 				break;
 			};
@@ -147,8 +146,8 @@ class Relation {
 			case I.RelationType.Checkbox:
 			default: {
 				ret = [
-					{ id: I.FilterCondition.Equal,			 name: translate('filterConditionEqual') },
-					{ id: I.FilterCondition.NotEqual,		 name: translate('filterConditionNotEqual') },
+					{ id: I.FilterCondition.Equal,			 name: translate('filterConditionEqual'), short: '', colon: true },
+					{ id: I.FilterCondition.NotEqual,		 name: translate('filterConditionNotEqual'), short: translate('filterConditionShortNot'), colon: true },
 				];
 				break;
 			};
@@ -261,10 +260,10 @@ class Relation {
 	 */
 	public filterConditionsDictionary () {
 		return [
-			{ id: I.FilterCondition.Equal,		 name: translate('filterConditionEqual') },
-			{ id: I.FilterCondition.NotEqual,	 name: translate('filterConditionNotEqual') },
+			{ id: I.FilterCondition.Equal,		 name: translate('filterConditionEqual'), short: '', colon: true },
+			{ id: I.FilterCondition.NotEqual,	 name: translate('filterConditionNotEqual'), short: translate('filterConditionShortNot'), colon: true },
 			{ id: I.FilterCondition.Empty,		 name: translate('filterConditionEmpty') },
-			{ id: I.FilterCondition.NotEmpty,	 name: translate('filterConditionNotEmpty') },
+			{ id: I.FilterCondition.NotEmpty,	 name: translate('filterConditionNotEmpty'), short: translate('filterConditionShortNotEmpty') },
 		];
 	};
 


### PR DESCRIPTION
Add short locale strings and colon separator pattern to make filter pills more compact (e.g. "Tag: Design" instead of "Tag Contains any Design").

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
