### PR TITLE
Feature/JS-8734: List view: add Regular mode and Size setting

### DIFF
--- a/src/json/text.json
+++ b/src/json/text.json
@@ -1845,6 +1845,7 @@
 
 	"menuDataviewViewEditCover": "Cover",
 	"menuDataviewViewEditCardSize": "Card size",
+	"menuDataviewViewEditListSize": "Size",
 	"menuDataviewViewEditFitMedia": "Fit media",
 	"menuDataviewViewEditGroupBy": "Group by",
 	"menuDataviewViewEditDate": "Date Property",
@@ -2469,6 +2470,8 @@
 	"libRelationSmall": "Small",
 	"libRelationMedium": "Medium",
 	"libRelationLarge": "Large",
+	"libRelationCompact": "Compact",
+	"libRelationRegular": "Regular",
 	"libRelationPageCover": "Object cover",
 	"libRelationPicture": "Picture",
 

--- a/src/scss/block/dataview/view/list.scss
+++ b/src/scss/block/dataview/view/list.scss
@@ -161,6 +161,29 @@
 			.cellContent.isEmpty:not(.editModeOn, .withMenu) { display: none; }
 
 			.loadMore { margin-top: 2px; }
+
+			&.isRegular {
+				.row { height: 52px !important; }
+				.row {
+					.sides { align-items: flex-start; padding-top: 4px; }
+
+					.side.left {
+						flex-direction: column;
+						.lines { width: 100%; display: flex; flex-direction: column; gap: 0px; }
+						.lines {
+							.line { display: flex; flex-direction: row; align-items: center; }
+							.line.second {
+								.description {
+									@include text-small; color: var(--color-text-secondary); @include text-overflow-nw;
+									line-height: 20px; height: 20px;
+								}
+							}
+						}
+					}
+				}
+
+				.row.add { height: 28px; }
+			}
         }
     }
 
@@ -176,6 +199,10 @@
 			}
 			.row.add:hover {
 				.cell.add { background-color: transparent; }
+			}
+
+			&.isRegular {
+				.row { height: 52px !important; }
 			}
 		}
 	}

--- a/src/scss/block/dataview/view/list.scss
+++ b/src/scss/block/dataview/view/list.scss
@@ -163,26 +163,32 @@
 			.loadMore { margin-top: 2px; }
 
 			&.isRegular {
-				.row { height: 52px !important; }
+				.row { height: 52px !important; display: flex; align-items: center; }
 				.row {
-					.sides { align-items: flex-start; padding-top: 4px; }
+					.dropTarget { display: flex; align-items: center; height: 100%; flex: 1 1 auto; overflow: hidden; }
+					.selectionTarget { display: flex; align-items: center; width: 100%; height: 100%; }
 
-					.side.left {
-						flex-direction: column;
-						.lines { width: 100%; display: flex; flex-direction: column; gap: 0px; }
-						.lines {
-							.line { display: flex; flex-direction: row; align-items: center; }
-							.line.second {
-								.description {
-									@include text-small; color: var(--color-text-secondary); @include text-overflow-nw;
-									line-height: 20px; height: 20px;
-								}
-							}
+					.regularContent { display: flex; flex-direction: row; align-items: center; gap: 0px 12px; width: 100%; overflow: hidden; }
+					.regularContent {
+						.iconObject { flex-shrink: 0; }
+					}
+
+					.sides { flex: 1 1 0; flex-direction: column; align-items: stretch; justify-content: center; gap: 0px; overflow: hidden; min-width: 0; }
+
+					.line { display: flex; flex-direction: row; align-items: center; justify-content: space-between; gap: 0px 12px; }
+					.line.first {
+						.side.left { flex: 1 1 auto; min-width: 40%; }
+					}
+					.line.second { overflow: hidden; }
+					.line.second {
+						.description {
+							@include text-small; color: var(--color-text-secondary); @include text-overflow-nw;
+							line-height: 20px; height: 20px;
 						}
 					}
 				}
 
-				.row.add { height: 28px; }
+				.row.add { height: 28px; display: block; }
 			}
         }
     }

--- a/src/scss/block/dataview/view/list.scss
+++ b/src/scss/block/dataview/view/list.scss
@@ -190,8 +190,8 @@
 
 				.row.add { height: 28px; display: block; }
 			}
-        }
-    }
+		}
+	}
 
 	.block.blockDataview.isInline {
 		.viewContent.viewList { padding: 9px 0px 0px 0px; }
@@ -208,7 +208,7 @@
 			}
 
 			&.isRegular {
-				.row { height: 52px !important; }
+				.row { height: 52px !important; display: flex; align-items: center; }
 			}
 		}
 	}

--- a/src/ts/component/block/dataview/view/list.tsx
+++ b/src/ts/component/block/dataview/view/list.tsx
@@ -6,7 +6,8 @@ import { I, S, U } from 'Lib';
 import BodyRow from './list/row';
 import AddRow from './grid/body/add';
 
-const HEIGHT = 32;
+const HEIGHT_COMPACT = 32;
+const HEIGHT_REGULAR = 56;
 
 const ViewList = observer(forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 
@@ -18,7 +19,13 @@ const ViewList = observer(forwardRef<I.ViewRef, I.ViewComponent>((props, ref) =>
 	const limit = getLimit();
 	const length = records.length;
 	const isAllowedObject = props.isAllowedObject();
+	const isRegular = view.listSize == I.ListSize.Regular;
+	const rowHeight = isRegular ? HEIGHT_REGULAR : HEIGHT_COMPACT;
 	const cn = [ 'viewContent', className ];
+
+	if (isRegular) {
+		cn.push('isRegular');
+	};
 
 	useEffect(() => {
 		U.Common.triggerResizeEditor(isPopup);
@@ -83,7 +90,7 @@ const ViewList = observer(forwardRef<I.ViewRef, I.ViewComponent>((props, ref) =>
 										width={Number(width) || 0}
 										isScrolling={isScrolling}
 										rowCount={records.length}
-										rowHeight={HEIGHT}
+										rowHeight={rowHeight}
 										onRowsRendered={onRowsRendered}
 										rowRenderer={({ key, index, style }) => {
 											const id = records[index];

--- a/src/ts/component/block/dataview/view/list/row.tsx
+++ b/src/ts/component/block/dataview/view/list/row.tsx
@@ -3,7 +3,7 @@ import $ from 'jquery';
 import { motion, AnimatePresence } from 'motion/react';
 import { observer } from 'mobx-react';
 import { I, S, U, keyboard, Relation } from 'Lib';
-import { Cell, DropTarget, Icon, SelectionTarget } from 'Component';
+import { Cell, DropTarget, Icon, IconObject, SelectionTarget } from 'Component';
 
 interface Props extends I.ViewComponent {
 	style?: any;
@@ -112,6 +112,12 @@ const ListRow = observer(forwardRef<I.RowRef, Props>((props, ref) => {
 		onCellClick(e, relation.relationKey, record.id);
 	};
 
+	// In Regular mode, override getView to always hide the icon inside the name Cell
+	// since we render it separately at the row level
+	const getViewForCell = isRegular
+		? () => ({ ...view, hideIcon: true })
+		: getView;
+
 	const mapper = (vr: any, i: number) => {
 		const relation = S.Record.getRelationByKey(vr.relationKey);
 		const id = Relation.cellId(idPrefix, relation.relationKey, record.id);
@@ -138,6 +144,7 @@ const ListRow = observer(forwardRef<I.RowRef, Props>((props, ref) => {
 					ref={ref => onRefCell(ref, id)}
 					{...props}
 					getRecord={() => record}
+					getView={getViewForCell}
 					subId={subId}
 					relationKey={relation.relationKey}
 					viewType={view.type}
@@ -168,22 +175,37 @@ const ListRow = observer(forwardRef<I.RowRef, Props>((props, ref) => {
 	let content = null;
 
 	if (isRegular) {
+		let rowIcon = null;
+
+		if (!hideIcon) {
+			rowIcon = (
+				<IconObject
+					id={`list-icon-${record.id}`}
+					object={record}
+					size={48}
+					canEdit={!props.readonly && U.Object.isTaskLayout(record.layout)}
+					noClick={true}
+				/>
+			);
+		};
+
 		content = (
-			<div className="sides">
-				<div className="side left">
-					<div className="lines">
-						<div className="line first">
+			<div className="regularContent">
+				{rowIcon}
+				<div className="sides">
+					<div className="line first">
+						<div className="side left">
 							{left.map(mapper)}
 						</div>
-						{record.description ? (
-							<div className="line second">
-								<div className="description">{record.description}</div>
-							</div>
-						) : ''}
+						<div className="side right">
+							{right.map(mapper)}
+						</div>
 					</div>
-				</div>
-				<div className="side right">
-					{right.map(mapper)}
+					{record.description ? (
+						<div className="line second">
+							<div className="description">{record.description}</div>
+						</div>
+					) : ''}
 				</div>
 			</div>
 		);

--- a/src/ts/component/block/dataview/view/list/row.tsx
+++ b/src/ts/component/block/dataview/view/list/row.tsx
@@ -45,16 +45,26 @@ const ListRow = observer(forwardRef<I.RowRef, Props>((props, ref) => {
 	const cn = [ 'row' ];
 	const relations = view.getVisibleRelations();
 	const nameIndex = relations.findIndex(it => it.relationKey == 'name');
+	const isRegular = view.listSize == I.ListSize.Regular;
 	const selection = S.Common.getRef('selectionProvider');
 
 	const left = [];
 	const right = [];
 
 	relations.forEach((el, idx) => {
-		if (idx <= nameIndex) {
-			left.push(el);
+		if (isRegular) {
+			if (el.relationKey == 'name') {
+				left.push(el);
+			} else
+			if (el.relationKey != 'description') {
+				right.push(el);
+			};
 		} else {
-			right.push(el);
+			if (idx <= nameIndex) {
+				left.push(el);
+			} else {
+				right.push(el);
+			};
 		};
 	});
 
@@ -155,19 +165,43 @@ const ListRow = observer(forwardRef<I.RowRef, Props>((props, ref) => {
 
 	const lw = 50 + left.length * 5;
 
-	let content = (
-		<div className="sides">
-			<div
-				className={[ 'side', 'left', (left.length > 1 ? 's60' : '') ].join(' ')}
-				style={{ width: `${lw}%` }}
-			>
-				{left.map(mapper)}
+	let content = null;
+
+	if (isRegular) {
+		content = (
+			<div className="sides">
+				<div className="side left">
+					<div className="lines">
+						<div className="line first">
+							{left.map(mapper)}
+						</div>
+						{record.description ? (
+							<div className="line second">
+								<div className="description">{record.description}</div>
+							</div>
+						) : ''}
+					</div>
+				</div>
+				<div className="side right">
+					{right.map(mapper)}
+				</div>
 			</div>
-			<div className="side right">
-				{right.map(mapper)}
+		);
+	} else {
+		content = (
+			<div className="sides">
+				<div
+					className={[ 'side', 'left', (left.length > 1 ? 's60' : '') ].join(' ')}
+					style={{ width: `${lw}%` }}
+				>
+					{left.map(mapper)}
+				</div>
+				<div className="side right">
+					{right.map(mapper)}
+				</div>
 			</div>
-		</div>
-	);
+		);
+	};
 
 	if (!isInline) {
 		content = (

--- a/src/ts/component/menu/dataview/relation/edit.tsx
+++ b/src/ts/component/menu/dataview/relation/edit.tsx
@@ -76,9 +76,11 @@ const MenuDataviewRelationEdit = observer(forwardRef<I.MenuRef, I.Menu>((props, 
 		const isFile = relation && (relation.format == I.RelationType.File);
 		const isName = relation && (relation.relationKey == 'name');
 		const isDescription = relation && (relation.relationKey == 'description');
+		const view = getView?.();
+		const isListRegular = view && (view.type == I.ViewType.List) && (view.listSize == I.ListSize.Regular);
 		const canFilter = !isFile;
 		const canSort = !isFile;
-		const canHide = !isName;
+		const canHide = !isName && !(isDescription && isListRegular);
 		const canAlign = !isName; 
 		const canCalculate = relation;
 		const isType = U.Object.isTypeLayout(object.layout);

--- a/src/ts/component/menu/dataview/relation/list.tsx
+++ b/src/ts/component/menu/dataview/relation/list.tsx
@@ -207,7 +207,9 @@ const MenuRelationList = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => 
 	const Item = (item: any) => {
 		const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: item.id, disabled: isReadonly });
 		const isName = item.relationKey == 'name';
-		const canHide = !isReadonly && (!isName || (view.type == I.ViewType.Gallery));
+		const isDescription = item.relationKey == 'description';
+		const isListRegular = (view.type == I.ViewType.List) && (view.listSize == I.ListSize.Regular);
+		const canHide = !isReadonly && (!isName || (view.type == I.ViewType.Gallery)) && !(isDescription && isListRegular);
 		const cn = [ 'item' ];
 		const style = {
 			...item.style,

--- a/src/ts/component/menu/dataview/view/layout.tsx
+++ b/src/ts/component/menu/dataview/view/layout.tsx
@@ -108,8 +108,9 @@ const MenuViewLayout = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 
 	const getSections = () => {
-		const { type, coverRelationKey, cardSize, coverFit, wrapContent, groupRelationKey, endRelationKey, groupBackgroundColors, hideIcon, pageLimit } = saveParam.current;
+		const { type, coverRelationKey, cardSize, listSize, coverFit, wrapContent, groupRelationKey, endRelationKey, groupBackgroundColors, hideIcon, pageLimit } = saveParam.current;
 		const isGrid = type == I.ViewType.Grid;
+		const isList = type == I.ViewType.List;
 		const isGallery = type == I.ViewType.Gallery;
 		const isBoard = type == I.ViewType.Board;
 		const isCalendar = type == I.ViewType.Calendar;
@@ -124,6 +125,14 @@ const MenuViewLayout = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 				id: 'wrapContent', name: translate('menuDataviewViewEditWrapContent'), withSwitch: true, switchValue: wrapContent,
 				onSwitch: (e: any, v: boolean) => onSwitch(e, 'wrapContent', v),
 			});
+		};
+
+		if (isList) {
+			const listSizeOption = Relation.getListSizeOptions().find(it => it.id == listSize);
+
+			settings = settings.concat([
+				{ id: 'listSize', name: translate('menuDataviewViewEditListSize'), caption: (listSizeOption ? listSizeOption.name : translate('commonSelect')), arrow: true },
+			]);
 		};
 
 		if (isGallery) {
@@ -316,6 +325,15 @@ const MenuViewLayout = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 				menuId = 'select';
 				menuParam.data = Object.assign(menuParam.data, {
 					options: Relation.getPageLimitOptions(type, isInline),
+				});
+				break;
+			};
+
+			case 'listSize': {
+				menuId = 'select';
+				menuParam.data = Object.assign(menuParam.data, {
+					value: String(saveParam.current.listSize),
+					options: Relation.getListSizeOptions(),
 				});
 				break;
 			};

--- a/src/ts/interface/block/dataview.ts
+++ b/src/ts/interface/block/dataview.ts
@@ -7,6 +7,11 @@ export enum CardSize {
 	Large			 = 2,
 };
 
+export enum ListSize {
+	Compact			 = 0,
+	Regular			 = 1,
+};
+
 export enum DateFormat {
 	MonthAbbrBeforeDay	 = 0, // Jul 30, 2020
 	MonthAbbrAfterDay	 = 1, // 30 Jul 2020
@@ -239,6 +244,7 @@ export interface View {
 	groupBackgroundColors: boolean;
 	coverFit: boolean;
 	cardSize: I.CardSize;
+	listSize: I.ListSize;
 	hideIcon: boolean;
 	pageLimit: number;
 	sorts: Sort[];

--- a/src/ts/lib/api/mapper.ts
+++ b/src/ts/lib/api/mapper.ts
@@ -369,6 +369,7 @@ export const Mapper = {
 				groupRelationKey: obj.getGrouprelationkey(),
 				endRelationKey: obj.getEndrelationkey(),
 				wrapContent: obj.getWrapcontent(),
+				listSize: obj.getListsize(),
 				groupBackgroundColors: obj.getGroupbackgroundcolors(),
 				pageLimit: obj.getPagelimit(),
 				defaultTemplateId: obj.getDefaulttemplateid(),
@@ -1090,6 +1091,7 @@ export const Mapper = {
 			item.setGrouprelationkey(obj.groupRelationKey);
 			item.setEndrelationkey(obj.endRelationKey);
 			item.setWrapcontent(obj.wrapContent);
+			item.setListsize(obj.listSize as any);
 			item.setGroupbackgroundcolors(obj.groupBackgroundColors);
 			item.setCoverfit(obj.coverFit);
 			item.setCardsize(obj.cardSize as any);

--- a/src/ts/lib/relation.ts
+++ b/src/ts/lib/relation.ts
@@ -657,6 +657,13 @@ class Relation {
 		];
 	};
 
+	public getListSizeOptions () {
+		return [
+			{ id: I.ListSize.Compact, name: translate('libRelationCompact') },
+			{ id: I.ListSize.Regular, name: translate('libRelationRegular') },
+		];
+	};
+
 	/**
 	 * Gets cover options for a dataview.
 	 * @param {string} rootId - The root object ID.

--- a/src/ts/lib/relation.ts
+++ b/src/ts/lib/relation.ts
@@ -657,6 +657,10 @@ class Relation {
 		];
 	};
 
+	/**
+	 * Gets size options for list view.
+	 * @returns {Array<{id: I.ListSize, name: string}>} The list size options.
+	 */
 	public getListSizeOptions () {
 		return [
 			{ id: I.ListSize.Compact, name: translate('libRelationCompact') },

--- a/src/ts/model/view.ts
+++ b/src/ts/model/view.ts
@@ -31,6 +31,7 @@ class View implements I.View {
 	coverRelationKey = '';
 	coverFit = false;
 	cardSize: I.CardSize = I.CardSize.Small;
+	listSize: I.ListSize = I.ListSize.Compact;
 	hideIcon = false;
 	groupRelationKey = '';
 	endRelationKey = '';
@@ -51,6 +52,7 @@ class View implements I.View {
 		this.coverFit = Boolean(props.coverFit);
 		this.hideIcon = Boolean(props.hideIcon);
 		this.cardSize = Number(props.cardSize) || I.CardSize.Small;
+		this.listSize = Number(props.listSize) || I.ListSize.Compact;
 		this.groupRelationKey = String(props.groupRelationKey || '');
 		this.endRelationKey = String(props.endRelationKey || '');
 		this.wrapContent = Boolean(props.wrapContent);
@@ -75,6 +77,7 @@ class View implements I.View {
 			coverRelationKey: observable,
 			coverFit: observable,
 			cardSize: observable,
+			listSize: observable,
 			hideIcon: observable,
 			groupRelationKey: observable,
 			endRelationKey: observable,


### PR DESCRIPTION
## Summary

- Add `ListSize` enum (`Compact` / `Regular`) and wire it through interface, model, mapper, and gRPC
- Add a **Size** dropdown in the List view layout settings panel (between layout selector and "Show icon" toggle)
- In **Regular** mode, rows are two-line: object name on the first line, description on the second line, other properties on the right
- In **Compact** mode (default), behavior is unchanged — single-line rows with all properties inline

Middleware PR: anyproto/anytype-heart#2912

Closes https://linear.app/anytype/issue/JS-8734

## Changes

| File | Change |
|------|--------|
| `src/ts/interface/block/dataview.ts` | Add `ListSize` enum, add `listSize` to `View` interface |
| `src/ts/model/view.ts` | Add `listSize` observable property |
| `src/ts/lib/api/mapper.ts` | Map `listSize` from/to gRPC (`getListsize`/`setListsize`) |
| `src/ts/lib/relation.ts` | Add `getListSizeOptions()` returning Compact/Regular |
| `src/json/text.json` | Add translation keys for Size, Compact, Regular |
| `src/ts/component/menu/dataview/view/layout.tsx` | Add Size dropdown for List view type |
| `src/ts/component/block/dataview/view/list.tsx` | Dynamic row height based on `listSize`, add `isRegular` CSS class |
| `src/ts/component/block/dataview/view/list/row.tsx` | Two-line layout in Regular mode with description line |
| `src/scss/block/dataview/view/list.scss` | Styles for Regular mode rows |

## Test plan

- [ ] Open a Set/Collection with List view
- [ ] Open view settings → verify "Size" dropdown appears with "Compact" selected by default
- [ ] Switch to "Regular" → rows become two-line with description below name
- [ ] Switch back to "Compact" → rows return to single-line
- [ ] Verify setting persists across page navigation
- [ ] Verify setting is per-view (different views can have different sizes)
- [ ] Verify inline dataview list also respects the size setting
- [ ] Switch to Grid/Gallery/Board view → "Size" dropdown should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)