### PR TITLE
Feature/JS-8844: Black/gray message preview styling for chat objects in vault

### DIFF
--- a/src/scss/component/sidebar/page/vault.scss
+++ b/src/scss/component/sidebar/page/vault.scss
@@ -46,6 +46,9 @@
 			.chatCounter { position: absolute; right: -4px; bottom: -4px; }
 		}
 		.info { flex-grow: 1; display: flex; flex-direction: column; overflow: hidden; }
+		.info.hasUnread {
+			.label.lastMessage, .label.chatName { color: var(--color-text-primary); }
+		}
 
 		&.noMessages {
 			.info { flex-direction: row; }
@@ -59,10 +62,6 @@
 
 		.name { flex-grow: 1; @include text-overflow-nw; font-weight: 500; line-height: 20px; }
 		.label { @include text-small; color: var(--color-text-secondary); flex-grow: 1; }
-
-		.info.hasUnread {
-			.label.lastMessage, .label.chatName { color: var(--color-text-primary); }
-		}
 		.label.chatName { font-weight: 500; @include text-overflow-nw; }
 
 		&::before {

--- a/src/scss/component/sidebar/page/vault.scss
+++ b/src/scss/component/sidebar/page/vault.scss
@@ -59,6 +59,10 @@
 
 		.name { flex-grow: 1; @include text-overflow-nw; font-weight: 500; line-height: 20px; }
 		.label { @include text-small; color: var(--color-text-secondary); flex-grow: 1; }
+
+		.info.hasUnread {
+			.label.lastMessage, .label.chatName { color: var(--color-text-primary); }
+		}
 		.label.chatName { font-weight: 500; @include text-overflow-nw; }
 
 		&::before {

--- a/src/ts/component/sidebar/page/vault.tsx
+++ b/src/ts/component/sidebar/page/vault.tsx
@@ -410,6 +410,9 @@ const SidebarPageVault = observer(forwardRef<{}, I.SidebarPageComponent>((props,
 			cn.push('isMuted');
 		};
 
+		const rawCounters = !isChat && !isOneToOne ? S.Chat.getSpaceCounters(targetSpaceId, true) : null;
+		const hasUnread = rawCounters && (item.notificationMode != I.NotificationMode.Nothing) && !!(rawCounters.messageCounter || rawCounters.mentionCounter);
+
 		if (lastMessage) {
 			const { createdAt, creator, isSynced } = lastMessage;
 
@@ -497,7 +500,7 @@ const SidebarPageVault = observer(forwardRef<{}, I.SidebarPageComponent>((props,
 					{vaultIsMinimal ? counter : ''}
 				</div>
 				{!vaultIsMinimal ? (
-					<div className="info">
+					<div className={[ 'info', (hasUnread ? 'hasUnread' : '') ].join(' ')}>
 						{info}
 					</div>
 				) : ''}

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -372,9 +372,10 @@ class ChatStore {
 	/**
 	 * Gets the mention and message counters for a space.
 	 * @param {string} spaceId - The space ID.
+	 * @param {boolean} [ignoreMute] - If true, include counters regardless of notification mode.
 	 * @returns {Counter} The counters for the space.
 	 */
-	getSpaceCounters (spaceId: string): I.ChatCounter {
+	getSpaceCounters (spaceId: string, ignoreMute?: boolean): I.ChatCounter {
 		const ret = { mentionCounter: 0, messageCounter: 0 };
 		const spaceMap = this.stateMap.get(spaceId);
 
@@ -396,11 +397,11 @@ class ChatStore {
 
 			const chatMode = U.Object.getChatNotificationMode(spaceview, chatId);
 
-			if (state.mentionCounter && [ I.NotificationMode.All, I.NotificationMode.Mentions ].includes(chatMode)) {
+			if (state.mentionCounter && (ignoreMute || [ I.NotificationMode.All, I.NotificationMode.Mentions ].includes(chatMode))) {
 				ret.mentionCounter += Number(state.mentionCounter) || 0;
 			};
 
-			if (state.messageCounter && [ I.NotificationMode.All ].includes(chatMode)) {
+			if (state.messageCounter && (ignoreMute || [ I.NotificationMode.All ].includes(chatMode))) {
 				ret.messageCounter += Number(state.messageCounter) || 0;
 			};
 		};

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -373,7 +373,7 @@ class ChatStore {
 	 * Gets the mention and message counters for a space.
 	 * @param {string} spaceId - The space ID.
 	 * @param {boolean} [ignoreMute] - If true, include counters regardless of notification mode.
-	 * @returns {Counter} The counters for the space.
+	 * @returns {I.ChatCounter} The counters for the space.
 	 */
 	getSpaceCounters (spaceId: string, ignoreMute?: boolean): I.ChatCounter {
 		const ret = { mentionCounter: 0, messageCounter: 0 };


### PR DESCRIPTION
Display unread message previews in primary color and read previews in secondary color for data spaces in the vault sidebar, based on unread state and notification settings.

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
