### PR TITLE
Bugfix/JS-8946: Fix text filter not saving last value due to stale closure

### DIFF
--- a/src/ts/component/block/dataview/filters.tsx
+++ b/src/ts/component/block/dataview/filters.tsx
@@ -52,8 +52,6 @@ const BlockDataviewFilters = observer(forwardRef<{}, Props>((props, ref) => {
 	};
 
 	const onClick = (e: any, item: any) => {
-		const filter: I.Filter = view.getFilter(item.id);
-
 		S.Menu.open('dataviewFilterValues', {
 			element: `#block-${blockId} #dataviewFilters #item-${item.id}`,
 			classNameWrap: 'fromBlock',
@@ -68,9 +66,12 @@ const BlockDataviewFilters = observer(forwardRef<{}, Props>((props, ref) => {
 				getTarget,
 				readonly: isReadonly,
 				save: () => {
-					C.BlockDataviewFilterReplace(rootId, blockId, view.id, item.id, filter, () => {
-						loadData(view.id, 0, false);
-					});
+					const currentFilter = view.getFilter(item.id);
+					if (currentFilter) {
+						C.BlockDataviewFilterReplace(rootId, blockId, view.id, item.id, currentFilter, () => {
+							loadData(view.id, 0, false);
+						});
+					};
 				},
 				itemId: item.id,
 			}

--- a/src/ts/component/menu/dataview/filter/list.tsx
+++ b/src/ts/component/menu/dataview/filter/list.tsx
@@ -201,7 +201,6 @@ const MenuFilterList = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		};
 
 		const view = getView();
-		const filter: I.Filter = view.getFilter(item.id);
 
 		S.Menu.open('dataviewFilterValues', {
 			element: `#${getId()} #item-${item.id}`,
@@ -218,9 +217,12 @@ const MenuFilterList = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 				getTarget,
 				readonly: isReadonly,
 				save: () => {
-					C.BlockDataviewFilterReplace(rootId, blockId, view.id, item.id, filter, () => {
-						loadData(view.id, 0, false);
-					});
+					const currentFilter = view.getFilter(item.id);
+					if (currentFilter) {
+						C.BlockDataviewFilterReplace(rootId, blockId, view.id, item.id, currentFilter, () => {
+							loadData(view.id, 0, false);
+						});
+					};
 				},
 				itemId: item.id,
 			}


### PR DESCRIPTION
The save closure captured the filter object reference at menu open time. After backend events replaced it in the view's filters array, subsequent saves sent stale data. Now reads the current filter fresh at save time.

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
