### PR TITLE
Feature/JS-8861: Menu relation icons

### DIFF
--- a/src/scss/block/dataview.scss
+++ b/src/scss/block/dataview.scss
@@ -234,7 +234,7 @@
 					.icon.sortArrow { width: 20px; height: 20px; margin: 0px; background-image: url('~img/icon/dataview/filters/sort.svg'); }
 					.icon.sortArrow.c1 { transform: rotateZ(180deg); }
 					.icon.advanced { width: 20px; height: 20px; background-image: url('~img/icon/dataview/filters/advanced0.svg'); }
-					.iconObject { flex-shrink: 0; }
+					.icon.relation { width: 20px; height: 20px; flex-shrink: 0; }
 					.icon.arrow { width: 8px; height: 8px; background-image: url('~img/arrow/filterValue0.svg'); }
 
 					&.isActive { color: var(--color-system-accent-100); background-color: var(--color-system-selection); }
@@ -243,7 +243,7 @@
 						.name { font-weight: 500; }
 
 						.icon.advanced { background-image: url('~img/icon/dataview/filters/advanced1.svg'); }
-						.iconRelation { background-color: var(--color-system-accent-100); }
+						.icon.relation { background-color: var(--color-system-accent-100); }
 						.icon.arrow { background-image: url('~img/arrow/filterValue1.svg'); }
 					}
 					&:hover, &.hover { background-color: var(--color-shape-highlight-medium); border-color: transparent; }

--- a/src/scss/block/dataview/view/grid.scss
+++ b/src/scss/block/dataview/view/grid.scss
@@ -31,7 +31,7 @@
 
 			.cellContent { height: 36px !important; overflow: visible !important; }
 			.flex { padding: 9px 14px; gap: 0px 6px; align-items: center; height: 100%; }
-			.iconObject { width: 20px; height: 20px; margin: 0px; vertical-align: top; flex-shrink: 0; display: none; }
+			.icon.relation { width: 20px; height: 20px; margin: 0px; vertical-align: top; flex-shrink: 0; display: none; }
 
 			.name { 
 				display: inline-block; line-height: 20px; height: 20px; vertical-align: top; width: 100%; 
@@ -49,7 +49,7 @@
 		.cellHead.small { text-align: center; }
 		.cellHead.small {
 			.flex { display: inline-block; }
-			.iconObject { display: block; }
+			.icon.relation { display: block; }
 			.name { display: none; }
 		}
 

--- a/src/scss/component/icon.scss
+++ b/src/scss/component/icon.scss
@@ -32,6 +32,31 @@
 .icon.widget-bin { background-image: url('~img/icon/widget/system/bin.svg'); }
 .icon.widget-all { background-image: url('~img/icon/widget/system/all.svg'); }
 
+.icon.relation.c-longText,
+.icon.relation.c-shortText,
+.icon.relation.c-number,
+.icon.relation.c-date,
+.icon.relation.c-select,
+.icon.relation.c-object,
+.icon.relation.c-file,
+.icon.relation.c-checkbox,
+.icon.relation.c-url,
+.icon.relation.c-email,
+.icon.relation.c-phone { mask-size: contain; mask-repeat: no-repeat; mask-position: center; background: var(--color-icon); }
+
+.icon.relation.c-longText { mask-image: url('~img/icon/relation/default/longText.svg'); }
+.icon.relation.c-shortText { mask-image: url('~img/icon/relation/default/shortText.svg'); }
+.icon.relation.c-number { mask-image: url('~img/icon/relation/default/number.svg'); }
+.icon.relation.c-date { mask-image: url('~img/icon/relation/default/date.svg'); }
+.icon.relation.c-select.isMultiSelect { mask-image: url('~img/icon/relation/default/multiSelect.svg'); }
+.icon.relation.c-select.isSelect { mask-image: url('~img/icon/relation/default/select.svg'); }
+.icon.relation.c-object { mask-image: url('~img/icon/relation/default/object.svg'); }
+.icon.relation.c-file { mask-image: url('~img/icon/relation/default/file.svg'); }
+.icon.relation.c-checkbox { mask-image: url('~img/icon/relation/default/checkbox.svg'); }
+.icon.relation.c-url { mask-image: url('~img/icon/relation/default/url.svg'); }
+.icon.relation.c-email { mask-image: url('~img/icon/relation/default/email.svg'); }
+.icon.relation.c-phone { mask-image: url('~img/icon/relation/default/phone.svg'); }
+
 .icon.layout.c-page { background-image: url('~img/icon/object/page.svg'); }
 .icon.layout.c-human { background-image: url('~img/icon/object/human.svg'); }
 .icon.layout.c-task { background-image: url('~img/icon/object/task.svg'); }

--- a/src/scss/menu/dataview/filter.scss
+++ b/src/scss/menu/dataview/filter.scss
@@ -20,7 +20,7 @@
 				&.advanced { background-image: url('~img/icon/dataview/filters/advanced0.svg'); }
 			}
 
-			.iconObject { flex-shrink: 0; }
+			.icon.relation { width: 20px; height: 20px; flex-shrink: 0; }
 
 			.filterContent { display: flex; gap: 6px; align-items: center; @include text-overflow-nw; }
 			.value { @include text-overflow-nw; }
@@ -41,7 +41,7 @@
 				.icon.filterIcon {
 					&.advanced { background-image: url('~img/icon/dataview/filters/advanced1.svg'); }
 				}
-				.iconRelation { background-color: var(--color-system-accent-100); }
+				.icon.relation { background-color: var(--color-system-accent-100); }
 
 				&:hover,
 				&.hover {

--- a/src/ts/component/block/dataview/filters/item.tsx
+++ b/src/ts/component/block/dataview/filters/item.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, MouseEvent } from 'react';
 import { observer } from 'mobx-react';
 import { I, S, U, Relation, translate } from 'Lib';
-import { Icon, IconObject, Label } from 'Component';
+import { Icon, Label } from 'Component';
 
 interface FilterWithRelation extends I.Filter {
 	relation: any;
@@ -141,7 +141,7 @@ const DataviewFilterItem = observer(forwardRef<{}, Props>((props, ref) => {
 			onClick={onClick}
 			onContextMenu={onContextMenu}
 		>
-			<IconObject size={20} object={{ relationFormat: relation.format, layout: I.ObjectLayout.Relation }} />
+			<Icon className={`relation ${Relation.className(relation.format)}`} />
 
 			<div className="content">
 				<Label className="name" text={displayName} />

--- a/src/ts/component/block/dataview/filters/rule.tsx
+++ b/src/ts/component/block/dataview/filters/rule.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, useRef, useEffect } from 'react';
 import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { I, S, U, Relation, translate, Preview } from 'Lib';
-import { Icon, Select, Input, IconObject, Label, Tag } from 'Component';
+import { Icon, Select, Input, Label, Tag } from 'Component';
 import ItemObject from 'Component/cell/item/object';
 
 interface Props {
@@ -446,7 +446,7 @@ const DataviewFilterRule = observer(forwardRef<{}, Props>((props, ref) => {
 
 			<div className="inner">
 				<div className="relationSelect select round c36" onClick={onRelationClick}>
-					{relation ? <IconObject size={20} object={{ relationFormat: relation.format, layout: I.ObjectLayout.Relation }} /> : ''}
+					{relation ? <Icon className={`relation ${Relation.className(relation.format)}`} /> : ''}
 					<Label text={relation?.name || ''} />
 					<Icon className="arrow" />
 				</div>

--- a/src/ts/component/block/dataview/view/grid/head/cell.tsx
+++ b/src/ts/component/block/dataview/view/grid/head/cell.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { I, S, J, U, keyboard, Relation, Dataview } from 'Lib';
-import { IconObject, ObjectName } from 'Component';
+import { Icon, ObjectName } from 'Component';
 
 interface Props extends I.ViewComponent, I.ViewRelation {
 	rootId: string;
@@ -123,7 +123,7 @@ const HeadCell = observer(forwardRef<{}, Props>((props, ref) => {
 					{...attributes}
 					{...listeners}
 				>
-					<IconObject object={relation} tooltipParam={{ text: relation.name }} />
+					<Icon className={`relation ${Relation.className(relation.format)}`} />
 					<ObjectName object={relation} />
 				</div>
 

--- a/src/ts/component/menu/block/link/settings.tsx
+++ b/src/ts/component/menu/block/link/settings.tsx
@@ -168,12 +168,12 @@ const MenuBlockLinkSettings = observer(forwardRef<I.MenuRef, I.Menu>((props, ref
 		const itemIconSize = canIconSize ? { id: 'iconSize', name: translate('commonIcon'), caption: icon.name, arrow: true } : null;
 		const itemIconSwitch = canIconSwitch ? { id: 'iconSwitch', name: translate('commonIcon'), withSwitch: true, switchValue: (icon.id != I.LinkIconSize.None) } : null;
 		const itemCover = canCover ? { id: 'cover', name: translate('menuBlockLinkSettingsCover'), withSwitch: true, switchValue: hasRelationKey('cover') } : null;
-		const itemName = { id: 'name', name: translate('menuBlockLinkSettingsName'), object: { relationFormat: I.RelationType.ShortText, layout: I.ObjectLayout.Relation } };
+		const itemName = { id: 'name', name: translate('menuBlockLinkSettingsName'), icon: `relation ${Relation.className(I.RelationType.ShortText)}` };
 		const itemDescription = canDescription ? {
-			id: 'description', name: translate('menuBlockLinkSettingsDescription'), object: { relationFormat: I.RelationType.LongText, layout: I.ObjectLayout.Relation },
+			id: 'description', name: translate('menuBlockLinkSettingsDescription'), icon: `relation ${Relation.className(I.RelationType.LongText)}`,
 			caption: description.name, arrow: true
 		} : null;
-		const itemType = { id: 'type', name: translate('commonObjectType'), object: { relationFormat: I.RelationType.Object, layout: I.ObjectLayout.Relation }, withSwitch: true, switchValue: hasRelationKey('type') };
+		const itemType = { id: 'type', name: translate('commonObjectType'), icon: `relation ${Relation.className(I.RelationType.Object)}`, withSwitch: true, switchValue: hasRelationKey('type') };
 
 		let sections: any[] = [
 			{ children: [ itemStyle, itemIconSize, itemIconSwitch, itemCover ] },

--- a/src/ts/component/menu/block/mention.tsx
+++ b/src/ts/component/menu/block/mention.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, useRef, useState, useImperativeHandle, useEffect } f
 import { observer } from 'mobx-react';
 import $ from 'jquery';
 import { MenuItemVertical, Loader, ObjectName, ObjectType, EmptySearch } from 'Component';
-import { I, S, U, J, C, keyboard, Mark, translate, analytics } from 'Lib';
+import { I, S, U, J, C, keyboard, Mark, Relation, translate, analytics } from 'Lib';
 import { AutoSizer, CellMeasurer, InfiniteLoader, List, CellMeasurerCache } from 'react-virtualized';
 
 const HEIGHT_ITEM = 28;
@@ -72,7 +72,7 @@ const MenuBlockMention = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => 
 				name: translate('commonDates'), 
 				children: [
 					...dates,
-					{ id: 'selectDate', object: { relationFormat: I.RelationType.Date, layout: I.ObjectLayout.Relation }, name: translate(`placeholderCell${I.RelationType.Date}`) },
+					{ id: 'selectDate', icon: `relation ${Relation.className(I.RelationType.Date)}`, name: translate(`placeholderCell${I.RelationType.Date}`) },
 					{ isDiv: true },
 				]
 			});

--- a/src/ts/component/menu/block/relation/edit.tsx
+++ b/src/ts/component/menu/block/relation/edit.tsx
@@ -433,7 +433,7 @@ const MenuBlockRelationEdit = observer(forwardRef<I.MenuRef, I.Menu>((props, ref
 				<div className="name">{translate('menuBlockRelationEditRelationType')}</div>
 				<MenuItemVertical 
 					id="relation-type" 
-					object={format === null ? undefined : { relationFormat: format, layout: I.ObjectLayout.Relation }}
+					icon={format === null ? undefined : `relation ${Relation.className(format)}`}
 					name={format === null ? translate('menuBlockRelationEditSelectRelationType') : translate(`relationName${format}`)}
 					onMouseEnter={onRelationType} 
 					onClick={onRelationType} 

--- a/src/ts/component/menu/dataview/filter/list.tsx
+++ b/src/ts/component/menu/dataview/filter/list.tsx
@@ -3,7 +3,7 @@ import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { AutoSizer, CellMeasurer, InfiniteLoader, List, CellMeasurerCache } from 'react-virtualized';
 import { I, C, S, U, Relation, keyboard, translate, analytics, Dataview } from 'Lib';
-import { MenuItemVertical, Icon, IconObject, Label } from 'Component';
+import { MenuItemVertical, Icon, Label } from 'Component';
 
 const HEIGHT_ITEM = 28;
 const HEIGHT_FILTER = 32;
@@ -392,7 +392,7 @@ const MenuFilterList = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 							</>
 						) : (
 							<>
-								<IconObject size={20} object={{ relationFormat: item.relation.format, layout: I.ObjectLayout.Relation }} />
+								<Icon className={`relation ${Relation.className(item.relation.format)}`} />
 								<div className="filterContent">
 									<Label className="relationName" text={item.relation.name} />
 									{Relation.isFilterActive(item) ? (

--- a/src/ts/component/menu/dataview/relation/edit.tsx
+++ b/src/ts/component/menu/dataview/relation/edit.tsx
@@ -149,7 +149,7 @@ const MenuDataviewRelationEdit = observer(forwardRef<I.MenuRef, I.Menu>((props, 
 				{
 					children: [
 						canAlign ? { id: 'align', icon: U.Data.alignHIcon(viewRelation?.align), name: translate('commonAlign'), arrow: true } : null,
-						canCalculate ? { id: 'calculate', object: { relationFormat: I.RelationType.Number, layout: I.ObjectLayout.Relation }, name: translate('commonCalculate'), arrow: true } : null,
+						canCalculate ? { id: 'calculate', icon: `relation ${Relation.className(I.RelationType.Number)}`, name: translate('commonCalculate'), arrow: true } : null,
 					]
 				},
 			]);
@@ -716,7 +716,7 @@ const MenuDataviewRelationEdit = observer(forwardRef<I.MenuRef, I.Menu>((props, 
 				<div className="name">{translate('menuDataviewRelationEditRelationType')}</div>
 				<MenuItemVertical 
 					id="relation-type" 
-					object={format === null ? undefined : { relationFormat: format, layout: I.ObjectLayout.Relation }}
+					icon={format === null ? undefined : `relation ${Relation.className(format)}`}
 					name={format === null ? translate('menuDataviewRelationEditSelectRelationType') : translate(`relationName${format}`)}
 					onMouseEnter={onRelationType} 
 					readonly={isReadonly}

--- a/src/ts/component/menu/dataview/relation/list.tsx
+++ b/src/ts/component/menu/dataview/relation/list.tsx
@@ -6,8 +6,8 @@ import { DndContext, closestCenter, useSensors, useSensor, PointerSensor, Keyboa
 import { SortableContext, verticalListSortingStrategy, sortableKeyboardCoordinates, arrayMove, useSortable } from '@dnd-kit/sortable';
 import { restrictToVerticalAxis, restrictToFirstScrollableAncestor } from '@dnd-kit/modifiers';
 import { CSS } from '@dnd-kit/utilities';
-import { I, C, S, J, U, keyboard, Dataview, translate, analytics } from 'Lib';
-import { Icon, IconObject, Switch } from 'Component';
+import { I, C, S, J, U, keyboard, Relation, Dataview, translate, analytics } from 'Lib';
+import { Icon, Switch } from 'Component';
 
 const HEIGHT = 28;
 const LIMIT = 20;
@@ -237,7 +237,7 @@ const MenuRelationList = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => 
 			>
 				{!isReadonly ? <Icon className="dnd" /> : ''}
 				<span className="clickable" onClick={e => onClick(e, item)}>
-					<IconObject object={item.relation} />
+					<Icon className={`relation ${Relation.className(item.relation.format)}`} />
 					<div className="name">{item.relation.name}</div>
 				</span>
 				{canHide ? (

--- a/src/ts/component/menu/dataview/sort.tsx
+++ b/src/ts/component/menu/dataview/sort.tsx
@@ -6,7 +6,7 @@ import { DndContext, closestCenter, useSensors, useSensor, PointerSensor, Keyboa
 import { SortableContext, verticalListSortingStrategy, sortableKeyboardCoordinates, arrayMove, useSortable } from '@dnd-kit/sortable';
 import { restrictToVerticalAxis, restrictToFirstScrollableAncestor } from '@dnd-kit/modifiers';
 import { CSS } from '@dnd-kit/utilities';
-import { Icon, IconObject } from 'Component';
+import { Icon } from 'Component';
 import { I, C, S, U, J, Relation, keyboard, analytics, translate } from 'Lib';
 
 const HEIGHT = 48;
@@ -356,7 +356,7 @@ const MenuSort = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 				<div className="sides">
 					<div className="side left">
 						<div className="chip relation" onClick={e => onSortNameClick(e, item)}>
-							<IconObject size={20} iconSize={20} object={{ relationFormat: relation.format, layout: I.ObjectLayout.Relation }} />
+							<Icon className={`relation ${Relation.className(relation.format)}`} />
 							<div className="name">{relation.name}</div>
 						</div>
 						<div className="chip type" onClick={e => onTypeChange(e, item)}>

--- a/src/ts/component/menu/relation/suggest.tsx
+++ b/src/ts/component/menu/relation/suggest.tsx
@@ -103,7 +103,7 @@ const MenuRelationSuggest = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) 
 	const getSections = () => {
 		const reg = new RegExp(U.String.regexEscape(data.filter), 'gi');
 		const systemKeys = Relation.systemKeys();
-		const items = U.Common.objectCopy(itemsRef.current || []).map(it => ({ ...it, object: it }));
+		const items = U.Common.objectCopy(itemsRef.current || []).map(it => ({ ...it, icon: `relation ${Relation.className(it.format)}` }));
 		const library = items.filter(it => !systemKeys.includes(it.relationKey));
 		const system = items.filter(it => systemKeys.includes(it.relationKey));
 		const types = data.types || [];

--- a/src/ts/component/sidebar/page/settings/library.tsx
+++ b/src/ts/component/sidebar/page/settings/library.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useRef, useState, useEffect } from 'react';
 import { observer } from 'mobx-react';
-import { analytics, I, J, keyboard, S, Storage, translate, U, sidebar } from 'Lib';
+import { analytics, I, J, keyboard, Relation, S, Storage, translate, U, sidebar } from 'Lib';
 import { Button, Filter, Icon, IconObject, ObjectName } from 'Component';
 import { AutoSizer, CellMeasurer, InfiniteLoader, List, CellMeasurerCache } from 'react-virtualized';
 
@@ -420,7 +420,11 @@ const SidebarPageSettingsLibrary = observer(forwardRef<{}, I.SidebarPageComponen
 					style={style}
 					onContextMenu={() => onContext(item)}
 				>
-					<IconObject object={item} />
+					{U.Object.isRelationLayout(item.layout) ? (
+						<Icon className={`relation ${Relation.className(item.format)}`} />
+					) : (
+						<IconObject object={item} />
+					)}
 					<ObjectName object={item} />
 				</div>
 			);

--- a/src/ts/component/sidebar/section/type/relation.tsx
+++ b/src/ts/component/sidebar/section/type/relation.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useState, useRef, useImperativeHandle, useEffect, MouseEvent } from 'react';
 import { observer } from 'mobx-react';
-import { Title, Label, Icon, ObjectName, IconObject } from 'Component';
+import { Title, Label, Icon, ObjectName } from 'Component';
 import { I, S, U, Relation, translate, keyboard, analytics } from 'Lib';
 import { DndContext, closestCenter, useSensors, useSensor, PointerSensor, KeyboardSensor, DragOverlay } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy, sortableKeyboardCoordinates, arrayMove, useSortable } from '@dnd-kit/sortable';
@@ -276,7 +276,7 @@ const SidebarSectionTypeRelation = observer(forwardRef<I.SidebarSectionRef, I.Si
 				{!item.isEmpty ? (
 					<>
 						{canDrag ? <Icon className="dnd" /> : ''}
-						<IconObject object={item} />
+						<Icon className={`relation ${Relation.className(item.format)}`} />
 					</>
 				) : ''}
 				<ObjectName object={item} />

--- a/src/ts/lib/relation.ts
+++ b/src/ts/lib/relation.ts
@@ -634,7 +634,7 @@ class Relation {
 
 			ret.push({
 				id: relation.relationKey,
-				object: { relationFormat: relation.format, layout: I.ObjectLayout.Relation },
+				icon: `relation ${this.className(relation.format)}`,
 				name: relation.name,
 				isHidden: relation.isHidden,
 				format: relation.format,

--- a/src/ts/lib/util/menu.ts
+++ b/src/ts/lib/util/menu.ts
@@ -527,7 +527,7 @@ class UtilMenu {
 			{ id: I.RelationType.Phone },
 		].map((it: any) => {
 			it.name = translate(`relationName${it.id}`);
-			it.object = { relationFormat: it.id, layout: I.ObjectLayout.Relation };
+			it.icon = `relation ${Relation.className(it.id)}`;
 			return it;
 		});
 	};


### PR DESCRIPTION
Relation icons in menus were going through IconObject which applies IconSize mapping (20px container → 18px icon). Switch all menu contexts to use Icon component with CSS class names (.icon.relation.c-*) and mask-image, so icons render at full container size as regular menu icons.

IconObject with Relation layout is preserved for object icon contexts.

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
