### PR TITLE
perf: replace Array.find/includes with Set/Map for O(1) lookups in loops

### DIFF
--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -1,13 +1,34 @@
-import React, { forwardRef, useRef, useEffect, DragEvent, MouseEvent, useState, useLayoutEffect, useImperativeHandle } from 'react';
-import $ from 'jquery';
-import raf from 'raf';
-import { observer } from 'mobx-react';
-import { I, C, S, U, J, M, keyboard, translate, Preview, Mark, analytics } from 'Lib';
+import React, {
+	forwardRef,
+	useRef,
+	useEffect,
+	DragEvent,
+	MouseEvent,
+	useState,
+	useLayoutEffect,
+	useImperativeHandle,
+} from "react";
+import $ from "jquery";
+import raf from "raf";
+import { observer } from "mobx-react";
+import {
+	I,
+	C,
+	S,
+	U,
+	J,
+	M,
+	keyboard,
+	translate,
+	Preview,
+	Mark,
+	analytics,
+} from "Lib";
 
-import Form from './chat/form';
-import Message from './chat/message';
-import Empty from './chat/empty';
-import SectionDate from './chat/message/date';
+import Form from "./chat/form";
+import Message from "./chat/message";
+import Empty from "./chat/empty";
+import SectionDate from "./chat/message/date";
 
 interface RefProps {
 	forceUpdate: () => void;
@@ -17,1087 +38,1348 @@ interface RefProps {
 	onDrop: (e: DragEvent) => void;
 	getFormRef: () => any;
 	loadAndScrollToMessage: (id: string) => void;
-};
+}
 
 const GROUP_TIME = 300;
 
-const BlockChat = observer(forwardRef<RefProps, I.BlockComponent>((props, ref) => {
+const BlockChat = observer(
+	forwardRef<RefProps, I.BlockComponent>((props, ref) => {
+		const { space } = S.Common;
+		const { account } = S.Auth;
+		const { rootId, block, isPopup, readonly } = props;
+		const nodeRef = useRef(null);
+		const formRef = useRef(null);
+		const scrollWrapperRef = useRef(null);
+		const messageRefs = useRef({});
+		const timeoutInterface = useRef(0);
+		const timeoutScrollStop = useRef(0);
+		const timeoutResize = useRef(0);
+		const top = useRef(0);
+		const scrolledItems = useRef(new Set());
+		const isBottom = useRef(false);
+		const isAutoLoadDisabled = useRef(false);
+		const [firstUnreadOrderId, setFirstUnreadOrderId] = useState("");
+		const [dummy, setDummy] = useState(0);
+		const [isLoaded, setIsLoaded] = useState(false);
+		const frameRef = useRef(0);
+		const namespace = U.Common.getEventNamespace(isPopup);
+		const jumpIds = useRef([]);
 
-	const { space } = S.Common;
-	const { account } = S.Auth;
-	const { rootId, block, isPopup, readonly } = props;
-	const nodeRef = useRef(null);
-	const formRef = useRef(null);
-	const scrollWrapperRef = useRef(null);
-	const messageRefs = useRef({});
-	const timeoutInterface = useRef(0);
-	const timeoutScrollStop = useRef(0);
-	const timeoutResize = useRef(0);
-	const top = useRef(0);
-	const scrolledItems = useRef(new Set());
-	const isBottom = useRef(false);
-	const isAutoLoadDisabled = useRef(false);
-	const [ firstUnreadOrderId, setFirstUnreadOrderId ] = useState('');
-	const [ dummy, setDummy ] = useState(0);
-	const [ isLoaded, setIsLoaded ] = useState(false);
-	const frameRef = useRef(0);
-	const namespace = U.Common.getEventNamespace(isPopup);
-	const jumpIds = useRef([]);
+		const getChatId = () => {
+			const object = S.Detail.get(rootId, rootId, ["chatId"]);
 
-	const getChatId = () => {
-		const object = S.Detail.get(rootId, rootId, [ 'chatId' ]);
+			if (object._empty_) {
+				return rootId;
+			}
 
-		if (object._empty_) {
-			return rootId;
+			return object.chatId || rootId;
 		};
 
-		return object.chatId || rootId;
-	};
-
-	const getAnalyticsChatId = () => {
-		const chatId = getChatId();
-		return S.Detail.get(chatId, chatId, [ 'analyticsChatId' ]).analyticsChatId;
-	};
-
-	const getSubId = () => {
-		return S.Chat.getChatSubId('chat', space, getChatId());
-	};
-
-	const chatId = getChatId();
-	const subId = getSubId();
-	const messages = S.Chat.getList(subId);
-	const analyticsChatId = getAnalyticsChatId();
-
-	const unbind = () => {
-		const events = [ 'messageAdd', 'messageUpdate', 'reactionUpdate', 'focus' ];
-		const ns = block.id + namespace;
-
-		$(window).off(events.map(it => `${it}.${ns}`).join(' '));
-		U.Common.getScrollContainer(isPopup).off(`scroll.${ns}`);
-	};
-
-	const rebind = () => {
-		const win = $(window);
-		const ns = block.id + namespace;
-
-		unbind();
-
-		win.on(`messageAdd.${ns}`, (e, message, subIds) => onMessageAdd(message, subIds));
-		win.on(`messageUpdate.${ns}`, (e, message, subIds) => onMessageAdd(message, subIds));
-		win.on(`reactionUpdate.${ns}`, () => scrollToBottomCheck());
-		win.on(`focus.${ns}`, () => readScrolledMessages());
-
-		U.Common.getScrollContainer(isPopup).on(`scroll.${ns}`, e => onScroll(e));
-	};
-
-	const loadDepsAndReplies = (list: I.ChatMessage[], callBack?: () => void) => {
-		loadReplies(getReplyIds(list), () => {
-			loadDeps(getDepsIds(list), callBack);
-		});
-	};
-
-	const loadState = (callBack?: () => void) => {
-		const chatId = getChatId();
-		const subId = getSubId();
-
-		if (!chatId) {
-			return;
+		const getAnalyticsChatId = () => {
+			const chatId = getChatId();
+			return S.Detail.get(chatId, chatId, ["analyticsChatId"])
+				.analyticsChatId;
 		};
 
-		C.ChatSubscribeLastMessages(chatId, 1, subId, (message: any) => {
-			if (message.state) {
-				S.Chat.setState(subId, message.state);
-			};
-
-			callBack?.();
-		});
-	};
-
-	const subscribeMessages = (clear: boolean, callBack?: () => void) => {
-		const chatId = getChatId();
-		const subId = getSubId();
-
-		if (!chatId) {
-			return;
-		};
-
-		C.ChatSubscribeLastMessages(chatId, J.Constant.limit.chat.messages, subId, (message: any) => {
-			if (message.error.code) {
-				callBack?.();
-				return;
-			};
-
-			if (message.state) {
-				S.Chat.setState(subId, message.state);
-			};
-
-			const messages = message.messages || [];
-			if (!messages.length) {
-				setLoaded(true);
-				callBack?.();
-				return;
-			};
-
-			loadDepsAndReplies(messages, () => {
-				if (clear) {
-					S.Chat.set(subId, messages);
-				};
-
-				if (messages.length < J.Constant.limit.chat.messages) {
-					setLoaded(true);
-				} else {
-					setDummy(dummy + 1);
-				};
-
-				callBack?.();
-			});
-		});
-	};
-
-	const loadMessages = (dir: number, clear: boolean, callBack?: () => void) => {
-		const chatId = getChatId();
-		const subId = getSubId();
-
-		if (!chatId) {
-			return;
-		};
-
-		if (!clear && (dir > 0) && isLoaded) {
-			setIsBottom(true);
-			return;
-		};
-
-		if (clear) {
-			subscribeMessages(clear, () => {
-				setIsBottom(true);
-				callBack?.();
-			});
-		} else {
-			const messages = S.Chat.getList(subId);
-			if (!messages.length) {
-				return;
-			};
-
-			const first = messages[0];
-			const before = dir < 0 ? messages[0].orderId : '';
-			const after = dir > 0 ? messages[messages.length - 1].orderId : '';
-
-			if (!before && !after) {
-				return;
-			};
-
-			C.ChatGetMessages(chatId, before, after, J.Constant.limit.chat.messages, false, (message: any) => {
-				if (message.error.code) {
-					setLoaded(true);
-					callBack?.();
-					return;
-				};
-
-				const messages = message.messages || [];
-
-				if (dir > 0) {
-					if (messages.length < J.Constant.limit.chat.messages) {
-						setLoaded(true);
-						setIsBottom(true);
-						subscribeMessages(false);
-					} else {
-						setIsBottom(false);
-					};
-				} else {
-					const y = U.Common.getMaxScrollHeight(isPopup);
-					const top = U.Common.getScrollContainerTop(isPopup);
-
-					setIsBottom(!(top < y));
-				};
-
-				loadDepsAndReplies(messages, () => {
-					if (messages.length) {
-						S.Chat[(dir < 0 ? 'prepend' : 'append')](subId, messages);
-
-						if (first && (dir < 0)) {
-							scrollToMessage(first.id);
-						};
-					};
-
-					callBack?.();
-				});
-			});
-		};
-	};
-
-	const loadMessagesByOrderId = (orderId: string, callBack?: () => void) => {
-		const chatId = getChatId();
-		if (!chatId) {
-			return;
-		};
-
-		const subId = getSubId();
-		const limit = Math.ceil(J.Constant.limit.chat.messages / 2);
-
-		let list = [];
-
-		C.ChatGetMessages(chatId, orderId, '', limit, true, (message: any) => {
-			if (!message.error.code && message.messages.length) {
-				list = list.concat(message.messages);
-			};
-
-			C.ChatGetMessages(chatId, '', orderId, limit, false, (message: any) => {
-				if (!message.error.code && message.messages.length) {
-					list = list.concat(message.messages);
-				};
-
-				loadDepsAndReplies(list, () => {
-					S.Chat.set(subId, list);
-					callBack?.();
-				});
-			});
-		});
-	};
-
-	const getMessages = () => {
-		return S.Chat.getList(getSubId());
-	};
-
-	const getDepsIds = (list: any[]) => {
-		const subId = getSubId();
-		const markTypes = [ I.MarkType.Object, I.MarkType.Mention ];
-
-		let attachments = [];
-		let marks = [];
-
-		if (formRef.current) {
-			attachments = attachments.concat(formRef.current.getAttachments().filter(it => !it.isTmp).map(it => it.id));
-			marks = marks.concat(formRef.current.getMarks());
-
-			const replyingId = formRef.current.getReplyingId();
-
-			if (replyingId) {
-				const message = S.Chat.getMessageById(subId, replyingId);
-				if (message) {
-					list.push(message);
-				};
-			};
-		};
-
-		list.forEach(it => {
-			attachments = attachments.concat((it.attachments || []).map(it => it.target));
-			marks = marks.concat(it.content.marks || []);
-		});
-
-		marks = marks.filter(it => markTypes.includes(it.type) && it.param).map(it => it.param);
-
-		return attachments.concat(marks).filter(it => it);
-	};
-
-	const getReplyIds = (list: any[]) => {
-		return (list || []).filter(it => it.replyToMessageId).map(it => it.replyToMessageId);
-	};
-
-	const loadDeps = (ids: string[], callBack?: () => void) => {
-		if (!ids.length) {
-			callBack?.();
-			return;
-		};
-
-		U.Subscription.subscribeIds({
-			subId: getSubId(),
-			ids,
-			noDeps: true,
-			keys: U.Subscription.chatRelationKeys(),
-			updateDetails: true,
-		}, callBack);
-	};
-
-	const loadReplies = (ids: string[], callBack?: () => void) => {
-		if (!ids.length) {
-			callBack?.();
-			return;
+		const getSubId = () => {
+			return S.Chat.getChatSubId("chat", space, getChatId());
 		};
 
 		const chatId = getChatId();
 		const subId = getSubId();
+		const messages = S.Chat.getList(subId);
+		const analyticsChatId = getAnalyticsChatId();
 
-		C.ChatGetMessagesByIds(chatId, ids, (message: any) => {
-			if (!message.error.code) {
-				message.messages.forEach(it => S.Chat.setReply(subId, it));
-			};
+		const unbind = () => {
+			const events = [
+				"messageAdd",
+				"messageUpdate",
+				"reactionUpdate",
+				"focus",
+			];
+			const ns = block.id + namespace;
 
-			callBack?.();
-		});
-	};
-
-	const getSections = () => {
-		const sections = [];
-
-		messages.forEach(item => {
-			const key = U.Date.dateWithFormat(I.DateFormat.ShortUS, item.createdAt);
-			const section = sections.find(it => it.key == key);
-
-			if (!section) {
-				sections.push({ createdAt: item.createdAt, key, isSection: true, list: [ item ] });
-			} else {
-				section.list.push(item);
-			};
-		});
-
-		// Message groups by author/time
-		sections.forEach(section => {
-			const length = section.list.length;
-
-			for (let i = 0; i < length; ++i) {
-				const prev = section.list[i - 1];
-				const item = section.list[i];
-
-				item.isFirst = false;
-				item.isLast = false;
-
-				if (prev && ((item.creator != prev.creator) || (item.createdAt - prev.createdAt >= GROUP_TIME) || item.replyToMessageId)) {
-					item.isFirst = true;
-
-					if (prev) {
-						prev.isLast = true;
-					};
-				};
-			};
-
-			section.list[0].isFirst = true;
-			section.list[length - 1].isLast = true;
-			section.list.sort((c1, c2) => U.Data.sortByOrderId(c1, c2));
-		});
-
-		sections.sort((c1, c2) => U.Data.sortByNumericKey('createdAt', c1, c2, I.SortType.Asc));
-
-		return sections;
-	};
-
-	const getItems = () => {
-		let items = [];
-		for (const section of sections) {
-			items.push({ key: section.key, createdAt: section.createdAt, isSection: true });
-			items = items.concat(section.list);
-		};
-		return items;
-	};
-
-	const onMessageAdd = (message: I.ChatMessage, subIds: string[]) => {
-		if (subIds.includes(getSubId())) {
-			loadDepsAndReplies([ message ], () => scrollToBottomCheck());
-		};
-	};
-
-	const onContextMenu = (e: MouseEvent, item: any, onMore?: boolean) => {
-		if (readonly) {
-			return;
+			$(window).off(events.map((it) => `${it}.${ns}`).join(" "));
+			U.Common.getScrollContainer(isPopup).off(`scroll.${ns}`);
 		};
 
-		const message = `#block-${U.Common.esc(block.id)} #item-${U.Common.esc(item.id)}`;
-		const container = U.Common.getScrollContainer(isPopup);
+		const rebind = () => {
+			const win = $(window);
+			const ns = block.id + namespace;
 
-		const menuParam: Partial<I.MenuParam> = {
-			classNameWrap: 'fromBlock',
-			onOpen: () => {
-				$(message).addClass('hover');
-				container.addClass('over');
-			},
-			onClose: () => {
-				$(message).removeClass('hover');
-				container.removeClass('over');
-			},
-			data: {
-				options: getMessageMenuOptions(item, onMore),
-				onSelect: (e, option) => {
-					switch (option.id) {
-						case 'reaction': {
-							messageRefs.current[item.id]?.onReactionAdd();
-							break;
-						};
-
-						case 'copy': {
-							const block = new M.Block({
-								type: I.BlockType.Text,
-								content: item.content,
-							});
-					
-							U.Common.clipboardCopy({ 
-								text: U.String.sanitize(Mark.insertEmoji(item.content.text, item.content.marks)),
-								anytype: {
-									range: { from: 0, to: item.content.text.length },
-									blocks: [ block ],
-								},
-							});
-
-							analytics.event('ClickMessageMenuCopy', { chatId: analyticsChatId });
-							break;
-						};
-
-						case 'link': {
-							const object = S.Detail.get(rootId, rootId);
-
-							U.Object.copyLink(object, space, 'deeplink', '', `&messageId=${item.id}`);
-							analytics.event('ClickMessageMenuLink', { chatId: analyticsChatId });
-							break;
-						};
-
-						case 'reply': {
-							formRef.current.onReply(item);
-							break;
-						};
-
-						case 'edit': {
-							formRef.current.onEdit(item);
-							break;
-						};
-
-						case 'delete': {
-							formRef.current.onDelete(item.id);
-							break;
-						};
-					};
-				},
-			},
-		};
-
-		if (onMore) {
-			menuParam.element = `${message} .icon.more`;
-		} else {
-			menuParam.recalcRect = () => ({ x: keyboard.mouse.page.x, y: keyboard.mouse.page.y, width: 0, height: 0 });
-		};
-
-		S.Menu.open('select', menuParam);
-	};
-
-	const renderDates = () => {
-		const node = $(nodeRef.current);
-		const dates = node.find('.sectionDate');
-		const offset = J.Size.header + 8;
-		const container = U.Common.getScrollContainer(isPopup);
-		const top = container.offset().top;
-
-		raf.cancel(frameRef.current);
-		frameRef.current = raf(() => {
-			dates.css({ position: 'static', left: '', top: '', width: '' });
-
-			let last = null;
-
-			dates.each((i, item: any) => {
-				item = $(item);
-
-				const y = item.offset().top;
-				if (y <= offset) {
-					last = item;
-				};
-			});
-
-			if (!last && dates.length) {
-				last = dates.first();
-			};
-
-			if (last) {
-				const width = last.outerWidth();
-				const { left } = last.offset();
-
-				last.css({ position: 'fixed', width, left, top: top + offset });
-			};
-		});
-	};
-
-	const onScroll = (e: any) => {
-		const subId = getSubId();
-		const container = U.Common.getScrollContainer(isPopup);
-		const st = Math.ceil(container.scrollTop());
-		const max = U.Common.getMaxScrollHeight(isPopup);
-		const list = getMessagesInViewport();
-		const state = S.Chat.getState(subId);
-		const { lastStateId } = state;
-		const isBottom = st >= max;
-
-		setIsBottom(isBottom);
-
-		if (!isAutoLoadDisabled.current) {
-			if (st <= 0) {
-				loadMessages(-1, false);
-			};
-
-			if (isBottom) {
-				loadMessages(1, false);
-			};
-		};
-
-		renderDates();
-
-		if (S.Common.windowIsFocused && list.length) {
-			list.forEach(it => {
-				scrolledItems.current.add(it.id);
-
-				if (!it.isReadMessage) {
-					readMessage(it.id, it.orderId, lastStateId, I.ChatReadType.Message);
-				};
-				if (!it.isReadMention && it.hasMention) {
-					readMessage(it.id, it.orderId, lastStateId, I.ChatReadType.Mention);
-				};
-			});
-		};
-
-		window.clearTimeout(timeoutScrollStop.current);
-		timeoutScrollStop.current = window.setTimeout(() => onReadStop(), 300);
-
-		top.current = st;
-
-		Preview.tooltipHide(true);
-		Preview.previewHide(true);
-	};
-
-	const readMessage = (id: string, orderId: string, lastStateId: string, type: I.ChatReadType) => {
-		const chatId = getChatId();
-		const subId = getSubId();
-
-		if (type == I.ChatReadType.Message) {
-			S.Chat.setReadMessageStatus(subId, [ id ], true);
-		};
-		if (type == I.ChatReadType.Mention) {
-			S.Chat.setReadMentionStatus(subId, [ id ], true);
-		};
-
-		C.ChatReadMessages(chatId, orderId, orderId, lastStateId, type);
-	};
-
-	const onReadStop = () => {
-		if (!scrolledItems.current.size) {
-			return;
-		};
-
-		const chatId = getChatId();
-		const subId = getSubId();
-		const ids: string[] = [ ...scrolledItems.current ] as string[];
-		const first = S.Chat.getMessageById(subId, ids[0]);
-		const last = S.Chat.getMessageById(subId, ids[ids.length - 1]);
-		const state = S.Chat.getState(subId);
-		const { lastStateId } = state;
-
-		if (S.Common.windowIsFocused) {
-			if (first && last) {
-				C.ChatReadMessages(chatId, first.orderId, last.orderId, lastStateId, I.ChatReadType.Message);
-				C.ChatReadMessages(chatId, first.orderId, last.orderId, lastStateId, I.ChatReadType.Mention);
-			};
-
-			S.Chat.setReadMessageStatus(subId, ids, true);
-			S.Chat.setReadMentionStatus(subId, ids, true);
-		};
-
-		scrolledItems.current.clear();
-	};
-
-	const getMessageScrollOffset = (id: string): number => {
-		const ref = messageRefs.current[id];
-		if (!ref) {
-			return 0;
-		};
-
-		const node = $(ref.getNode());
-
-		return node.length ? node.offset().top + node.outerHeight() : 0;
-	};
-
-	const getMessageScrollPosition = (id: string): number => {
-		const ref = messageRefs.current[id];
-		if (!ref) {
-			return 0;
-		};
-
-		const node = $(ref.getNode());
-		return node.length ? node.position().top + node.outerHeight() : 0;
-	};
-
-	const getMessagesInViewport = () => {
-		const messages = getMessages();
-		const container = U.Common.getScrollContainer(isPopup);
-		const formHeight = Number($(formRef.current?.getNode()).outerHeight()) || 0;
-		const ch = container.outerHeight();
-		const max = ch - formHeight;
-		const ret = [];
-
-		messages.forEach((it: any) => {
-			const st = getMessageScrollOffset(it.id);
-
-			if ((st >= 0) && (st <= max)) {
-				ret.push(it);
-			};
-		});
-
-		return ret;
-	};
-
-	const getMessageMenuOptions = (message: I.ChatMessage, noControls: boolean): I.Option[] => {
-		const { reactions } = message;
-		const limit = J.Constant.limit.chat.reactions;
-		const self = reactions.filter(it => it.authors.includes(account.id));
-		const noReaction = (self.length >= limit.self) || (reactions.length >= limit.all);
-
-		let options: any[] = [];
-
-		if (message.content.text) {
-			options.push({ id: 'copy', icon: 'chat-copy', name: translate('blockChatCopyText') });
-		};
-
-		options.push({ id: 'link', icon: 'chat-link', name: translate('commonCopyLink') });
-
-		if (message.creator == S.Auth.account.id) {
-			options = options.concat([
-				{ id: 'edit', icon: 'chat-pencil', name: translate('commonEdit') },
-				{ isDiv: true },
-				{ id: 'delete', icon: 'remove-red', name: translate('commonDelete'), color: 'red' },
-			]);
-		};
-
-		if (!noControls) {
-			options = ([
-				!noReaction ? { id: 'reaction', icon: 'chat-reaction', name: translate('blockChatReactionAdd') } : null,
-				{ id: 'reply', icon: 'chat-reply', name: translate('blockChatReply') },
-				options.length ? { isDiv: true } : null,
-			].filter(it => it)).concat(options);
-		};
-
-		return options;
-	};
-
-	const readScrolledMessages = () => {
-		scrolledItems.current = new Set(getMessagesInViewport().map(it => it.id));
-		onReadStop();
-	};
-
-	const loadAndScrollToMessage = (id: string) => {
-		if (!id) {
-			return;
-		};
-
-		const subId = getSubId();
-		const message = S.Chat.getMessageById(subId, id);
-
-		if (message) {
-			scrollToMessage(message.id, true, true);
-			return;
-		};
-
-		setLoaded(false);
-		setIsBottom(false);
-
-		C.ChatGetMessagesByIds(chatId, [ id ], (message: any) => {
-			if (message.error.code || !message.messages.length) {
-				return;
-			};
-
-			const first = message.messages[0];
-
-			S.Chat.clear(subId);
-			loadMessagesByOrderId(first.orderId, () => {
-				raf(() => scrollToMessage(first.id, true, true));
-			});
-		});
-	};
-
-	const scrollToMessage = (id: string, animate?: boolean, highlight?: boolean) => {
-		if (!id) {
-			return;
-		};
-
-		const state = S.Chat.getState(subId);
-		const { lastStateId } = state;
-		const message = S.Chat.getMessageById(subId, id);
-
-		if (message) {
-			readMessage(id, message.orderId, lastStateId, I.ChatReadType.Message);
-			readMessage(id, message.orderId, lastStateId, I.ChatReadType.Mention);
-		};
-
-		if (!hasScroll()) {
-			readScrolledMessages();
-			return;
-		};
-
-		raf(() => {
-			const container = U.Common.getScrollContainer(isPopup);
-			const top = getMessageScrollPosition(id);
-			const y = Math.max(0, top - container.height() / 2 - J.Size.header);
-
-			setIsBottom(false);
-			setAutoLoadDisabled(true);
-
-			const cb = () => {
-				readScrolledMessages();
-
-				if (highlight) {
-					highlightMessage(id);
-				};
-
-				window.setTimeout(() => setAutoLoadDisabled(false), 50);
-			};
-
-			if (animate) {
-				container.stop(true, true).animate({ scrollTop: y }, 300, cb);
-			} else {
-				container.scrollTop(y);
-				cb();
-			};
-		});
-	};
-
-	const scrollToBottom = (animate?: boolean) => {
-		setIsBottom(true);
-
-		if (!hasScroll()) {
-			readScrolledMessages();
-			return;
-		};
-
-		raf(() => {
-			const y = U.Common.getMaxScrollHeight(isPopup);
-			const top = U.Common.getScrollContainerTop(isPopup);
-
-			if (top >= y) {
-				return;
-			};
-
-			const container = U.Common.getScrollContainer(isPopup);
-			const cb = () => {
-				readScrolledMessages();
-				window.setTimeout(() => setAutoLoadDisabled(false), 50);
-			};
-
-			setAutoLoadDisabled(true);
-
-			if (animate) {
-				container.stop(true, true).animate({ scrollTop: y }, 300, cb);
-			} else {
-				container.scrollTop(y);
-				cb();
-			};
-		});
-	};
-
-	const scrollToBottomCheck = () => {
-		if (isBottom.current) {
-			scrollToBottom(false);
-		};
-	};
-
-	const onScrollToBottomClick = () => {
-		if (jumpIds.current.length) {
-			const idx = jumpIds.current.length - 1;
-			const id = jumpIds.current[idx];
-			const ref = messageRefs.current[id];
-			const container = U.Common.getScrollContainer(isPopup);
-			const threshold = container.outerHeight() / 2;
-
-			jumpIds.current.splice(idx, 1);
-			if (ref && (getMessageScrollOffset(id) < threshold)) {
-				onScrollToBottomClick();
-			} else {
-				scrollToMessage(id, true, true);
-			};
-		} else {
-			loadMessages(1, true, () => scrollToBottom(true));
-		};
-	};
-
-	const onReplyEdit = (e: MouseEvent, message: any) => {
-		formRef.current.onReply(message);
-		scrollToBottomCheck();
-	};
-
-	const onReplyClick = (e: MouseEvent, item: any) => {
-		jumpIds.current.push(item.id);
-		loadAndScrollToMessage(item.replyToMessageId);
-		analytics.event('ClickScrollToReply', { chatId: analyticsChatId });
-	};
-
-	const getReplyContent = (message: any): { title: string; text: string; attachment: any; isMultiple: boolean; } => {
-		const subId = getSubId();
-		const { creator, content } = message;
-		const author = U.Space.getParticipant(U.Space.getParticipantId(S.Common.space, creator));
-		const title = U.String.sprintf(translate('blockChatReplying'), author?.name);
-		const layouts = U.Object.getFileLayouts().concat(I.ObjectLayout.Bookmark);
-		const attachments = (message.attachments || []).map(it => S.Detail.get(subId, it.target)).filter(it => !it._empty_ && !it.isDeleted);
-		const length = attachments.length;
-
-		let text: string = '';
-		let attachmentText: string = '';
-		let attachment: any = null;
-		let isMultiple: boolean = false;
-
-		if (content.text) {
-			text = U.String.sanitize(Mark.toHtml(content.text, content.marks));
-			text = text.replace(/\n\r?/g, ' ');
-		};
-
-		if (!length) {
-			return { title, text, attachment: null, isMultiple: false };
-		};
-
-		const first = attachments[0];
-
-		if (length == 1) {
-			attachmentText = first.name || U.Common.plural(1, translate('pluralAttachment'));
-			attachment = first;
-		} else {
-			let attachmentLayout = I.ObjectLayout[first.layout];
-
-			attachment = null;
-			attachments.forEach((el) => {
-				if ((I.ObjectLayout[el.layout] != attachmentLayout) || !layouts.includes(el.layout)) {
-					isMultiple = true;
-					attachment = first;
-					attachmentLayout = 'Attachment';
-				};
-			});
-
-			attachmentText = text.length ? 
-				`${U.Common.plural(length, translate(`plural${attachmentLayout}`))} (${length})` : 
-				`${length} ${U.Common.plural(length, translate(`plural${attachmentLayout}`)).toLowerCase()}`;
-		};
-
-		if (!text) {
-			text = attachmentText;
-			attachment = first;
-		};
-
-		return { title, text, attachment, isMultiple };
-	};
-
-	const onDragOver = (e: DragEvent) => {
-		formRef.current?.onDragOver(e);
-	};
-
-	const onDragLeave = (e: DragEvent) => {
-		formRef.current?.onDragLeave(e);
-	};
-
-	const onDrop = (e: DragEvent) => {
-		formRef.current?.onDrop(e);
-	};
-
-	const setIsBottom = (v: boolean) => {
-		isBottom.current = v;
-
-		const node = $(formRef.current?.getNode());
-		const btn = node.find(`#navigation-${I.ChatReadType.Message}`);
-
-		btn.toggleClass('active', !v);
-
-		if (v) {
-			jumpIds.current = [];
-		};
-	};
-
-	const setAutoLoadDisabled = (v: boolean) => {
-		isAutoLoadDisabled.current = v;
-	};
-
-	const hasScroll = () => {
-		return U.Common.getMaxScrollHeight(isPopup) > 0;
-	};
-
-	const highlightMessage = (id: string, orderId?: string) => {
-		if (!id && !orderId) {
-			return;
-		};
-
-		const subId = getSubId();
-
-		let targetId = id;
-		if (!targetId && orderId) {
-			const target = S.Chat.getMessageByOrderId(subId, orderId);
-
-			if (target) {
-				targetId = target.id;
-			};
-		};
-
-		if (targetId && messageRefs.current[targetId]) {
-			messageRefs.current[targetId].highlight();
-		};
-	};
-
-	const init = () => {
-		setLoaded(false);
-		loadState(() => {
-			const subId = getSubId();
-			const match = keyboard.getMatch(isPopup);
-			const state = S.Chat.getState(subId);
-
-			const cb1 = (orderId: string) => {
-				if (orderId) {
-					loadMessagesByOrderId(orderId, () => {
-						const target = S.Chat.getMessageByOrderId(subId, orderId);
-						if (target) {
-							setFirstUnreadOrderId(target.orderId);
-						} else {
-							loadMessages(1, true, cb2);
-						};
-					});
-				} else {
-					loadMessages(1, true, cb2);
-				};
-			};
-			const cb2 = () => {
-				scrollToBottom(false);
-			};
-
-			if (match.params.messageId) {
-				C.ChatGetMessagesByIds(chatId, [ match.params.messageId ], (message: any) => {
-					if (message.error.code) {
-						return;
-					};
-
-					if (message.messages.length) {
-						cb1(message.messages[0].orderId);
-					} else {
-						cb1(state.messageOrderId);
-					};
-				});
-			} else {
-				cb1(state.messageOrderId);
-			};
-		});
-	};
-
-	const resize = () => {
-		renderDates();
-
-		const container = U.Common.getScrollContainer(isPopup);
-		const ns = block.id + namespace;
-
-		container.off(`scroll.${ns}`);
-		window.clearTimeout(timeoutResize.current);
-		timeoutResize.current = window.setTimeout(() => container.on(`scroll.${ns}`, e => onScroll(e)), 50);
-	};
-
-	const setLoaded = (v: boolean) => {
-		setIsLoaded(v);
-	};
-
-	const sections = getSections();
-	const isEmpty = isLoaded && !messages.length;
-	const items = getItems();
-
-	let content = null;
-	if (isEmpty) {
-		content = <Empty />;
-	} else {
-		content = (
-			<div className="scroll">
-				{items.map((item, i) => {
-					if (item.isSection) {
-						return <SectionDate key={item.key} date={item.createdAt} />;
-					} else {
-						return (
-							<Message
-								ref={ref => {
-									if (ref) {
-										messageRefs.current[item.id] = ref;
-									} else {
-										delete messageRefs.current[item.id];
-									};
-								}}
-								key={item.id}
-								{...props}
-								id={item.id}
-								rootId={chatId}
-								blockId={block.id}
-								subId={subId}
-								analyticsChatId={analyticsChatId}
-								index={i}
-								isNew={item.orderId == firstUnreadOrderId}
-								hasMore={!!getMessageMenuOptions(item, true).length}
-								onContextMenu={e => onContextMenu(e, item)}
-								onMore={e => onContextMenu(e, item, true)}
-								onReplyEdit={e => onReplyEdit(e, item)}
-								onReplyClick={e => onReplyClick(e, item)}
-								getReplyContent={getReplyContent}
-								scrollToBottom={scrollToBottomCheck}
-							/>
-						);
-					};
-				})}
-			</div>
-		);
-	};
-
-	useEffect(() => {
-		rebind();
-
-		return () => {
 			unbind();
 
-			window.clearTimeout(timeoutInterface.current);
-			window.clearTimeout(timeoutScrollStop.current);
-			window.clearTimeout(timeoutResize.current);
+			win.on(`messageAdd.${ns}`, (e, message, subIds) =>
+				onMessageAdd(message, subIds),
+			);
+			win.on(`messageUpdate.${ns}`, (e, message, subIds) =>
+				onMessageAdd(message, subIds),
+			);
+			win.on(`reactionUpdate.${ns}`, () => scrollToBottomCheck());
+			win.on(`focus.${ns}`, () => readScrolledMessages());
+
+			U.Common.getScrollContainer(isPopup).on(`scroll.${ns}`, (e) =>
+				onScroll(e),
+			);
+		};
+
+		const loadDepsAndReplies = (
+			list: I.ChatMessage[],
+			callBack?: () => void,
+		) => {
+			loadReplies(getReplyIds(list), () => {
+				loadDeps(getDepsIds(list), callBack);
+			});
+		};
+
+		const loadState = (callBack?: () => void) => {
+			const chatId = getChatId();
+			const subId = getSubId();
+
+			if (!chatId) {
+				return;
+			}
+
+			C.ChatSubscribeLastMessages(chatId, 1, subId, (message: any) => {
+				if (message.state) {
+					S.Chat.setState(subId, message.state);
+				}
+
+				callBack?.();
+			});
+		};
+
+		const subscribeMessages = (clear: boolean, callBack?: () => void) => {
+			const chatId = getChatId();
+			const subId = getSubId();
+
+			if (!chatId) {
+				return;
+			}
+
+			C.ChatSubscribeLastMessages(
+				chatId,
+				J.Constant.limit.chat.messages,
+				subId,
+				(message: any) => {
+					if (message.error.code) {
+						callBack?.();
+						return;
+					}
+
+					if (message.state) {
+						S.Chat.setState(subId, message.state);
+					}
+
+					const messages = message.messages || [];
+					if (!messages.length) {
+						setLoaded(true);
+						callBack?.();
+						return;
+					}
+
+					loadDepsAndReplies(messages, () => {
+						if (clear) {
+							S.Chat.set(subId, messages);
+						}
+
+						if (messages.length < J.Constant.limit.chat.messages) {
+							setLoaded(true);
+						} else {
+							setDummy(dummy + 1);
+						}
+
+						callBack?.();
+					});
+				},
+			);
+		};
+
+		const loadMessages = (
+			dir: number,
+			clear: boolean,
+			callBack?: () => void,
+		) => {
+			const chatId = getChatId();
+			const subId = getSubId();
+
+			if (!chatId) {
+				return;
+			}
+
+			if (!clear && dir > 0 && isLoaded) {
+				setIsBottom(true);
+				return;
+			}
+
+			if (clear) {
+				subscribeMessages(clear, () => {
+					setIsBottom(true);
+					callBack?.();
+				});
+			} else {
+				const messages = S.Chat.getList(subId);
+				if (!messages.length) {
+					return;
+				}
+
+				const first = messages[0];
+				const before = dir < 0 ? messages[0].orderId : "";
+				const after =
+					dir > 0 ? messages[messages.length - 1].orderId : "";
+
+				if (!before && !after) {
+					return;
+				}
+
+				C.ChatGetMessages(
+					chatId,
+					before,
+					after,
+					J.Constant.limit.chat.messages,
+					false,
+					(message: any) => {
+						if (message.error.code) {
+							setLoaded(true);
+							callBack?.();
+							return;
+						}
+
+						const messages = message.messages || [];
+
+						if (dir > 0) {
+							if (
+								messages.length < J.Constant.limit.chat.messages
+							) {
+								setLoaded(true);
+								setIsBottom(true);
+								subscribeMessages(false);
+							} else {
+								setIsBottom(false);
+							}
+						} else {
+							const y = U.Common.getMaxScrollHeight(isPopup);
+							const top = U.Common.getScrollContainerTop(isPopup);
+
+							setIsBottom(!(top < y));
+						}
+
+						loadDepsAndReplies(messages, () => {
+							if (messages.length) {
+								S.Chat[dir < 0 ? "prepend" : "append"](
+									subId,
+									messages,
+								);
+
+								if (first && dir < 0) {
+									scrollToMessage(first.id);
+								}
+							}
+
+							callBack?.();
+						});
+					},
+				);
+			}
+		};
+
+		const loadMessagesByOrderId = (
+			orderId: string,
+			callBack?: () => void,
+		) => {
+			const chatId = getChatId();
+			if (!chatId) {
+				return;
+			}
+
+			const subId = getSubId();
+			const limit = Math.ceil(J.Constant.limit.chat.messages / 2);
+
+			let list = [];
+
+			C.ChatGetMessages(
+				chatId,
+				orderId,
+				"",
+				limit,
+				true,
+				(message: any) => {
+					if (!message.error.code && message.messages.length) {
+						list = list.concat(message.messages);
+					}
+
+					C.ChatGetMessages(
+						chatId,
+						"",
+						orderId,
+						limit,
+						false,
+						(message: any) => {
+							if (
+								!message.error.code &&
+								message.messages.length
+							) {
+								list = list.concat(message.messages);
+							}
+
+							loadDepsAndReplies(list, () => {
+								S.Chat.set(subId, list);
+								callBack?.();
+							});
+						},
+					);
+				},
+			);
+		};
+
+		const getMessages = () => {
+			return S.Chat.getList(getSubId());
+		};
+
+		const getDepsIds = (list: any[]) => {
+			const subId = getSubId();
+			const markTypes = [I.MarkType.Object, I.MarkType.Mention];
+
+			let attachments = [];
+			let marks = [];
+
+			if (formRef.current) {
+				attachments = attachments.concat(
+					formRef.current
+						.getAttachments()
+						.filter((it) => !it.isTmp)
+						.map((it) => it.id),
+				);
+				marks = marks.concat(formRef.current.getMarks());
+
+				const replyingId = formRef.current.getReplyingId();
+
+				if (replyingId) {
+					const message = S.Chat.getMessageById(subId, replyingId);
+					if (message) {
+						list.push(message);
+					}
+				}
+			}
+
+			list.forEach((it) => {
+				attachments = attachments.concat(
+					(it.attachments || []).map((it) => it.target),
+				);
+				marks = marks.concat(it.content.marks || []);
+			});
+
+			marks = marks
+				.filter((it) => markTypes.includes(it.type) && it.param)
+				.map((it) => it.param);
+
+			return attachments.concat(marks).filter((it) => it);
+		};
+
+		const getReplyIds = (list: any[]) => {
+			return (list || [])
+				.filter((it) => it.replyToMessageId)
+				.map((it) => it.replyToMessageId);
+		};
+
+		const loadDeps = (ids: string[], callBack?: () => void) => {
+			if (!ids.length) {
+				callBack?.();
+				return;
+			}
+
+			U.Subscription.subscribeIds(
+				{
+					subId: getSubId(),
+					ids,
+					noDeps: true,
+					keys: U.Subscription.chatRelationKeys(),
+					updateDetails: true,
+				},
+				callBack,
+			);
+		};
+
+		const loadReplies = (ids: string[], callBack?: () => void) => {
+			if (!ids.length) {
+				callBack?.();
+				return;
+			}
+
+			const chatId = getChatId();
+			const subId = getSubId();
+
+			C.ChatGetMessagesByIds(chatId, ids, (message: any) => {
+				if (!message.error.code) {
+					message.messages.forEach((it) =>
+						S.Chat.setReply(subId, it),
+					);
+				}
+
+				callBack?.();
+			});
+		};
+
+		const getSections = () => {
+			const sections = [];
+
+			const sectionMap = new Map();
+			messages.forEach((item) => {
+				const key = U.Date.dateWithFormat(
+					I.DateFormat.ShortUS,
+					item.createdAt,
+				);
+				let section = sectionMap.get(key);
+
+				if (!section) {
+					section = {
+						createdAt: item.createdAt,
+						key,
+						isSection: true,
+						list: [],
+					};
+					sectionMap.set(key, section);
+					sections.push(section);
+				}
+				section.list.push(item);
+			});
+
+			// Message groups by author/time
+			sections.forEach((section) => {
+				const length = section.list.length;
+
+				for (let i = 0; i < length; ++i) {
+					const prev = section.list[i - 1];
+					const item = section.list[i];
+
+					item.isFirst = false;
+					item.isLast = false;
+
+					if (
+						prev &&
+						(item.creator != prev.creator ||
+							item.createdAt - prev.createdAt >= GROUP_TIME ||
+							item.replyToMessageId)
+					) {
+						item.isFirst = true;
+
+						if (prev) {
+							prev.isLast = true;
+						}
+					}
+				}
+
+				section.list[0].isFirst = true;
+				section.list[length - 1].isLast = true;
+				section.list.sort((c1, c2) => U.Data.sortByOrderId(c1, c2));
+			});
+
+			sections.sort((c1, c2) =>
+				U.Data.sortByNumericKey("createdAt", c1, c2, I.SortType.Asc),
+			);
+
+			return sections;
+		};
+
+		const getItems = () => {
+			let items = [];
+			for (const section of sections) {
+				items.push({
+					key: section.key,
+					createdAt: section.createdAt,
+					isSection: true,
+				});
+				items = items.concat(section.list);
+			}
+			return items;
+		};
+
+		const onMessageAdd = (message: I.ChatMessage, subIds: string[]) => {
+			if (subIds.includes(getSubId())) {
+				loadDepsAndReplies([message], () => scrollToBottomCheck());
+			}
+		};
+
+		const onContextMenu = (e: MouseEvent, item: any, onMore?: boolean) => {
+			if (readonly) {
+				return;
+			}
+
+			const message = `#block-${U.Common.esc(block.id)} #item-${U.Common.esc(item.id)}`;
+			const container = U.Common.getScrollContainer(isPopup);
+
+			const menuParam: Partial<I.MenuParam> = {
+				classNameWrap: "fromBlock",
+				onOpen: () => {
+					$(message).addClass("hover");
+					container.addClass("over");
+				},
+				onClose: () => {
+					$(message).removeClass("hover");
+					container.removeClass("over");
+				},
+				data: {
+					options: getMessageMenuOptions(item, onMore),
+					onSelect: (e, option) => {
+						switch (option.id) {
+							case "reaction": {
+								messageRefs.current[item.id]?.onReactionAdd();
+								break;
+							}
+
+							case "copy": {
+								const block = new M.Block({
+									type: I.BlockType.Text,
+									content: item.content,
+								});
+
+								U.Common.clipboardCopy({
+									text: U.String.sanitize(
+										Mark.insertEmoji(
+											item.content.text,
+											item.content.marks,
+										),
+									),
+									anytype: {
+										range: {
+											from: 0,
+											to: item.content.text.length,
+										},
+										blocks: [block],
+									},
+								});
+
+								analytics.event("ClickMessageMenuCopy", {
+									chatId: analyticsChatId,
+								});
+								break;
+							}
+
+							case "link": {
+								const object = S.Detail.get(rootId, rootId);
+
+								U.Object.copyLink(
+									object,
+									space,
+									"deeplink",
+									"",
+									`&messageId=${item.id}`,
+								);
+								analytics.event("ClickMessageMenuLink", {
+									chatId: analyticsChatId,
+								});
+								break;
+							}
+
+							case "reply": {
+								formRef.current.onReply(item);
+								break;
+							}
+
+							case "edit": {
+								formRef.current.onEdit(item);
+								break;
+							}
+
+							case "delete": {
+								formRef.current.onDelete(item.id);
+								break;
+							}
+						}
+					},
+				},
+			};
+
+			if (onMore) {
+				menuParam.element = `${message} .icon.more`;
+			} else {
+				menuParam.recalcRect = () => ({
+					x: keyboard.mouse.page.x,
+					y: keyboard.mouse.page.y,
+					width: 0,
+					height: 0,
+				});
+			}
+
+			S.Menu.open("select", menuParam);
+		};
+
+		const renderDates = () => {
+			const node = $(nodeRef.current);
+			const dates = node.find(".sectionDate");
+			const offset = J.Size.header + 8;
+			const container = U.Common.getScrollContainer(isPopup);
+			const top = container.offset().top;
+
 			raf.cancel(frameRef.current);
-			messageRefs.current = {};
+			frameRef.current = raf(() => {
+				dates.css({ position: "static", left: "", top: "", width: "" });
+
+				let last = null;
+
+				dates.each((i, item: any) => {
+					item = $(item);
+
+					const y = item.offset().top;
+					if (y <= offset) {
+						last = item;
+					}
+				});
+
+				if (!last && dates.length) {
+					last = dates.first();
+				}
+
+				if (last) {
+					const width = last.outerWidth();
+					const { left } = last.offset();
+
+					last.css({
+						position: "fixed",
+						width,
+						left,
+						top: top + offset,
+					});
+				}
+			});
 		};
-	}, []);
 
-	useEffect(() => {
-		const match = keyboard.getMatch(isPopup);
-	});
+		const onScroll = (e: any) => {
+			const subId = getSubId();
+			const container = U.Common.getScrollContainer(isPopup);
+			const st = Math.ceil(container.scrollTop());
+			const max = U.Common.getMaxScrollHeight(isPopup);
+			const list = getMessagesInViewport();
+			const state = S.Chat.getState(subId);
+			const { lastStateId } = state;
+			const isBottom = st >= max;
 
-	useEffect(() => {
-		rebind();
-		init();
-	}, [ rootId, space, chatId, analyticsChatId ]);
+			setIsBottom(isBottom);
 
-	useLayoutEffect(() => {
-		scrollToBottomCheck();
-	}, [ messages.length ]);
+			if (!isAutoLoadDisabled.current) {
+				if (st <= 0) {
+					loadMessages(-1, false);
+				}
 
-	useLayoutEffect(() => {
-		const target = S.Chat.getMessageByOrderId(subId, firstUnreadOrderId);
-		if (target) {
-			scrollToMessage(target.id);
+				if (isBottom) {
+					loadMessages(1, false);
+				}
+			}
+
+			renderDates();
+
+			if (S.Common.windowIsFocused && list.length) {
+				list.forEach((it) => {
+					scrolledItems.current.add(it.id);
+
+					if (!it.isReadMessage) {
+						readMessage(
+							it.id,
+							it.orderId,
+							lastStateId,
+							I.ChatReadType.Message,
+						);
+					}
+					if (!it.isReadMention && it.hasMention) {
+						readMessage(
+							it.id,
+							it.orderId,
+							lastStateId,
+							I.ChatReadType.Mention,
+						);
+					}
+				});
+			}
+
+			window.clearTimeout(timeoutScrollStop.current);
+			timeoutScrollStop.current = window.setTimeout(
+				() => onReadStop(),
+				300,
+			);
+
+			top.current = st;
+
+			Preview.tooltipHide(true);
+			Preview.previewHide(true);
 		};
-	}, [ firstUnreadOrderId ]);
 
-	useImperativeHandle(ref, () => ({
-		forceUpdate: () => setDummy(dummy + 1),
-		resize,
-		onDragOver,
-		onDragLeave,
-		onDrop,
-		getFormRef: () => formRef.current,
-		loadAndScrollToMessage,
-	}));
+		const readMessage = (
+			id: string,
+			orderId: string,
+			lastStateId: string,
+			type: I.ChatReadType,
+		) => {
+			const chatId = getChatId();
+			const subId = getSubId();
 
-	return (
-		<div 
-			ref={nodeRef}
-			className="wrap"
-			onDragOver={onDragOver} 
-			onDragLeave={onDragLeave} 
-			onDrop={onDrop}
-		>
-			<div id="scrollWrapper" ref={scrollWrapperRef} className="scrollWrapper">
-				{content}
+			if (type == I.ChatReadType.Message) {
+				S.Chat.setReadMessageStatus(subId, [id], true);
+			}
+			if (type == I.ChatReadType.Mention) {
+				S.Chat.setReadMentionStatus(subId, [id], true);
+			}
+
+			C.ChatReadMessages(chatId, orderId, orderId, lastStateId, type);
+		};
+
+		const onReadStop = () => {
+			if (!scrolledItems.current.size) {
+				return;
+			}
+
+			const chatId = getChatId();
+			const subId = getSubId();
+			const ids: string[] = [...scrolledItems.current] as string[];
+			const first = S.Chat.getMessageById(subId, ids[0]);
+			const last = S.Chat.getMessageById(subId, ids[ids.length - 1]);
+			const state = S.Chat.getState(subId);
+			const { lastStateId } = state;
+
+			if (S.Common.windowIsFocused) {
+				if (first && last) {
+					C.ChatReadMessages(
+						chatId,
+						first.orderId,
+						last.orderId,
+						lastStateId,
+						I.ChatReadType.Message,
+					);
+					C.ChatReadMessages(
+						chatId,
+						first.orderId,
+						last.orderId,
+						lastStateId,
+						I.ChatReadType.Mention,
+					);
+				}
+
+				S.Chat.setReadMessageStatus(subId, ids, true);
+				S.Chat.setReadMentionStatus(subId, ids, true);
+			}
+
+			scrolledItems.current.clear();
+		};
+
+		const getMessageScrollOffset = (id: string): number => {
+			const ref = messageRefs.current[id];
+			if (!ref) {
+				return 0;
+			}
+
+			const node = $(ref.getNode());
+
+			return node.length ? node.offset().top + node.outerHeight() : 0;
+		};
+
+		const getMessageScrollPosition = (id: string): number => {
+			const ref = messageRefs.current[id];
+			if (!ref) {
+				return 0;
+			}
+
+			const node = $(ref.getNode());
+			return node.length ? node.position().top + node.outerHeight() : 0;
+		};
+
+		const getMessagesInViewport = () => {
+			const messages = getMessages();
+			const container = U.Common.getScrollContainer(isPopup);
+			const formHeight =
+				Number($(formRef.current?.getNode()).outerHeight()) || 0;
+			const ch = container.outerHeight();
+			const max = ch - formHeight;
+			const ret = [];
+
+			messages.forEach((it: any) => {
+				const st = getMessageScrollOffset(it.id);
+
+				if (st >= 0 && st <= max) {
+					ret.push(it);
+				}
+			});
+
+			return ret;
+		};
+
+		const getMessageMenuOptions = (
+			message: I.ChatMessage,
+			noControls: boolean,
+		): I.Option[] => {
+			const { reactions } = message;
+			const limit = J.Constant.limit.chat.reactions;
+			const self = reactions.filter((it) =>
+				it.authors.includes(account.id),
+			);
+			const noReaction =
+				self.length >= limit.self || reactions.length >= limit.all;
+
+			let options: any[] = [];
+
+			if (message.content.text) {
+				options.push({
+					id: "copy",
+					icon: "chat-copy",
+					name: translate("blockChatCopyText"),
+				});
+			}
+
+			options.push({
+				id: "link",
+				icon: "chat-link",
+				name: translate("commonCopyLink"),
+			});
+
+			if (message.creator == S.Auth.account.id) {
+				options = options.concat([
+					{
+						id: "edit",
+						icon: "chat-pencil",
+						name: translate("commonEdit"),
+					},
+					{ isDiv: true },
+					{
+						id: "delete",
+						icon: "remove-red",
+						name: translate("commonDelete"),
+						color: "red",
+					},
+				]);
+			}
+
+			if (!noControls) {
+				options = [
+					!noReaction
+						? {
+								id: "reaction",
+								icon: "chat-reaction",
+								name: translate("blockChatReactionAdd"),
+							}
+						: null,
+					{
+						id: "reply",
+						icon: "chat-reply",
+						name: translate("blockChatReply"),
+					},
+					options.length ? { isDiv: true } : null,
+				]
+					.filter((it) => it)
+					.concat(options);
+			}
+
+			return options;
+		};
+
+		const readScrolledMessages = () => {
+			scrolledItems.current = new Set(
+				getMessagesInViewport().map((it) => it.id),
+			);
+			onReadStop();
+		};
+
+		const loadAndScrollToMessage = (id: string) => {
+			if (!id) {
+				return;
+			}
+
+			const subId = getSubId();
+			const message = S.Chat.getMessageById(subId, id);
+
+			if (message) {
+				scrollToMessage(message.id, true, true);
+				return;
+			}
+
+			setLoaded(false);
+			setIsBottom(false);
+
+			C.ChatGetMessagesByIds(chatId, [id], (message: any) => {
+				if (message.error.code || !message.messages.length) {
+					return;
+				}
+
+				const first = message.messages[0];
+
+				S.Chat.clear(subId);
+				loadMessagesByOrderId(first.orderId, () => {
+					raf(() => scrollToMessage(first.id, true, true));
+				});
+			});
+		};
+
+		const scrollToMessage = (
+			id: string,
+			animate?: boolean,
+			highlight?: boolean,
+		) => {
+			if (!id) {
+				return;
+			}
+
+			const state = S.Chat.getState(subId);
+			const { lastStateId } = state;
+			const message = S.Chat.getMessageById(subId, id);
+
+			if (message) {
+				readMessage(
+					id,
+					message.orderId,
+					lastStateId,
+					I.ChatReadType.Message,
+				);
+				readMessage(
+					id,
+					message.orderId,
+					lastStateId,
+					I.ChatReadType.Mention,
+				);
+			}
+
+			if (!hasScroll()) {
+				readScrolledMessages();
+				return;
+			}
+
+			raf(() => {
+				const container = U.Common.getScrollContainer(isPopup);
+				const top = getMessageScrollPosition(id);
+				const y = Math.max(
+					0,
+					top - container.height() / 2 - J.Size.header,
+				);
+
+				setIsBottom(false);
+				setAutoLoadDisabled(true);
+
+				const cb = () => {
+					readScrolledMessages();
+
+					if (highlight) {
+						highlightMessage(id);
+					}
+
+					window.setTimeout(() => setAutoLoadDisabled(false), 50);
+				};
+
+				if (animate) {
+					container
+						.stop(true, true)
+						.animate({ scrollTop: y }, 300, cb);
+				} else {
+					container.scrollTop(y);
+					cb();
+				}
+			});
+		};
+
+		const scrollToBottom = (animate?: boolean) => {
+			setIsBottom(true);
+
+			if (!hasScroll()) {
+				readScrolledMessages();
+				return;
+			}
+
+			raf(() => {
+				const y = U.Common.getMaxScrollHeight(isPopup);
+				const top = U.Common.getScrollContainerTop(isPopup);
+
+				if (top >= y) {
+					return;
+				}
+
+				const container = U.Common.getScrollContainer(isPopup);
+				const cb = () => {
+					readScrolledMessages();
+					window.setTimeout(() => setAutoLoadDisabled(false), 50);
+				};
+
+				setAutoLoadDisabled(true);
+
+				if (animate) {
+					container
+						.stop(true, true)
+						.animate({ scrollTop: y }, 300, cb);
+				} else {
+					container.scrollTop(y);
+					cb();
+				}
+			});
+		};
+
+		const scrollToBottomCheck = () => {
+			if (isBottom.current) {
+				scrollToBottom(false);
+			}
+		};
+
+		const onScrollToBottomClick = () => {
+			if (jumpIds.current.length) {
+				const idx = jumpIds.current.length - 1;
+				const id = jumpIds.current[idx];
+				const ref = messageRefs.current[id];
+				const container = U.Common.getScrollContainer(isPopup);
+				const threshold = container.outerHeight() / 2;
+
+				jumpIds.current.splice(idx, 1);
+				if (ref && getMessageScrollOffset(id) < threshold) {
+					onScrollToBottomClick();
+				} else {
+					scrollToMessage(id, true, true);
+				}
+			} else {
+				loadMessages(1, true, () => scrollToBottom(true));
+			}
+		};
+
+		const onReplyEdit = (e: MouseEvent, message: any) => {
+			formRef.current.onReply(message);
+			scrollToBottomCheck();
+		};
+
+		const onReplyClick = (e: MouseEvent, item: any) => {
+			jumpIds.current.push(item.id);
+			loadAndScrollToMessage(item.replyToMessageId);
+			analytics.event("ClickScrollToReply", { chatId: analyticsChatId });
+		};
+
+		const getReplyContent = (
+			message: any,
+		): {
+			title: string;
+			text: string;
+			attachment: any;
+			isMultiple: boolean;
+		} => {
+			const subId = getSubId();
+			const { creator, content } = message;
+			const author = U.Space.getParticipant(
+				U.Space.getParticipantId(S.Common.space, creator),
+			);
+			const title = U.String.sprintf(
+				translate("blockChatReplying"),
+				author?.name,
+			);
+			const layouts = U.Object.getFileLayouts().concat(
+				I.ObjectLayout.Bookmark,
+			);
+			const attachments = (message.attachments || [])
+				.map((it) => S.Detail.get(subId, it.target))
+				.filter((it) => !it._empty_ && !it.isDeleted);
+			const length = attachments.length;
+
+			let text: string = "";
+			let attachmentText: string = "";
+			let attachment: any = null;
+			let isMultiple: boolean = false;
+
+			if (content.text) {
+				text = U.String.sanitize(
+					Mark.toHtml(content.text, content.marks),
+				);
+				text = text.replace(/\n\r?/g, " ");
+			}
+
+			if (!length) {
+				return { title, text, attachment: null, isMultiple: false };
+			}
+
+			const first = attachments[0];
+
+			if (length == 1) {
+				attachmentText =
+					first.name ||
+					U.Common.plural(1, translate("pluralAttachment"));
+				attachment = first;
+			} else {
+				let attachmentLayout = I.ObjectLayout[first.layout];
+
+				attachment = null;
+				attachments.forEach((el) => {
+					if (
+						I.ObjectLayout[el.layout] != attachmentLayout ||
+						!layouts.includes(el.layout)
+					) {
+						isMultiple = true;
+						attachment = first;
+						attachmentLayout = "Attachment";
+					}
+				});
+
+				attachmentText = text.length
+					? `${U.Common.plural(length, translate(`plural${attachmentLayout}`))} (${length})`
+					: `${length} ${U.Common.plural(length, translate(`plural${attachmentLayout}`)).toLowerCase()}`;
+			}
+
+			if (!text) {
+				text = attachmentText;
+				attachment = first;
+			}
+
+			return { title, text, attachment, isMultiple };
+		};
+
+		const onDragOver = (e: DragEvent) => {
+			formRef.current?.onDragOver(e);
+		};
+
+		const onDragLeave = (e: DragEvent) => {
+			formRef.current?.onDragLeave(e);
+		};
+
+		const onDrop = (e: DragEvent) => {
+			formRef.current?.onDrop(e);
+		};
+
+		const setIsBottom = (v: boolean) => {
+			isBottom.current = v;
+
+			const node = $(formRef.current?.getNode());
+			const btn = node.find(`#navigation-${I.ChatReadType.Message}`);
+
+			btn.toggleClass("active", !v);
+
+			if (v) {
+				jumpIds.current = [];
+			}
+		};
+
+		const setAutoLoadDisabled = (v: boolean) => {
+			isAutoLoadDisabled.current = v;
+		};
+
+		const hasScroll = () => {
+			return U.Common.getMaxScrollHeight(isPopup) > 0;
+		};
+
+		const highlightMessage = (id: string, orderId?: string) => {
+			if (!id && !orderId) {
+				return;
+			}
+
+			const subId = getSubId();
+
+			let targetId = id;
+			if (!targetId && orderId) {
+				const target = S.Chat.getMessageByOrderId(subId, orderId);
+
+				if (target) {
+					targetId = target.id;
+				}
+			}
+
+			if (targetId && messageRefs.current[targetId]) {
+				messageRefs.current[targetId].highlight();
+			}
+		};
+
+		const init = () => {
+			setLoaded(false);
+			loadState(() => {
+				const subId = getSubId();
+				const match = keyboard.getMatch(isPopup);
+				const state = S.Chat.getState(subId);
+
+				const cb1 = (orderId: string) => {
+					if (orderId) {
+						loadMessagesByOrderId(orderId, () => {
+							const target = S.Chat.getMessageByOrderId(
+								subId,
+								orderId,
+							);
+							if (target) {
+								setFirstUnreadOrderId(target.orderId);
+							} else {
+								loadMessages(1, true, cb2);
+							}
+						});
+					} else {
+						loadMessages(1, true, cb2);
+					}
+				};
+				const cb2 = () => {
+					scrollToBottom(false);
+				};
+
+				if (match.params.messageId) {
+					C.ChatGetMessagesByIds(
+						chatId,
+						[match.params.messageId],
+						(message: any) => {
+							if (message.error.code) {
+								return;
+							}
+
+							if (message.messages.length) {
+								cb1(message.messages[0].orderId);
+							} else {
+								cb1(state.messageOrderId);
+							}
+						},
+					);
+				} else {
+					cb1(state.messageOrderId);
+				}
+			});
+		};
+
+		const resize = () => {
+			renderDates();
+
+			const container = U.Common.getScrollContainer(isPopup);
+			const ns = block.id + namespace;
+
+			container.off(`scroll.${ns}`);
+			window.clearTimeout(timeoutResize.current);
+			timeoutResize.current = window.setTimeout(
+				() => container.on(`scroll.${ns}`, (e) => onScroll(e)),
+				50,
+			);
+		};
+
+		const setLoaded = (v: boolean) => {
+			setIsLoaded(v);
+		};
+
+		const sections = getSections();
+		const isEmpty = isLoaded && !messages.length;
+		const items = getItems();
+
+		let content = null;
+		if (isEmpty) {
+			content = <Empty />;
+		} else {
+			content = (
+				<div className="scroll">
+					{items.map((item, i) => {
+						if (item.isSection) {
+							return (
+								<SectionDate
+									key={item.key}
+									date={item.createdAt}
+								/>
+							);
+						} else {
+							return (
+								<Message
+									ref={(ref) => {
+										if (ref) {
+											messageRefs.current[item.id] = ref;
+										} else {
+											delete messageRefs.current[item.id];
+										}
+									}}
+									key={item.id}
+									{...props}
+									id={item.id}
+									rootId={chatId}
+									blockId={block.id}
+									subId={subId}
+									analyticsChatId={analyticsChatId}
+									index={i}
+									isNew={item.orderId == firstUnreadOrderId}
+									hasMore={
+										!!getMessageMenuOptions(item, true)
+											.length
+									}
+									onContextMenu={(e) =>
+										onContextMenu(e, item)
+									}
+									onMore={(e) => onContextMenu(e, item, true)}
+									onReplyEdit={(e) => onReplyEdit(e, item)}
+									onReplyClick={(e) => onReplyClick(e, item)}
+									getReplyContent={getReplyContent}
+									scrollToBottom={scrollToBottomCheck}
+								/>
+							);
+						}
+					})}
+				</div>
+			);
+		}
+
+		useEffect(() => {
+			rebind();
+
+			return () => {
+				unbind();
+
+				window.clearTimeout(timeoutInterface.current);
+				window.clearTimeout(timeoutScrollStop.current);
+				window.clearTimeout(timeoutResize.current);
+				raf.cancel(frameRef.current);
+				messageRefs.current = {};
+			};
+		}, []);
+
+		useEffect(() => {
+			const match = keyboard.getMatch(isPopup);
+		});
+
+		useEffect(() => {
+			rebind();
+			init();
+		}, [rootId, space, chatId, analyticsChatId]);
+
+		useLayoutEffect(() => {
+			scrollToBottomCheck();
+		}, [messages.length]);
+
+		useLayoutEffect(() => {
+			const target = S.Chat.getMessageByOrderId(
+				subId,
+				firstUnreadOrderId,
+			);
+			if (target) {
+				scrollToMessage(target.id);
+			}
+		}, [firstUnreadOrderId]);
+
+		useImperativeHandle(ref, () => ({
+			forceUpdate: () => setDummy(dummy + 1),
+			resize,
+			onDragOver,
+			onDragLeave,
+			onDrop,
+			getFormRef: () => formRef.current,
+			loadAndScrollToMessage,
+		}));
+
+		return (
+			<div
+				ref={nodeRef}
+				className="wrap"
+				onDragOver={onDragOver}
+				onDragLeave={onDragLeave}
+				onDrop={onDrop}
+			>
+				<div
+					id="scrollWrapper"
+					ref={scrollWrapperRef}
+					className="scrollWrapper"
+				>
+					{content}
+				</div>
+
+				<Form
+					ref={formRef}
+					{...props}
+					rootId={chatId}
+					blockId={block.id}
+					subId={subId}
+					analyticsChatId={analyticsChatId}
+					onScrollToBottomClick={onScrollToBottomClick}
+					scrollToBottom={scrollToBottomCheck}
+					scrollToMessage={scrollToMessage}
+					loadMessagesByOrderId={loadMessagesByOrderId}
+					getMessages={getMessages}
+					getReplyContent={getReplyContent}
+					highlightMessage={highlightMessage}
+					loadDepsAndReplies={loadDepsAndReplies}
+					isEmpty={isEmpty}
+				/>
 			</div>
-
-			<Form 
-				ref={formRef}
-				{...props}
-				rootId={chatId}
-				blockId={block.id}
-				subId={subId}
-				analyticsChatId={analyticsChatId}
-				onScrollToBottomClick={onScrollToBottomClick}
-				scrollToBottom={scrollToBottomCheck}
-				scrollToMessage={scrollToMessage}
-				loadMessagesByOrderId={loadMessagesByOrderId}
-				getMessages={getMessages}
-				getReplyContent={getReplyContent}
-				highlightMessage={highlightMessage}
-				loadDepsAndReplies={loadDepsAndReplies}
-				isEmpty={isEmpty}
-			/>
-		</div>
-	);
-
-}));
+		);
+	}),
+);
 
 export default BlockChat;

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -1,15 +1,17 @@
-import { observable, action, makeObservable, set } from 'mobx';
-import { J, I, U, M, S, Renderer, Mark } from 'Lib';
+import { observable, action, makeObservable, set } from "mobx";
+import { J, I, U, M, S, Renderer, Mark } from "Lib";
 
 class ChatStore {
-
 	public messageMap: Map<string, any[]> = observable(new Map());
-	public replyMap: Map<string, Map<string, I.ChatMessage>> = observable(new Map());
-	public stateMap: Map<string, Map<string, I.ChatStoreState>> = observable.map(new Map());
+	public replyMap: Map<string, Map<string, I.ChatMessage>> = observable(
+		new Map(),
+	);
+	public stateMap: Map<string, Map<string, I.ChatStoreState>> =
+		observable.map(new Map());
 	public attachmentsMap: Map<string, any[]> = observable(new Map());
-	private badgeValue = '';
+	private badgeValue = "";
 
-	constructor () {
+	constructor() {
 		makeObservable(this, {
 			add: action,
 			update: action,
@@ -18,47 +20,47 @@ class ChatStore {
 			setState: action,
 			setAttachments: action,
 		});
-	};
+	}
 
 	/**
 	 * Sets the chat message list for a subId.
 	 * @param {string} subId - The subscription ID.
 	 * @param {I.ChatMessage[]} list - The chat messages.
 	 */
-	set (subId: string, list: I.ChatMessage[]): void {
-		list = list.map(it => new M.ChatMessage(it));
-		list = U.Common.arrayUniqueObjects(list, 'id');
-		
+	set(subId: string, list: I.ChatMessage[]): void {
+		list = list.map((it) => new M.ChatMessage(it));
+		list = U.Common.arrayUniqueObjects(list, "id");
+
 		this.messageMap.set(subId, observable.array(list));
-	};
+	}
 
 	/**
 	 * Prepends chat messages to the list for a subId.
 	 * @param {string} subId - The subscription ID.
 	 * @param {I.ChatMessage[]} add - The chat messages to prepend.
 	 */
-	prepend (subId: string, add: I.ChatMessage[]): void {
-		const ids = this.getList(subId).map(it => it.id);
+	prepend(subId: string, add: I.ChatMessage[]): void {
+		const ids = new Set(this.getList(subId).map((it) => it.id));
 
-		add = (add || []).filter(it => !ids.includes(it.id));
-		add = add.map(it => new M.ChatMessage(it));
+		add = (add || []).filter((it) => !ids.has(it.id));
+		add = add.map((it) => new M.ChatMessage(it));
 
 		this.getList(subId).unshift(...add);
-	};
+	}
 
 	/**
 	 * Appends chat messages to the list for a subId.
 	 * @param {string} subId - The subscription ID.
 	 * @param {I.ChatMessage[]} add - The chat messages to append.
 	 */
-	append (subId: string, add: I.ChatMessage[]): void {
-		const ids = this.getList(subId).map(it => it.id);
+	append(subId: string, add: I.ChatMessage[]): void {
+		const ids = new Set(this.getList(subId).map((it) => it.id));
 
-		add = (add || []).filter(it => !ids.includes(it.id));
-		add = add.map(it => new M.ChatMessage(it));
+		add = (add || []).filter((it) => !ids.has(it.id));
+		add = add.map((it) => new M.ChatMessage(it));
 
 		this.getList(subId).push(...add);
-	};
+	}
 
 	/**
 	 * Adds a chat message at a specific index.
@@ -66,52 +68,55 @@ class ChatStore {
 	 * @param {number} idx - The index to insert at.
 	 * @param {I.ChatMessage} param - The chat message to add.
 	 */
-	add (subId: string, idx: number, param: I.ChatMessage): void {
+	add(subId: string, idx: number, param: I.ChatMessage): void {
 		const list = this.getList(subId);
 		const item = this.getMessageById(subId, param.id);
-		
+
 		if (item) {
 			return;
-		};
+		}
 
 		list.splice(idx, 0, param);
 		this.set(subId, list);
-	};
+	}
 
 	/**
 	 * Updates a chat message by ID.
 	 * @param {string} subId - The subscription ID.
 	 * @param {Partial<I.ChatMessage>} param - The chat message update.
 	 */
-	update (subId: string, param: Partial<I.ChatMessage>): void {
+	update(subId: string, param: Partial<I.ChatMessage>): void {
 		const item = this.getMessageById(subId, param.id);
 
 		if (item) {
 			set(item, param);
-		};
-	};
+		}
+	}
 
 	/**
 	 * Deletes a chat message by ID.
 	 * @param {string} subId - The subscription ID.
 	 * @param {string} id - The chat message ID.
 	 */
-	delete (subId: string, id: string) {
-		this.set(subId, this.getList(subId).filter(it => it.id != id));
-	};
+	delete(subId: string, id: string) {
+		this.set(
+			subId,
+			this.getList(subId).filter((it) => it.id != id),
+		);
+	}
 
 	/**
 	 * Sets a reply message for a subId.
 	 * @param {string} subId - The subscription ID.
 	 * @param {I.ChatMessage} message - The reply message.
 	 */
-	setReply (subId: string, message: I.ChatMessage) {
+	setReply(subId: string, message: I.ChatMessage) {
 		const map = this.replyMap.get(subId) || new Map();
 
 		map.set(message.id, message);
 
 		this.replyMap.set(subId, map);
-	};
+	}
 
 	/**
 	 * Sets the read status for messages by IDs.
@@ -119,9 +124,11 @@ class ChatStore {
 	 * @param {string[]} ids - The message IDs.
 	 * @param {boolean} value - The read status value.
 	 */
-	setReadMessageStatus (subId: string, ids: string[], value: boolean) {
-		(ids || []).forEach(id => this.update(subId, { id, isReadMessage: value }));
-	};
+	setReadMessageStatus(subId: string, ids: string[], value: boolean) {
+		(ids || []).forEach((id) =>
+			this.update(subId, { id, isReadMessage: value }),
+		);
+	}
 
 	/**
 	 * Sets the read mention status for messages by IDs.
@@ -129,9 +136,11 @@ class ChatStore {
 	 * @param {string[]} ids - The message IDs.
 	 * @param {boolean} value - The read mention status value.
 	 */
-	setReadMentionStatus (subId: string, ids: string[], value: boolean) {
-		(ids || []).forEach(id => this.update(subId, { id, isReadMention: value }));
-	};
+	setReadMentionStatus(subId: string, ids: string[], value: boolean) {
+		(ids || []).forEach((id) =>
+			this.update(subId, { id, isReadMention: value }),
+		);
+	}
 
 	/**
 	 * Sets the synced status for messages by IDs.
@@ -139,9 +148,11 @@ class ChatStore {
 	 * @param {string[]} ids - The message IDs.
 	 * @param {boolean} value - The read mention status value.
 	 */
-	setSyncStatus (subId: string, ids: string[], value: boolean) {
-		(ids || []).forEach(id => this.update(subId, { id, isSynced: value }));
-	};
+	setSyncStatus(subId: string, ids: string[], value: boolean) {
+		(ids || []).forEach((id) =>
+			this.update(subId, { id, isSynced: value }),
+		);
+	}
 
 	/**
 	 * Creates a chat state object with observables.
@@ -149,7 +160,7 @@ class ChatStore {
 	 * @param {I.ChatState} state - The chat state input.
 	 * @returns {ChatState} The created chat state object.
 	 */
-	private createState (state: I.ChatState): I.ChatStoreState {
+	private createState(state: I.ChatState): I.ChatStoreState {
 		const { messages, mentions, lastStateId, order } = state;
 		const el = {
 			messageOrderId: messages.orderId,
@@ -170,7 +181,7 @@ class ChatStore {
 		});
 
 		return el;
-	};
+	}
 
 	/**
 	 * Parses a subId into its components.
@@ -178,44 +189,56 @@ class ChatStore {
 	 * @param {string} subId - The subscription ID.
 	 * @returns {{ prefix: string; spaceId: string; chatId: string; tabId: string }} The parsed parameters.
 	 */
-	private getSubParam (subId: string): { prefix: string; spaceId: string; chatId: string; tabId: string } {
-		subId = String(subId || '');
+	private getSubParam(subId: string): {
+		prefix: string;
+		spaceId: string;
+		chatId: string;
+		tabId: string;
+	} {
+		subId = String(subId || "");
 
-		const [ prefix, spaceId, chatId, tabId ] = subId.split('-');
+		const [prefix, spaceId, chatId, tabId] = subId.split("-");
 
 		if (prefix == J.Constant.subId.chatSpace) {
 			return { prefix, spaceId, chatId, tabId };
 		} else {
-			const [ rootId, blockId ] = chatId.split(':');
-			return { prefix: '', spaceId, chatId: rootId, tabId };
-		};
-	};
+			const [rootId, blockId] = chatId.split(":");
+			return { prefix: "", spaceId, chatId: rootId, tabId };
+		}
+	}
 
 	/**
 	 * Gets the subscription ID for a space and chat.
 	 * @param {string} spaceId - The space ID.
 	 * @returns {string} The subscription ID.
 	 */
-	getSpaceSubId (spaceId: string): string {
-		return [ J.Constant.subId.chatSpace, spaceId, '', S.Common.tabId ].join('-');
-	};
+	getSpaceSubId(spaceId: string): string {
+		return [J.Constant.subId.chatSpace, spaceId, "", S.Common.tabId].join(
+			"-",
+		);
+	}
 
 	/**
 	 * Gets the subscription ID for a space and chat.
-	 * @param {string} spaceId - The space ID.	
+	 * @param {string} spaceId - The space ID.
 	 * @param {string} chatId - The chat ID.
 	 * @returns {string} The subscription ID.
 	 */
-	getChatSubId (prefix: string, spaceId: string, chatId: string): string {
-		return [ prefix, spaceId, `${chatId}:${J.Constant.blockId.chat}`, S.Common.tabId ].join('-');
-	};
+	getChatSubId(prefix: string, spaceId: string, chatId: string): string {
+		return [
+			prefix,
+			spaceId,
+			`${chatId}:${J.Constant.blockId.chat}`,
+			S.Common.tabId,
+		].join("-");
+	}
 
 	/**
 	 * Sets the chat state for a subId.
 	 * @param {string} subId - The subscription ID.
 	 * @param {I.ChatState} state - The chat state.
 	 */
-	setState (subId: string, state: I.ChatState) {
+	setState(subId: string, state: I.ChatState) {
 		const param = this.getSubParam(subId);
 		const spaceMap = this.stateMap.get(param.spaceId) || new Map();
 		const current = spaceMap.get(param.chatId);
@@ -224,9 +247,9 @@ class ChatStore {
 			const { messages, mentions, lastStateId, order } = state;
 
 			// Ignore outdated state
-			if (current.order && order && (order < current.order)) {
+			if (current.order && order && order < current.order) {
 				return;
-			};
+			}
 
 			set(current, {
 				messageOrderId: messages.orderId,
@@ -238,59 +261,62 @@ class ChatStore {
 			});
 		} else {
 			spaceMap.set(param.chatId, this.createState(state));
-		};
+		}
 
 		this.stateMap.set(param.spaceId, spaceMap);
 		this.setBadge();
-	};
+	}
 
 	/**
 	 * Gets the chat state for a subId.
 	 * @param {string} subId - The subscription ID.
 	 * @returns {ChatState} The chat state.
 	 */
-	getState (subId: string): I.ChatStoreState {
+	getState(subId: string): I.ChatStoreState {
 		const param = this.getSubParam(subId);
 		const ret = {
-			messageOrderId: '',
+			messageOrderId: "",
 			messageCounter: 0,
-			mentionOrderId: '',
+			mentionOrderId: "",
 			mentionCounter: 0,
-			lastStateId: '',
+			lastStateId: "",
 			order: 0,
 		};
 
-		return Object.assign(ret, this.stateMap.get(param.spaceId)?.get(param.chatId) || {});
-	};
+		return Object.assign(
+			ret,
+			this.stateMap.get(param.spaceId)?.get(param.chatId) || {},
+		);
+	}
 
 	/**
 	 * Clears all chat data for a subId.
 	 * @param {string} subId - The subscription ID.
 	 */
-	clear (subId: string) {
+	clear(subId: string) {
 		this.messageMap.delete(subId);
 		this.replyMap.delete(subId);
 		this.attachmentsMap.delete(subId);
-	};
+	}
 
 	/**
 	 * Clears all chat data in the store.
 	 */
-	clearAll () {
+	clearAll() {
 		this.messageMap.clear();
 		this.replyMap.clear();
 		this.stateMap.clear();
 		this.attachmentsMap.clear();
-	};
+	}
 
 	/**
 	 * Gets the chat message list for a subId.
 	 * @param {string} subId - The subscription ID.
 	 * @returns {any[]} The chat messages.
 	 */
-	getList (subId: string): any[] {
+	getList(subId: string): any[] {
 		return this.messageMap.get(subId) || [];
-	};
+	}
 
 	/**
 	 * Gets a chat message by ID.
@@ -298,9 +324,9 @@ class ChatStore {
 	 * @param {string} id - The chat message ID.
 	 * @returns {I.ChatMessage} The chat message.
 	 */
-	getMessageById (subId: string, id: string): I.ChatMessage {
-		return this.getList(subId).find(it => it.id == id);
-	};
+	getMessageById(subId: string, id: string): I.ChatMessage {
+		return this.getList(subId).find((it) => it.id == id);
+	}
 
 	/**
 	 * Gets a chat message by order ID.
@@ -308,9 +334,9 @@ class ChatStore {
 	 * @param {string} orderId - The chat message order ID.
 	 * @returns {I.ChatMessage} The chat message.
 	 */
-	getMessageByOrderId (subId: string, orderId: string): I.ChatMessage {
-		return this.getList(subId).find(it => it.orderId == orderId);
-	};
+	getMessageByOrderId(subId: string, orderId: string): I.ChatMessage {
+		return this.getList(subId).find((it) => it.orderId == orderId);
+	}
 
 	/**
 	 * Gets a reply message by ID.
@@ -318,21 +344,21 @@ class ChatStore {
 	 * @param {string} id - The reply message ID.
 	 * @returns {I.ChatMessage} The reply message.
 	 */
-	getReply (subId: string, id: string): I.ChatMessage {
+	getReply(subId: string, id: string): I.ChatMessage {
 		return this.replyMap.get(subId)?.get(id);
-	};
+	}
 
 	/**
 	 * Gets the total mention and message counters for all spaces.
 	 * @returns {Counter} The total counters.
 	 */
-	getTotalCounters (): I.ChatCounter {
+	getTotalCounters(): I.ChatCounter {
 		const spaces = U.Space.getList();
 		const ret = { mentionCounter: 0, messageCounter: 0 };
 
 		if (!spaces.length) {
 			return ret;
-		};
+		}
 
 		for (const space of spaces) {
 			const spaceId = space.targetSpaceId;
@@ -340,34 +366,50 @@ class ChatStore {
 
 			if (!spaceMap) {
 				continue;
-			};
+			}
 
 			const spaceview = U.Space.getSpaceviewBySpaceId(spaceId);
 
-			for (const [ chatId, state ] of spaceMap) {
+			for (const [chatId, state] of spaceMap) {
 				if (!chatId) {
 					continue;
-				};
+				}
 
-				const chat = S.Detail.get(J.Constant.subId.chatGlobal, chatId, []);
+				const chat = S.Detail.get(
+					J.Constant.subId.chatGlobal,
+					chatId,
+					[],
+				);
 				if (chat._empty_ || chat.isArchived) {
 					continue;
-				};
+				}
 
-				const chatMode = U.Object.getChatNotificationMode(spaceview, chatId);
+				const chatMode = U.Object.getChatNotificationMode(
+					spaceview,
+					chatId,
+				);
 
-				if (state.mentionCounter && [ I.NotificationMode.All, I.NotificationMode.Mentions ].includes(chatMode)) {
+				if (
+					state.mentionCounter &&
+					[
+						I.NotificationMode.All,
+						I.NotificationMode.Mentions,
+					].includes(chatMode)
+				) {
 					ret.mentionCounter += Number(state.mentionCounter) || 0;
-				};
+				}
 
-				if (state.messageCounter && [ I.NotificationMode.All ].includes(chatMode)) {
+				if (
+					state.messageCounter &&
+					[I.NotificationMode.All].includes(chatMode)
+				) {
 					ret.messageCounter += Number(state.messageCounter) || 0;
-				};
-			};
-		};
+				}
+			}
+		}
 
 		return ret;
-	};
+	}
 
 	/**
 	 * Gets the mention and message counters for a space.
@@ -375,54 +417,69 @@ class ChatStore {
 	 * @param {boolean} [ignoreMute] - If true, include counters regardless of notification mode.
 	 * @returns {I.ChatCounter} The counters for the space.
 	 */
-	getSpaceCounters (spaceId: string, ignoreMute?: boolean): I.ChatCounter {
+	getSpaceCounters(spaceId: string, ignoreMute?: boolean): I.ChatCounter {
 		const ret = { mentionCounter: 0, messageCounter: 0 };
 		const spaceMap = this.stateMap.get(spaceId);
 
 		if (!spaceMap) {
 			return ret;
-		};
+		}
 
 		const spaceview = U.Space.getSpaceviewBySpaceId(spaceId);
 
-		for (const [ chatId, state ] of spaceMap) {
+		for (const [chatId, state] of spaceMap) {
 			if (!chatId) {
 				continue;
-			};
+			}
 
 			const chat = S.Detail.get(J.Constant.subId.chatGlobal, chatId, []);
 			if (chat._empty_ || chat.isArchived) {
 				continue;
-			};
+			}
 
-			const chatMode = U.Object.getChatNotificationMode(spaceview, chatId);
+			const chatMode = U.Object.getChatNotificationMode(
+				spaceview,
+				chatId,
+			);
 
-			if (state.mentionCounter && (ignoreMute || [ I.NotificationMode.All, I.NotificationMode.Mentions ].includes(chatMode))) {
+			if (
+				state.mentionCounter &&
+				(ignoreMute ||
+					[
+						I.NotificationMode.All,
+						I.NotificationMode.Mentions,
+					].includes(chatMode))
+			) {
 				ret.mentionCounter += Number(state.mentionCounter) || 0;
-			};
+			}
 
-			if (state.messageCounter && (ignoreMute || [ I.NotificationMode.All ].includes(chatMode))) {
+			if (
+				state.messageCounter &&
+				(ignoreMute || [I.NotificationMode.All].includes(chatMode))
+			) {
 				ret.messageCounter += Number(state.messageCounter) || 0;
-			};
-		};
+			}
+		}
 
 		return ret;
-	};
+	}
 
 	/**
 	 * Gets the last message for a space.
 	 * @param {string} spaceId - The space ID.
 	 * @returns {I.ChatMessage | null} The last message.
 	 */
-	getSpaceLastMessage (spaceId: string): I.ChatMessage | null {
+	getSpaceLastMessage(spaceId: string): I.ChatMessage | null {
 		const list = this.getList(this.getSpaceSubId(spaceId)).slice(0);
 		if (!list.length) {
 			return null;
-		};
+		}
 
-		list.sort((c1, c2) => U.Data.sortByNumericKey('createdAt', c1, c2, I.SortType.Desc));
+		list.sort((c1, c2) =>
+			U.Data.sortByNumericKey("createdAt", c1, c2, I.SortType.Desc),
+		);
 		return list[0];
-	};
+	}
 
 	/**
 	 * Gets the mention and message counters for a chat in a space.
@@ -430,13 +487,13 @@ class ChatStore {
 	 * @param {string} chatId - The chat ID.
 	 * @returns {Counter} The counters for the chat.
 	 */
-	getChatCounters (spaceId: string, chatId: string): I.ChatCounter {
+	getChatCounters(spaceId: string, chatId: string): I.ChatCounter {
 		const ret = { mentionCounter: 0, messageCounter: 0 };
 		const chat = S.Detail.get(J.Constant.subId.chatGlobal, chatId, []);
 
 		if (!spaceId || !chatId || chat._empty_ || chat.isArchived) {
 			return ret;
-		};
+		}
 
 		const spaceMap = this.stateMap.get(spaceId);
 
@@ -445,56 +502,58 @@ class ChatStore {
 			if (state) {
 				ret.mentionCounter = Number(state.mentionCounter) || 0;
 				ret.messageCounter = Number(state.messageCounter) || 0;
-			};
-		};
+			}
+		}
 
 		return ret;
-	};
+	}
 
 	/**
 	 * Sets the badge count in the UI based on message counters.
 	 */
-	setBadge () {
+	setBadge() {
 		const counters = this.getTotalCounters();
 		const t = this.counterString(counters.messageCounter);
 
 		if (t != this.badgeValue) {
 			this.badgeValue = t;
-			Renderer.send('setBadge', t);
-		};
-	};
+			Renderer.send("setBadge", t);
+		}
+	}
 
 	/**
 	 * Checks if message has a mantion of given participant ID
 	 * @param {I.ChatMessage} message - The space ID.
 	 * @param {string} participantId - The participant ID.
 	 */
-	isMention (message: I.ChatMessage, participantId: string): boolean {
-		return !!message.content.marks.find(it => (it.type == I.MarkType.Mention) && (it.param == participantId));
-	};
+	isMention(message: I.ChatMessage, participantId: string): boolean {
+		return !!message.content.marks.find(
+			(it) => it.type == I.MarkType.Mention && it.param == participantId,
+		);
+	}
 
 	/**
 	 * Converts a counter value to a string for display.
 	 * @param {number} c - The counter value.
 	 * @returns {string} The formatted counter string.
 	 */
-	counterString (c: number): string {
-		return String((c > 999 ? '999+' : c) || '');
-	};
+	counterString(c: number): string {
+		return String((c > 999 ? "999+" : c) || "");
+	}
 
 	/**
 	 * Sets the attachments list.
 	 */
-	setAttachments (id: string, list: any[]) {
+	setAttachments(id: string, list: any[]) {
 		this.attachmentsMap.set(id, list || []);
-	};
+	}
 
 	/**
 	 * Gets the attachments list.
 	 */
-	getAttachments (id: string): any[] {
+	getAttachments(id: string): any[] {
 		return this.attachmentsMap.get(id) || [];
-	};
+	}
 
 	/**
 	 * Gets a simple text representation of a message.
@@ -502,17 +561,21 @@ class ChatStore {
 	 * @param {I.ChatMessage} message - The chat message.
 	 * @returns {string} The simple text representation.
 	 */
-	getMessageSimpleText (spaceId: string, message: I.ChatMessage, withAuthor: boolean): string {
+	getMessageSimpleText(
+		spaceId: string,
+		message: I.ChatMessage,
+		withAuthor: boolean,
+	): string {
 		if (!message) {
-			return '';
-		};
+			return "";
+		}
 
 		const { creator, content, attachments, dependencies } = message;
 		const { text, marks } = content || {};
 
 		if (!text && !attachments.length) {
-			return '';
-		};
+			return "";
+		}
 
 		const ret = [];
 		const participantId = U.Space.getParticipantId(spaceId, creator);
@@ -521,27 +584,30 @@ class ChatStore {
 			const author = dependencies.get(participantId);
 			if (author) {
 				ret.push(`${U.Object.name(author)}:`);
-			};
-		};
+			}
+		}
 
 		if (text) {
 			let t = U.String.sanitize(Mark.insertEmoji(text, marks));
-			t = t.replace(/\n\r?/g, ' ');
+			t = t.replace(/\n\r?/g, " ");
 
 			ret.push(t);
-		};
+		}
 
 		if (attachments.length) {
-			const names = attachments.map(item => {
-				const object = dependencies.get(item.target);
-				return object ? U.Object.name(object) : '';
-			}).filter(it => it).join(', ');
+			const names = attachments
+				.map((item) => {
+					const object = dependencies.get(item.target);
+					return object ? U.Object.name(object) : "";
+				})
+				.filter((it) => it)
+				.join(", ");
 
 			ret.push(names);
-		};
+		}
 
-		return ret.join(' ');
-	};
+		return ret.join(" ");
+	}
 
 	/**
 	 * Mutates subscriptionIds array and adds chat preview and vault subscription ids properly.
@@ -549,7 +615,11 @@ class ChatStore {
 	 * @param {string} subId - The subscription ID.
 	 * @returns {string} The vault subscription ID.
 	 */
-	checkVaultSubscriptionIds (subIds: string[], spaceId: string, chatId: string): string[] {
+	checkVaultSubscriptionIds(
+		subIds: string[],
+		spaceId: string,
+		chatId: string,
+	): string[] {
 		const ret = [];
 
 		for (let i = 0; i < subIds.length; i++) {
@@ -562,16 +632,21 @@ class ChatStore {
 				ret.push(this.getSpaceSubId(spaceId));
 
 				if (!isArchived && !isDeleted) {
-					ret.push(this.getChatSubId(J.Constant.subId.chatPreview, spaceId, chatId));
-				};
+					ret.push(
+						this.getChatSubId(
+							J.Constant.subId.chatPreview,
+							spaceId,
+							chatId,
+						),
+					);
+				}
 			} else {
 				ret.push(subId);
-			};
-		};
+			}
+		}
 
 		return ret;
-	};
-
-};
+	}
+}
 
 export const Chat: ChatStore = new ChatStore();

--- a/src/ts/store/common.ts
+++ b/src/ts/store/common.ts
@@ -1,11 +1,11 @@
-import $ from 'jquery';
-import { action, computed, makeObservable, observable, set } from 'mobx';
-import { I, S, U, J, Storage, Renderer, keyboard } from 'Lib';
+import $ from "jquery";
+import { action, computed, makeObservable, observable, set } from "mobx";
+import { I, S, U, J, Storage, Renderer, keyboard } from "Lib";
 
 interface Filter {
 	from: number;
 	text: string;
-};
+}
 
 interface SpaceStorage {
 	bytesLimit: number;
@@ -13,28 +13,27 @@ interface SpaceStorage {
 	spaces: {
 		spaceId: string;
 		bytesUsage: number;
-	}[],
-};
+	}[];
+}
 
 class CommonStore {
-
-	public dataPathValue = '';
+	public dataPathValue = "";
 	public progressObj: I.Progress = null;
-	public filterObj: Filter = { from: 0, text: '' };
-	public gatewayUrl = '';
+	public filterObj: Filter = { from: 0, text: "" };
+	public gatewayUrl = "";
 	public toastObj: I.Toast = null;
 	public configObj: any = {};
-	public cellId = '';
-	public themeId = '';
+	public cellId = "";
+	public themeId = "";
 	public nativeThemeIsDark = false;
 	public defaultType = null;
 	public pinTimeId = null;
 	public isFullScreen = false;
 	public singleTabValue = false;
-	public redirect = '';
+	public redirect = "";
 	public languages: string[] = [];
-	public spaceId = '';
-	public notionToken = '';
+	public spaceId = "";
+	public notionToken = "";
 	public showRelativeDatesValue = null;
 	public fullscreenObjectValue = null;
 	public linkStyleValue = null;
@@ -43,11 +42,11 @@ class CommonStore {
 	public timeFormatValue = null;
 	public isOnlineValue = false;
 	public chatCmdSendValue = null;
-	public updateVersionValue = '';
+	public updateVersionValue = "";
 	public vaultMessagesValue = null;
 	public vaultIsMinimalValue = null;
 	public gridTitleClickValue = null;
-	public leftSidebarStateValue = { page: '', subPage: '' };
+	public leftSidebarStateValue = { page: "", subPage: "" };
 
 	public recentEditModeValue: I.RecentEditMode = null;
 	public hideSidebarValue = null;
@@ -60,8 +59,8 @@ class CommonStore {
 	};
 	public diffValue: I.Diff[] = [];
 	public refs: Map<string, any> = new Map();
-	public windowId = '';
-	public tabId = '';
+	public windowId = "";
+	public tabId = "";
 	public isActiveTab = true;
 	public windowIsFocused = true;
 	public routeParam: any = {};
@@ -69,38 +68,41 @@ class CommonStore {
 	public isPinnedValue = false;
 	public widgetSectionsValue: I.WidgetSectionParam[] = null;
 
-	public rightSidebarStateValue: { full: I.SidebarRightState, popup: I.SidebarRightState } = { 
+	public rightSidebarStateValue: {
+		full: I.SidebarRightState;
+		popup: I.SidebarRightState;
+	} = {
 		full: {
-			rootId: '',
-			page: '',
+			rootId: "",
+			page: "",
 			details: {},
 			readonly: false,
 			noPreview: false,
 			previous: null,
-			blockId: '',
-			back: '',
-		}, 
+			blockId: "",
+			back: "",
+		},
 		popup: {
-			rootId: '',
-			page: '',
+			rootId: "",
+			page: "",
 			details: {},
 			readonly: false,
 			noPreview: false,
 			previous: null,
-			blockId: '',
-			back: '',
+			blockId: "",
+			back: "",
 		},
 	};
 
-	public previewObj: I.Preview = { 
-		type: null, 
-		target: null, 
-		element: null, 
-		range: { from: 0, to: 0 }, 
+	public previewObj: I.Preview = {
+		type: null,
+		target: null,
+		element: null,
+		range: { from: 0, to: 0 },
 		marks: [],
 	};
 
-	private graphObj: I.GraphSettings = { 
+	private graphObj: I.GraphSettings = {
 		icon: true,
 		preview: true,
 		orphan: true,
@@ -111,7 +113,7 @@ class CommonStore {
 		link: true,
 		local: false,
 		cluster: false,
-		filter: '',
+		filter: "",
 		depth: 1,
 		filterTypes: [],
 		typeEdges: true,
@@ -126,7 +128,7 @@ class CommonStore {
 		spaces: [],
 	};
 
-	constructor () {
+	constructor() {
 		makeObservable(this, {
 			progressObj: observable,
 			filterObj: observable,
@@ -215,9 +217,9 @@ class CommonStore {
 			singleTabSet: action,
 			autoDownloadSet: action,
 		});
-	};
+	}
 
-	get config (): any {
+	get config(): any {
 		const config = window.AnytypeGlobalConfig || this.configObj || {};
 
 		return {
@@ -226,232 +228,237 @@ class CommonStore {
 			debug: config.debug || {},
 			flagsMw: config.flagsMw || {},
 		};
-	};
+	}
 
-	get preview (): I.Preview {
+	get preview(): I.Preview {
 		return this.previewObj;
-	};
+	}
 
-	get toast (): I.Toast {
+	get toast(): I.Toast {
 		return this.toastObj;
-	};
+	}
 
-	get filter (): Filter {
+	get filter(): Filter {
 		return this.filterObj;
-	};
+	}
 
-	get filterText () {
-		return String(this.filter.text || '').replace(/^[@\[]+/, '');
-	};
+	get filterText() {
+		return String(this.filter.text || "").replace(/^[@\[]+/, "");
+	}
 
-	get gateway (): string {
-		return String(this.gatewayUrl || '');
-	};
+	get gateway(): string {
+		return String(this.gatewayUrl || "");
+	}
 
-	get type (): string {
+	get type(): string {
 		if (this.defaultType === null) {
-			this.defaultType = Storage.get('defaultType');
-		};
+			this.defaultType = Storage.get("defaultType");
+		}
 
 		if (!this.defaultType) {
 			this.defaultType = J.Constant.default.typeKey;
-		};
+		}
 
 		let type = S.Record.getTypeByKey(this.defaultType);
-		if (!type || type.isArchived || type.isDeleted || !U.Object.isAllowedObject(type.recommendedLayout)) {
+		if (
+			!type ||
+			type.isArchived ||
+			type.isDeleted ||
+			!U.Object.isAllowedObject(type.recommendedLayout)
+		) {
 			type = S.Record.getTypeByKey(J.Constant.default.typeKey);
-		};
+		}
 
-		return type ? type.id : '';
-	};
+		return type ? type.id : "";
+	}
 
-	get fullscreen (): boolean {
+	get fullscreen(): boolean {
 		return this.isFullScreen;
-	};
+	}
 
-	get isPinned (): boolean {
+	get isPinned(): boolean {
 		return this.isPinnedValue;
-	};
+	}
 
-	get singleTab (): boolean {
+	get singleTab(): boolean {
 		return this.singleTabValue;
-	};
+	}
 
-	get pin (): string {
-		return String(this.pinValue || '');
-	};
+	get pin(): string {
+		return String(this.pinValue || "");
+	}
 
-	get pinTime (): number {
+	get pinTime(): number {
 		let ret = this.pinTimeId;
 		if (ret === null) {
-			ret = Storage.get('pinTime');
-		};
+			ret = Storage.get("pinTime");
+		}
 		return (Number(ret) || J.Constant.default.pinTime) * 1000;
-	};
+	}
 
-	get recentEditMode (): I.RecentEditMode {
+	get recentEditMode(): I.RecentEditMode {
 		let ret = this.recentEditModeValue;
 		if (ret === null) {
-			ret = Storage.get('recentEditMode');
-		};
+			ret = Storage.get("recentEditMode");
+		}
 		return Number(ret) || I.RecentEditMode.All;
-	};
+	}
 
-	get fullscreenObject (): boolean {
+	get fullscreenObject(): boolean {
 		let ret = this.fullscreenObjectValue;
 		if (ret === null) {
-			ret = Storage.get('fullscreenObject');
-		};
+			ret = Storage.get("fullscreenObject");
+		}
 		if (ret === undefined) {
 			ret = true;
-		};
+		}
 		return ret;
-	};
+	}
 
-	get hideSidebar (): boolean {
-		return this.boolGet('hideSidebar');
-	};
+	get hideSidebar(): boolean {
+		return this.boolGet("hideSidebar");
+	}
 
-	get autoDownload (): boolean {
-		return this.boolGet('autoDownload');
-	};
+	get autoDownload(): boolean {
+		return this.boolGet("autoDownload");
+	}
 
-	get chatCmdSend (): boolean {
-		return this.boolGet('chatCmdSend');
-	};
+	get chatCmdSend(): boolean {
+		return this.boolGet("chatCmdSend");
+	}
 
-	get theme (): string {
-		return String(this.themeId || '');
-	};
+	get theme(): string {
+		return String(this.themeId || "");
+	}
 
-	get nativeTheme (): string {
-		return this.nativeThemeIsDark ? 'dark' : '';
-	};
+	get nativeTheme(): string {
+		return this.nativeThemeIsDark ? "dark" : "";
+	}
 
-	get space (): string {
-		return String(this.spaceId || '');
-	};
+	get space(): string {
+		return String(this.spaceId || "");
+	}
 
-	get spaceStorage (): SpaceStorage {
+	get spaceStorage(): SpaceStorage {
 		const spaces = this.spaceStorageObj.spaces || [];
 		return { ...this.spaceStorageObj, spaces };
-	};
+	}
 
-	get interfaceLang (): string {
+	get interfaceLang(): string {
 		return this.config.interfaceLang || J.Constant.default.interfaceLang;
-	};
+	}
 
-	get showRelativeDates (): boolean {
-		return this.boolGet('showRelativeDates');
-	};
+	get showRelativeDates(): boolean {
+		return this.boolGet("showRelativeDates");
+	}
 
-	get linkStyle (): I.LinkCardStyle {
+	get linkStyle(): I.LinkCardStyle {
 		let ret = this.linkStyleValue;
 		if (ret === null) {
-			ret = Storage.get('linkStyle');
-		};
+			ret = Storage.get("linkStyle");
+		}
 		if (undefined === ret) {
 			ret = I.LinkCardStyle.Card;
-		};
+		}
 		return Number(ret) || I.LinkCardStyle.Text;
-	};
+	}
 
-	get fileStyle (): I.FileStyle {
+	get fileStyle(): I.FileStyle {
 		let ret = this.fileStyleValue;
 		if (ret === null) {
-			ret = Storage.get('fileStyle');
-		};
+			ret = Storage.get("fileStyle");
+		}
 		if (undefined === ret) {
 			ret = I.FileStyle.Embed;
-		};
+		}
 		return Number(ret) || I.FileStyle.Embed;
-	};
+	}
 
-	get dateFormat (): I.DateFormat {
+	get dateFormat(): I.DateFormat {
 		let ret = this.dateFormatValue;
-		
+
 		if (ret === null) {
-			ret = Storage.get('dateFormat');
+			ret = Storage.get("dateFormat");
 
 			if (undefined === ret) {
 				ret = I.DateFormat.Long;
-			};
-		};
+			}
+		}
 
 		return Number(ret);
-	};
+	}
 
-	get timeFormat (): I.TimeFormat {
+	get timeFormat(): I.TimeFormat {
 		let ret = this.timeFormatValue;
 		if (ret === null) {
-			ret = Storage.get('timeFormat');
-		};
+			ret = Storage.get("timeFormat");
+		}
 		return Number(ret) || I.TimeFormat.H12;
-	};
+	}
 
-	get dataPath (): string {
-		return String(this.dataPathValue || '');
-	};
+	get dataPath(): string {
+		return String(this.dataPathValue || "");
+	}
 
-	get isOnline (): boolean {
+	get isOnline(): boolean {
 		return Boolean(this.isOnlineValue);
-	};
+	}
 
-	get diff (): I.Diff[] {
+	get diff(): I.Diff[] {
 		return this.diffValue || [];
-	};
+	}
 
-	get firstDay (): number {
+	get firstDay(): number {
 		if (this.firstDayValue === null) {
-			this.firstDayValue = Storage.get('firstDay');
-		};
+			this.firstDayValue = Storage.get("firstDay");
+		}
 
 		return Number(this.firstDayValue) || 1;
-	};
+	}
 
-	get updateVersion (): string {
-		return String(this.updateVersionValue || '');
-	};
+	get updateVersion(): string {
+		return String(this.updateVersionValue || "");
+	}
 
-	get widgetSections (): I.WidgetSectionParam[] {
+	get widgetSections(): I.WidgetSectionParam[] {
 		return this.widgetSectionsValue || [];
-	};
+	}
 
-	get vaultMessages (): any {
-		return this.boolGet('vaultMessages');
-	};
+	get vaultMessages(): any {
+		return this.boolGet("vaultMessages");
+	}
 
-	get vaultIsMinimal (): any {
-		return this.boolGet('vaultIsMinimal');
-	};
+	get vaultIsMinimal(): any {
+		return this.boolGet("vaultIsMinimal");
+	}
 
-	get gridTitleClick (): boolean {
+	get gridTitleClick(): boolean {
 		let ret = this.gridTitleClickValue;
 		if (ret === null) {
-			ret = Storage.get('gridTitleClick');
-		};
+			ret = Storage.get("gridTitleClick");
+		}
 		if (ret === undefined) {
 			ret = true;
-		};
+		}
 		return ret;
-	};
+	}
 
 	/**
 	 * Sets the gateway URL.
 	 * @param {string} v - The gateway URL.
 	 */
-	gatewaySet (v: string) {
+	gatewaySet(v: string) {
 		this.gatewayUrl = v;
-	};
+	}
 
 	/**
 	 * Gets the file URL for a given file ID.
 	 * @param {string} id - The file ID.
 	 * @returns {string} The file URL.
 	 */
-	fileUrl (id: string) {
-		return [ this.gateway, 'file', String(id || '') ].join('/');
-	};
+	fileUrl(id: string) {
+		return [this.gateway, "file", String(id || "")].join("/");
+	}
 
 	/**
 	 * Gets the image URL for a given image ID and width.
@@ -459,509 +466,520 @@ class CommonStore {
 	 * @param {number} width - The image width.
 	 * @returns {string} The image URL.
 	 */
-	imageUrl (id: string, width: number) {
+	imageUrl(id: string, width: number) {
 		width = Number(width) || 0;
 
 		if (width === 0) {
 			width = 10000000;
-		} else
-		if ((width > 0) && (width <= I.ImageSize.Small)) {
+		} else if (width > 0 && width <= I.ImageSize.Small) {
 			width = I.ImageSize.Small;
-		} else
-		if ((width > I.ImageSize.Small) && (width <= I.ImageSize.Medium)) {
+		} else if (width > I.ImageSize.Small && width <= I.ImageSize.Medium) {
 			width = I.ImageSize.Medium;
-		} else 
-		if (width > I.ImageSize.Medium) {
+		} else if (width > I.ImageSize.Medium) {
 			width = I.ImageSize.Large;
-		};
+		}
 
-		return id ? [ this.gateway, 'image', String(id || '') ].join('/') + `?width=${width}` : '';
-	};
+		return id
+			? [this.gateway, "image", String(id || "")].join("/") +
+					`?width=${width}`
+			: "";
+	}
 
 	/**
 	 * Sets the filter 'from' value.
 	 * @param {number} from - The 'from' value.
 	 */
-	filterSetFrom (from: number) {
+	filterSetFrom(from: number) {
 		this.filterObj.from = from;
-	};
+	}
 
 	/**
 	 * Sets the filter text.
 	 * @param {string} text - The filter text.
 	 */
-	filterSetText (text: string) {
+	filterSetText(text: string) {
 		this.filterObj.text = text;
-	};
+	}
 
 	/**
 	 * Sets the filter values.
 	 * @param {number} from - The 'from' value.
 	 * @param {string} text - The filter text.
 	 */
-	filterSet (from: number, text: string) {
+	filterSet(from: number, text: string) {
 		this.filterSetFrom(from);
 		this.filterSetText(text);
-	};
+	}
 
 	/**
 	 * Sets the preview object.
 	 * @param {I.Preview} preview - The preview object.
 	 */
-	previewSet (preview: I.Preview) {
+	previewSet(preview: I.Preview) {
 		this.previewObj = preview;
-	};
+	}
 
 	/**
 	 * Sets the graph settings for a key.
 	 * @param {string} key - The key.
 	 * @param {Partial<I.GraphSettings>} param - The graph settings.
 	 */
-	graphSet (key: string, param: Partial<I.GraphSettings>) {
+	graphSet(key: string, param: Partial<I.GraphSettings>) {
 		Storage.set(key, Object.assign(this.getGraph(key), param));
-		$(window).trigger('updateGraphSettings');
-	};
+		$(window).trigger("updateGraphSettings");
+	}
 
 	/**
 	 * Sets the toast object, resolving object references if needed.
 	 * @param {I.Toast} toast - The toast object.
 	 */
-	toastSet (toast: I.Toast) {
+	toastSet(toast: I.Toast) {
 		const { objectId, targetId, originId } = toast;
-		const ids = [ objectId, targetId, originId ].filter(it => it);
+		const ids = [objectId, targetId, originId].filter((it) => it);
 
 		if (ids.length) {
 			U.Object.getByIds(ids, {}, (objects: any[]) => {
-				const map = U.Common.mapToObject(objects, 'id');
+				const map = U.Common.mapToObject(objects, "id");
 
 				if (targetId && map[targetId]) {
 					toast.target = map[targetId];
-				};
+				}
 
 				if (objectId && map[objectId]) {
 					toast.object = map[objectId];
-				};
+				}
 
 				if (originId && map[originId]) {
 					toast.origin = map[originId];
-				};
+				}
 
 				this.toastObj = toast;
 			});
 		} else {
 			this.toastObj = toast;
-		};
-	};
+		}
+	}
 
 	/**
 	 * Sets the current space ID.
 	 * @param {string} id - The space ID.
 	 */
-	spaceSet (id: string) {
-		this.spaceId = String(id || '');
-	};
+	spaceSet(id: string) {
+		this.spaceId = String(id || "");
+	}
 
 	/**
 	 * Clears the preview object.
 	 */
-	previewClear () {
-		this.previewObj = { type: I.PreviewType.None, target: null, element: null, range: { from: 0, to: 0 }, marks: [] };
-	};
+	previewClear() {
+		this.previewObj = {
+			type: I.PreviewType.None,
+			target: null,
+			element: null,
+			range: { from: 0, to: 0 },
+			marks: [],
+		};
+	}
 
 	/**
 	 * Clears the toast object.
 	 */
-	toastClear () {
+	toastClear() {
 		this.toastObj = null;
-	};
+	}
 
 	/**
 	 * Sets the default type.
 	 * @param {string} v - The type value.
 	 */
-	typeSet (v: string) {
-		this.defaultType = String(v || '');
+	typeSet(v: string) {
+		this.defaultType = String(v || "");
 
-		Storage.set('defaultType', this.defaultType);
-	};
+		Storage.set("defaultType", this.defaultType);
+	}
 
 	/**
 	 * Sets the pin time value.
 	 * @param {string} v - The pin time value.
 	 */
-	pinTimeSet (v: string) {
+	pinTimeSet(v: string) {
 		this.pinTimeId = Number(v) || J.Constant.default.pinTime;
 
-		Storage.set('pinTime', this.pinTimeId);
+		Storage.set("pinTime", this.pinTimeId);
 
 		// Update the centralized timer in main process with new timeout
 		if (keyboard.isPinChecked && this.pin) {
-			Renderer.send('startPinTimer', this.pinTime);
-		};
-	};
+			Renderer.send("startPinTimer", this.pinTime);
+		}
+	}
 
 	/**
 	 * Gets the pin ID for storage.
 	 */
-	pinId () {
+	pinId() {
 		const { account } = S.Auth;
 		if (!account) {
-			return '';
-		};
+			return "";
+		}
 
-		return [ account.id, 'pin' ].join('-');
-	};
+		return [account.id, "pin"].join("-");
+	}
 
 	/**
 	 * Sets the pin value.
 	 * @param {string} v - The pin value.
 	 */
-	pinSet (v: string) {
-		this.pinValue = String(v || '');
+	pinSet(v: string) {
+		this.pinValue = String(v || "");
 		keyboard.setPinChecked(true);
-		Renderer.send('keytarSet', this.pinId(), this.pinValue);
-		Renderer.send('pinSet');
-	};
+		Renderer.send("keytarSet", this.pinId(), this.pinValue);
+		Renderer.send("pinSet");
+	}
 
 	/**
 	 * Removes the pin value.
 	 */
-	pinRemove () {
+	pinRemove() {
 		this.pinValue = null;
 		keyboard.setPinChecked(true);
-		Renderer.send('keytarDelete', this.pinId());
-		Renderer.send('stopPinTimer');
-		Renderer.send('pinRemove');
-	};
+		Renderer.send("keytarDelete", this.pinId());
+		Renderer.send("stopPinTimer");
+		Renderer.send("pinRemove");
+	}
 
 	/**
 	 * Initializes the pin value, optionally calling a callback.
 	 * @param {() => void} callBack - The callback function to call after initialization.
 	 */
-	pinInit (callBack?: () => void) {
-		const pin = Storage.get('pin');
+	pinInit(callBack?: () => void) {
+		const pin = Storage.get("pin");
 
 		if (pin) {
 			this.pinSet(pin);
-			Storage.delete('pin');
+			Storage.delete("pin");
 
 			callBack?.();
 		} else {
-			Renderer.send('keytarGet', this.pinId()).then((value: string) => {
-				this.pinValue = String(value || '');
+			Renderer.send("keytarGet", this.pinId())
+				.then((value: string) => {
+					this.pinValue = String(value || "");
 
-				callBack?.();
-			}).catch((err: any) => {
-				console.error('[Common] Error retrieving pin from keychain:', err);
-				this.pinValue = '';
+					callBack?.();
+				})
+				.catch((err: any) => {
+					console.error(
+						"[Common] Error retrieving pin from keychain:",
+						err,
+					);
+					this.pinValue = "";
 
-				callBack?.();
-			});
-		};
-	};
+					callBack?.();
+				});
+		}
+	}
 
 	/**
 	 * Sets the show relative dates value.
 	 * @param {boolean} v - The show relative dates value.
 	 */
-	showRelativeDatesSet (v: boolean) {
-		this.boolSet('showRelativeDates', v);
-	};
+	showRelativeDatesSet(v: boolean) {
+		this.boolSet("showRelativeDates", v);
+	}
 
 	/**
 	 * Sets the fullscreen object value.
 	 * @param {boolean} v - The fullscreen value.
 	 */
-	fullscreenObjectSet (v: boolean) {
-		this.boolSet('fullscreenObject', v);
-	};
+	fullscreenObjectSet(v: boolean) {
+		this.boolSet("fullscreenObject", v);
+	}
 
 	/**
 	 * Sets the hide sidebar value.
 	 * @param {boolean} v - The hide sidebar value.
 	 */
-	hideSidebarSet (v: boolean) {
-		this.boolSet('hideSidebar', v);
-	};
+	hideSidebarSet(v: boolean) {
+		this.boolSet("hideSidebar", v);
+	}
 
-	autoDownloadSet (v: boolean) {
-		this.boolSet('autoDownload', v);
-	};
+	autoDownloadSet(v: boolean) {
+		this.boolSet("autoDownload", v);
+	}
 
 	/**
 	 * Sets the hide chat send option value.
 	 * @param {boolean} v - Value.
 	 */
-	chatCmdSendSet (v: boolean) {
-		this.boolSet('chatCmdSend', v);
-	};
+	chatCmdSendSet(v: boolean) {
+		this.boolSet("chatCmdSend", v);
+	}
 
 	/**
 	 * Sets the show sidebar left value.
 	 * @param {string} page - The page to set, '' if no page is shown
 	 * @param {string} subPage - The subPage to set, '' if no page is shown
 	 */
-	setLeftSidebarState (page: string, subPage: string) {
+	setLeftSidebarState(page: string, subPage: string) {
 		set(this.leftSidebarStateValue, { page, subPage });
-	};
+	}
 
 	/**
 	 * Sets the show sidebar right value.
 	 * @param {boolean} isPopup - Whether it is a popup.
 	 * @param {string} page - The page to set, null if no page is shown
 	 */
-	setRightSidebarState (isPopup: boolean, v: Partial<I.SidebarRightState>) {
+	setRightSidebarState(isPopup: boolean, v: Partial<I.SidebarRightState>) {
 		v = Object.assign({ noPreview: true }, v);
 		set(this.getRightSidebarState(isPopup), v);
-	};
+	}
 
 	/**
 	 * Clears the right sidebar state.
 	 * @param {boolean} isPopup - Whether it is a popup.
 	 */
-	clearRightSidebarState (isPopup: boolean) {
+	clearRightSidebarState(isPopup: boolean) {
 		set(this.rightSidebarStateValue[this.getStateKey(isPopup)], {
-			rootId: '',
-			page: '',
+			rootId: "",
+			page: "",
 			details: {},
 			readonly: false,
 			noPreview: false,
 			previous: null,
-			blockId: '',
-			back: '',
+			blockId: "",
+			back: "",
 		});
-	};
+	}
 
 	/**
 	 * Sets the fullscreen mode.
 	 * @param {boolean} v - The fullscreen value.
 	 */
-	fullscreenSet (v: boolean) {
+	fullscreenSet(v: boolean) {
 		this.isFullScreen = v;
-	};
+	}
 
 	/**
 	 * Sets the single tab mode.
 	 * @param {boolean} v - The single tab mode value.
 	 */
-	isPinnedSet (v: boolean) {
+	isPinnedSet(v: boolean) {
 		this.isPinnedValue = v;
-	};
+	}
 
-	singleTabSet (v: boolean) {
+	singleTabSet(v: boolean) {
 		this.singleTabValue = v;
-	};
+	}
 
 	/**
 	 * Sets the update version value.
 	 * @param {string} v - The update version value.
 	 */
-	updateVersionSet (v: string) {
-		this.updateVersionValue = String(v || '');
-	};
+	updateVersionSet(v: string) {
+		this.updateVersionValue = String(v || "");
+	}
 
 	/**
 	 * Sets the theme ID and updates the theme class.
 	 * @param {string} v - The theme ID.
 	 */
-	themeSet (v: string) {
-		this.themeId = String(v || '');
+	themeSet(v: string) {
+		this.themeId = String(v || "");
 		this.setThemeClass();
-	};
+	}
 
 	/**
 	 * Sets the redirect value.
 	 * @param {string} v - The redirect value.
 	 */
-	redirectSet (v: string) {
+	redirectSet(v: string) {
 		const param = U.Router.getParam(v);
 
-		if ((param.page == 'auth') && (param.action == 'pin-check')) {
+		if (param.page == "auth" && param.action == "pin-check") {
 			return;
-		};
+		}
 
 		this.redirect = v;
-	};
+	}
 
 	/**
 	 * Sets the Notion token value.
 	 * @param {string} v - The Notion token value.
 	 */
-	notionTokenSet (v: string) {
+	notionTokenSet(v: string) {
 		this.notionToken = v;
-	};
+	}
 
 	/**
 	 * Sets a reference by ID.
 	 * @param {string} id - The reference ID.
 	 * @param {any} ref - The reference object.
 	 */
-	refSet (id: string, ref: any) {
+	refSet(id: string, ref: any) {
 		if (id && ref) {
 			this.refs.set(id, ref);
-		};
-	};
+		}
+	}
 
 	/**
 	 * Gets a boolean value by key, loading from storage if needed.
 	 * @param {string} k - The key.
 	 * @returns {boolean} The boolean value.
 	 */
-	boolGet (k: string) {
+	boolGet(k: string) {
 		const tk = `${k}Value`;
 		if (this[tk] === null) {
 			this[tk] = Storage.get(k);
-		};
+		}
 		return !!this[tk];
-	};
+	}
 
 	/**
 	 * Sets a boolean value by key and stores it.
 	 * @param {string} k - The key.
 	 * @param {boolean} v - The value to set.
 	 */
-	boolSet (k: string, v: boolean) {
+	boolSet(k: string, v: boolean) {
 		v = Boolean(v);
 
 		this[`${k}Value`] = v;
 		Storage.set(k, v);
-	};
+	}
 
 	/**
 	 * Gets the current theme class string.
 	 * @returns {string} The theme class.
 	 */
-	getThemeClass (): string {
-		let ret = '';
+	getThemeClass(): string {
+		let ret = "";
 
-		if (this.themeId == 'system') {
-			ret = this.nativeThemeIsDark ? 'dark' : '';
+		if (this.themeId == "system") {
+			ret = this.nativeThemeIsDark ? "dark" : "";
 		} else {
 			ret = this.themeId;
-		};
+		}
 
-		return String(ret || '');
-	};
+		return String(ret || "");
+	}
 
 	/**
 	 * Sets the theme class on the document.
 	 */
-	setThemeClass () {
+	setThemeClass() {
 		const c = this.getThemeClass();
 
-		U.Common.addBodyClass('theme', c);
-		Renderer.send('setBackground', c);
-	};
+		U.Common.addBodyClass("theme", c);
+		Renderer.send("setBackground", c);
+	}
 
 	/**
 	 * Gets the theme path string.
 	 * @returns {string} The theme path.
 	 */
-	getThemePath () {
+	getThemePath() {
 		const c = this.getThemeClass();
-		return c ? `theme/${c}/` : '';
-	};
+		return c ? `theme/${c}/` : "";
+	}
 
 	/**
 	 * Sets the native theme dark mode value.
 	 * @param {boolean} isDark - Whether the theme is dark.
 	 */
-	nativeThemeSet (isDark: boolean) {
+	nativeThemeSet(isDark: boolean) {
 		this.nativeThemeIsDark = isDark;
-	};
+	}
 
 	/**
 	 * Sets the available languages.
 	 * @param {string[]} v - The languages array.
 	 */
-	languagesSet (v: string[]) {
+	languagesSet(v: string[]) {
 		this.languages = v;
-	};
+	}
 
 	/**
 	 * Sets the link style value.
 	 * @param {I.LinkCardStyle} v - The link style value.
 	 */
-	linkStyleSet (v: I.LinkCardStyle) {
+	linkStyleSet(v: I.LinkCardStyle) {
 		v = Number(v);
 		this.linkStyleValue = v;
-		Storage.set('linkStyle', v);
-	};
+		Storage.set("linkStyle", v);
+	}
 
 	/**
 	 * Sets the file style value.
 	 * @param {I.FileStyle} v - The file style value.
 	 */
-	fileStyleSet (v: I.FileStyle) {
+	fileStyleSet(v: I.FileStyle) {
 		v = Number(v);
 		this.fileStyleValue = v;
-		Storage.set('fileStyle', v);
-	};
+		Storage.set("fileStyle", v);
+	}
 
 	/**
 	 * Sets the date format value.
 	 * @param {I.DateFormat} v - The date format value.
 	 */
-	dateFormatSet (v: I.DateFormat) {
+	dateFormatSet(v: I.DateFormat) {
 		v = Number(v);
 		this.dateFormatValue = v;
-		Storage.set('dateFormat', v);
-	};
+		Storage.set("dateFormat", v);
+	}
 
 	/**
 	 * Sets the time format value.
 	 * @param {I.TimeFormat} v - The time format value.
 	 */
-	timeFormatSet (v: I.TimeFormat) {
+	timeFormatSet(v: I.TimeFormat) {
 		v = Number(v);
 		this.timeFormatValue = v;
-		Storage.set('timeFormat', v);
-	};
+		Storage.set("timeFormat", v);
+	}
 
 	/**
 	 * Sets the online status value.
 	 * @param {boolean} v - The online status value.
 	 */
-	isOnlineSet (v: boolean) {
+	isOnlineSet(v: boolean) {
 		this.isOnlineValue = Boolean(v);
-		console.log('[Online status]:', v);
-	};
+		console.log("[Online status]:", v);
+	}
 
 	/**
 	 * Sets the first day value.
 	 * @param {number} v - The first day value.
 	 */
-	firstDaySet (v: number) {
+	firstDaySet(v: number) {
 		this.firstDayValue = Number(v) || 1;
-		Storage.set('firstDay', this.firstDayValue);
-	};
+		Storage.set("firstDay", this.firstDayValue);
+	}
 
 	/**
 	 * Sets the vault messages value.
 	 * @param {boolean} v - The vault messages value.
 	 */
-	vaultMessagesSet (v: boolean) {
-		this.boolSet('vaultMessages', v);
-	};
+	vaultMessagesSet(v: boolean) {
+		this.boolSet("vaultMessages", v);
+	}
 
 	/**
 	 * Sets the vault isMinimal value.
 	 * @param {boolean} v - The vault isMinimal value.
 	 */
-	vaultIsMinimalSet (v: boolean) {
-		this.boolSet('vaultIsMinimal', v);
-	};
+	vaultIsMinimalSet(v: boolean) {
+		this.boolSet("vaultIsMinimal", v);
+	}
 
-	gridTitleClickSet (v: boolean) {
-		this.boolSet('gridTitleClick', v);
-	};
+	gridTitleClickSet(v: boolean) {
+		this.boolSet("gridTitleClick", v);
+	}
 
 	/**
 	 * Sets the config object, optionally forcing all values.
 	 * @param {any} config - The config object.
 	 * @param {boolean} force - Whether to force all values.
 	 */
-	configSet (config: any, force: boolean) {
+	configSet(config: any, force: boolean) {
 		let newConfig: any = {};
 		if (force) {
 			newConfig = Object.assign(newConfig, config);
@@ -969,72 +987,72 @@ class CommonStore {
 			for (const k in config) {
 				if (undefined === this.configObj[k]) {
 					newConfig[k] = config[k];
-				};
-			};
-		};
+				}
+			}
+		}
 
 		set(this.configObj, newConfig);
 
 		this.configObj.debug = this.configObj.debug || {};
 		this.singleTabSet(this.singleTab);
-		
+
 		keyboard.setBodyClass();
-	};
+	}
 
 	/**
 	 * Sets the space storage object.
 	 * @param {Partial<SpaceStorage>} value - The space storage value.
 	 */
-	spaceStorageSet (value: Partial<SpaceStorage>) {
+	spaceStorageSet(value: Partial<SpaceStorage>) {
 		set(this.spaceStorageObj, Object.assign(this.spaceStorageObj, value));
-	};
+	}
 
 	/**
 	 * Sets the data path value.
 	 * @param {string} v - The data path value.
 	 */
-	dataPathSet (v: string) {
-		this.dataPathValue = String(v || '');
-	};
+	dataPathSet(v: string) {
+		this.dataPathValue = String(v || "");
+	}
 
 	/**
 	 * Sets the diff value.
 	 * @param {I.Diff[]} diff - The diff value.
 	 */
-	diffSet (diff: I.Diff[]) {
+	diffSet(diff: I.Diff[]) {
 		this.diffValue = diff || [];
-	};
+	}
 
 	/**
 	 * Sets the window ID.
 	 * @param {string} id - The window ID.
 	 */
-	windowIdSet (id: string) {
-		this.windowId = String(id || '');
-	};
+	windowIdSet(id: string) {
+		this.windowId = String(id || "");
+	}
 
 	/**
 	 * Sets the tab ID.
 	 * @param {string} id - The tab ID.
 	 */
-	tabIdSet (id: string) {
-		this.tabId = String(id || '');
-	};
+	tabIdSet(id: string) {
+		this.tabId = String(id || "");
+	}
 
 	/**
 	 * Sets whether this tab is the active tab in the window.
 	 * @param {boolean} v - Whether this tab is active.
 	 */
-	isActiveTabSet (v: boolean) {
+	isActiveTabSet(v: boolean) {
 		this.isActiveTab = v;
-	};
+	}
 
 	/**
 	 * Gets the graph settings for a key.
 	 * @param {string} key - The key.
 	 * @returns {I.GraphSettings} The graph settings.
 	 */
-	getGraph (key: string): I.GraphSettings {
+	getGraph(key: string): I.GraphSettings {
 		const stored = Storage.get(key);
 		const def = U.Common.objectCopy(this.graphObj);
 		const result = Object.assign(def, stored);
@@ -1042,54 +1060,58 @@ class CommonStore {
 		// Ensure typeEdges has a default value
 		if (result.typeEdges === undefined) {
 			result.typeEdges = true;
-		};
+		}
 
 		return result;
-	};
+	}
 
 	/**
 	 * Gets a reference by ID.
 	 * @param {string} id - The reference ID.
 	 * @returns {any} The reference object.
 	 */
-	getRef (id: string) {
+	getRef(id: string) {
 		return this.refs.get(id);
-	};
+	}
 
 	/**
 	 * Gets the state key for a popup or full view.
 	 * @param {boolean} isPopup - Whether it is a popup.
 	 * @returns {string} The state key.
 	 */
-	getStateKey (isPopup: boolean): string {
-		return isPopup ? 'popup' : 'full';
-	};
+	getStateKey(isPopup: boolean): string {
+		return isPopup ? "popup" : "full";
+	}
 
 	/**
 	 * Gets the current state of the left sidebar.
 	 * @returns {page: string; subPage: string;} The current state shown in the sidebar
 	 */
-	getLeftSidebarState (): { page: string; subPage: string; } {
-		return this.leftSidebarStateValue || { page: '', subPage: '' };
-	};
+	getLeftSidebarState(): { page: string; subPage: string } {
+		return this.leftSidebarStateValue || { page: "", subPage: "" };
+	}
 
 	/**
 	 * Gets the current state of the right sidebar.
 	 * @param {boolean} isPopup - Whether it is a popup.
 	 * @returns {page: string; isOpen: boolean;} The current state shown in the sidebar
 	 */
-	getRightSidebarState (isPopup: boolean): I.SidebarRightState {
-		return this.rightSidebarStateValue[this.getStateKey(isPopup)] || { page: '' };
-	};
+	getRightSidebarState(isPopup: boolean): I.SidebarRightState {
+		return (
+			this.rightSidebarStateValue[this.getStateKey(isPopup)] || {
+				page: "",
+			}
+		);
+	}
 
 	/**
 	 * Gets the timeout value for a given ID.
 	 * @param {string} id - The timeout ID.
 	 * @returns {number} The timeout value.
 	 */
-	getTimeout (id: string): number {
+	getTimeout(id: string): number {
 		return Number(this.timeoutMap.get(id)) || 0;
-	};
+	}
 
 	/**
 	 * Sets a timeout for a given ID and function.
@@ -1097,7 +1119,7 @@ class CommonStore {
 	 * @param {number} delay - The timeout duration.
 	 * @param {() => void} func - The function to call after timeout.
 	 */
-	setTimeout (id: string, delay: number, func: () => void) {
+	setTimeout(id: string, delay: number, func: () => void) {
 		this.clearTimeout(id);
 
 		const t = window.setTimeout(() => {
@@ -1107,75 +1129,75 @@ class CommonStore {
 
 		this.timeoutMap.set(id, t);
 		return t;
-	};
+	}
 
 	/**
 	 * Clears a timeout with a given ID.
 	 * @param {string} id - The timeout ID.
 	 */
-	clearTimeout (id: string) {
+	clearTimeout(id: string) {
 		window.clearTimeout(this.getTimeout(id));
-	};
+	}
 
 	/**
 	 * Sets whether the window is focused.
 	 * @param {boolean} v - Whether the window is focused.
 	 */
-	windowIsFocusedSet (v: boolean) {
+	windowIsFocusedSet(v: boolean) {
 		this.windowIsFocused = Boolean(v);
-	};
+	}
 
-	recentEditModeSet (v: I.RecentEditMode) {
+	recentEditModeSet(v: I.RecentEditMode) {
 		this.recentEditModeValue = Number(v) || I.RecentEditMode.All;
-		Storage.set('recentEditMode', this.recentEditModeValue);
-	};
+		Storage.set("recentEditMode", this.recentEditModeValue);
+	}
 
-	nullifySpaceKeys () {
+	nullifySpaceKeys() {
 		this.defaultType = null;
 		this.widgetSectionsInit();
-	};
+	}
 
-	widgetSectionsInit () {
-		const saved = Storage.get('widgetSections') || [];
-		const full = [ ...saved ];
-		const order = [ 
-			I.WidgetSection.Unread, 
-			I.WidgetSection.Pin, 
-			I.WidgetSection.RecentEdit, 
-			I.WidgetSection.Type, 
+	widgetSectionsInit() {
+		const saved = Storage.get("widgetSections") || [];
+		const full = [...saved];
+		const order = [
+			I.WidgetSection.Unread,
+			I.WidgetSection.Pin,
+			I.WidgetSection.RecentEdit,
+			I.WidgetSection.Type,
 			I.WidgetSection.Bin,
 		];
 
+		const existingIds = new Set(full.map((it) => it.id));
 		for (const id of order) {
-			if (!full.find(it => it.id == id)) {
+			if (!existingIds.has(id)) {
 				full.push({ id, isClosed: false, isHidden: false });
-			};
-		};
+			}
+		}
 
 		if (!U.Common.compareJSON(full, this.widgetSectionsValue)) {
 			this.widgetSectionsValue = full;
-		};
-	};
+		}
+	}
 
-	widgetSectionsSet (sections: I.WidgetSectionParam[]) {
+	widgetSectionsSet(sections: I.WidgetSectionParam[]) {
 		this.widgetSectionsValue = sections || [];
-		Storage.set('widgetSections', this.widgetSectionsValue);
-	};
+		Storage.set("widgetSections", this.widgetSectionsValue);
+	}
 
-	checkWidgetSection (id: I.WidgetSection): boolean {
-		const section = this.widgetSections.find(it => it.id == id);
+	checkWidgetSection(id: I.WidgetSection): boolean {
+		const section = this.widgetSections.find((it) => it.id == id);
 		return section && !section.isClosed && !section.isHidden;
-	};
+	}
 
-	getWidgetSection (id: I.WidgetSection) {
-		return this.widgetSections.find(it => it.id == id);
-	};
+	getWidgetSection(id: I.WidgetSection) {
+		return this.widgetSections.find((it) => it.id == id);
+	}
 
-	updateWidgetSection (param: Partial<I.WidgetSectionParam>) {
+	updateWidgetSection(param: Partial<I.WidgetSectionParam>) {
 		set(this.getWidgetSection(param.id), param);
 		this.widgetSectionsSet(this.widgetSections);
-	};
-
-};
+	}
+}
 
 export const Common: CommonStore = new CommonStore();

--- a/src/ts/store/menu.ts
+++ b/src/ts/store/menu.ts
@@ -1,15 +1,14 @@
-import { observable, action, computed, set, makeObservable } from 'mobx';
-import $ from 'jquery';
-import { I, U, J, Preview } from 'Lib';
+import { observable, action, computed, set, makeObservable } from "mobx";
+import $ from "jquery";
+import { I, U, J, Preview } from "Lib";
 
 class MenuStore {
-
 	public menuList: I.Menu[] = [];
 
 	timeout = 0;
 	isAnimatingFlag: Map<string, boolean> = new Map();
 
-	constructor () {
+	constructor() {
 		makeObservable(this, {
 			menuList: observable,
 			list: computed,
@@ -17,23 +16,23 @@ class MenuStore {
 			update: action,
 			updateData: action,
 			close: action,
-			closeAll: action
+			closeAll: action,
 		});
-	};
+	}
 
 	get list(): I.Menu[] {
 		return this.menuList;
-	};
+	}
 
 	/**
 	 * Opens a menu with the given ID and parameters.
 	 * @param {string} id - The menu ID.
 	 * @param {I.MenuParam} param - The menu parameters.
 	 */
-	open (id: string, param: I.MenuParam) {
+	open(id: string, param: I.MenuParam) {
 		if (!id) {
 			return;
-		};
+		}
 
 		param = this.normaliseParam(param);
 
@@ -42,11 +41,11 @@ class MenuStore {
 			this.update(id, param);
 		} else {
 			this.menuList.push({ id, param });
-		};
+		}
 
 		U.Data.updateTabsDimmer();
 		Preview.previewHide(true);
-	};
+	}
 
 	/**
 	 * Normalises menu parameters, setting defaults as needed.
@@ -54,44 +53,50 @@ class MenuStore {
 	 * @param {I.MenuParam} param - The menu parameters.
 	 * @returns {I.MenuParam} The normalised parameters.
 	 */
-	normaliseParam (param: I.MenuParam) {
+	normaliseParam(param: I.MenuParam) {
 		param.type = Number(param.type) || I.MenuType.Vertical;
 		param.vertical = Number(param.vertical) || I.MenuDirection.Bottom;
 		param.horizontal = Number(param.horizontal) || I.MenuDirection.Left;
 		param.data = param.data || {};
 
 		if (param.isSub) {
-			param.noAnimation = 'undefined' == typeof(param.noAnimation) ? true : param.noAnimation;
-			param.passThrough = 'undefined' == typeof(param.passThrough) ? true : param.passThrough;
-		};
+			param.noAnimation =
+				"undefined" == typeof param.noAnimation
+					? true
+					: param.noAnimation;
+			param.passThrough =
+				"undefined" == typeof param.passThrough
+					? true
+					: param.passThrough;
+		}
 
 		return param;
-	};
+	}
 
 	/**
 	 * Updates a menu with the given ID and parameters.
 	 * @param {string} id - The menu ID.
 	 * @param {any} param - The menu parameters.
 	 */
-	update (id: string, param: any) {
+	update(id: string, param: any) {
 		const item = this.get(id);
 		if (item) {
 			param.data = Object.assign(item.param.data, param.data);
 			set(item, { param: Object.assign(item.param, param) });
-		};
-	};
+		}
+	}
 
 	/**
 	 * Updates the data of a menu with the given ID.
 	 * @param {string} id - The menu ID.
 	 * @param {any} data - The new data.
 	 */
-	updateData (id: string, data: any) {
+	updateData(id: string, data: any) {
 		const item = this.get(id);
 		if (item) {
 			set(item.param.data, data);
-		};
-	};
+		}
+	}
 
 	/**
 	 * Replaces a menu with a new ID and parameters.
@@ -99,23 +104,23 @@ class MenuStore {
 	 * @param {string} newId - The new menu ID.
 	 * @param {I.MenuParam} param - The menu parameters.
 	 */
-	replace (oldId: string, newId: string, param: I.MenuParam) {
-		const idx = this.menuList.findIndex(it => it.id == oldId);
+	replace(oldId: string, newId: string, param: I.MenuParam) {
+		const idx = this.menuList.findIndex((it) => it.id == oldId);
 		if (idx >= 0) {
 			set(this.menuList[idx], { id: newId, param });
 		} else {
 			this.menuList.push({ id: newId, param });
-		};
-	};
+		}
+	}
 
 	/**
 	 * Gets a menu by ID.
 	 * @param {string} id - The menu ID.
 	 * @returns {I.Menu} The menu object.
 	 */
-	get (id: string): I.Menu {
-		return this.menuList.find(it => it.id == id);
-	};
+	get(id: string): I.Menu {
+		return this.menuList.find((it) => it.id == id);
+	}
 
 	/**
 	 * Checks if a menu is open.
@@ -124,24 +129,29 @@ class MenuStore {
 	 * @param {string[]} [filter] - Filter for menu IDs.
 	 * @returns {boolean} True if open, false otherwise.
 	 */
-	isOpen (id?: string, key?: string, filter?: string[]): boolean {
+	isOpen(id?: string, key?: string, filter?: string[]): boolean {
 		if (!id) {
 			let length = 0;
 			if (filter) {
-				length = this.menuList.filter(it => filter ? !filter.includes(it.id) && !filter.includes(it.param.component) : true).length;
+				const filterSet = new Set(filter);
+				length = this.menuList.filter(
+					(it) =>
+						!filterSet.has(it.id) &&
+						!filterSet.has(it.param.component),
+				).length;
 			} else {
 				length = this.menuList.length;
-			};
+			}
 			return length > 0;
-		};
+		}
 
 		const item = this.get(id);
 		if (!item) {
 			return false;
-		};
+		}
 
-		return key ? (item.param.menuKey == key) : true;
-	};
+		return key ? item.param.menuKey == key : true;
+	}
 
 	/**
 	 * Checks if any menu in a list of IDs is open.
@@ -149,26 +159,26 @@ class MenuStore {
 	 * @param {string[]} ids - The menu IDs.
 	 * @returns {boolean} True if any menu is open, false otherwise.
 	 */
-	isOpenList (ids: string[]) {
+	isOpenList(ids: string[]) {
 		for (const id of ids) {
 			if (this.isOpen(id)) {
 				return true;
-			};
-		};
+			}
+		}
 		return false;
-	};
+	}
 
 	/**
 	 * Closes a menu by ID.
 	 * @param {string} id - The menu ID.
 	 * @param {() => void} [callBack] - Optional callback after close.
 	 */
-	close (id: string, callBack?: () => void) {
+	close(id: string, callBack?: () => void) {
 		const item = this.get(id);
 		if (!item) {
 			callBack?.();
 			return;
-		};
+		}
 
 		const { param } = item;
 		const { noAnimation, subIds, onClose } = param;
@@ -177,14 +187,14 @@ class MenuStore {
 
 		if (subIds && subIds.length) {
 			this.closeAll(subIds);
-		};
+		}
 
 		if (el.length) {
-			el.toggleClass('noAnimation', noAnimation);
-			el.css({ transform: '' }).removeClass('show');
-		};
+			el.toggleClass("noAnimation", noAnimation);
+			el.css({ transform: "" }).removeClass("show");
+		}
 
-		const filtered = this.menuList.filter(it => it.id != id);
+		const filtered = this.menuList.filter((it) => it.id != id);
 		U.Data.updateTabsDimmer(null, filtered);
 
 		const onTimeout = () => {
@@ -201,8 +211,8 @@ class MenuStore {
 			window.setTimeout(onTimeout, t);
 		} else {
 			onTimeout();
-		};
-	};
+		}
+	}
 
 	/**
 	 * Sets the animating flag for a menu ID.
@@ -210,9 +220,9 @@ class MenuStore {
 	 * @param {string} id - The menu ID.
 	 * @param {boolean} v - The animating value.
 	 */
-	setIsAnimating (id: string, v: boolean) {
+	setIsAnimating(id: string, v: boolean) {
 		this.isAnimatingFlag.set(id, v);
-	};
+	}
 
 	/**
 	 * Checks if a menu is animating.
@@ -220,27 +230,29 @@ class MenuStore {
 	 * @param {string} id - The menu ID.
 	 * @returns {boolean} True if animating, false otherwise.
 	 */
-	isAnimating (id: string): boolean {
+	isAnimating(id: string): boolean {
 		return !!this.isAnimatingFlag.get(id);
-	};
+	}
 
 	/**
 	 * Closes all menus, optionally filtered by IDs.
 	 * @param {string[]} [ids] - Menu IDs to close.
 	 * @param {() => void} [callBack] - Optional callback after close.
 	 */
-	closeAll (ids?: string[], callBack?: () => void) {
+	closeAll(ids?: string[], callBack?: () => void) {
 		const items = this.getItems(ids);
 		if (!items.length) {
 			callBack?.();
 			return;
-		};
-		
+		}
+
 		const timeout = this.getTimeout(ids);
 
-		items.filter(it => !it.param.noClose).forEach(it => this.close(it.id));
+		items
+			.filter((it) => !it.param.noClose)
+			.forEach((it) => this.close(it.id));
 		this.onCloseAll(timeout, callBack);
-	};
+	}
 
 	/**
 	 * Closes all menus forcibly, optionally filtered by IDs.
@@ -248,13 +260,13 @@ class MenuStore {
 	 * @param {string[]} [ids] - Menu IDs to close.
 	 * @param {() => void} [callBack] - Optional callback after close.
 	 */
-	closeAllForced (ids?: string[], callBack?: () => void) {
+	closeAllForced(ids?: string[], callBack?: () => void) {
 		const items = this.getItems(ids);
 		const timeout = this.getTimeout(ids);
 
-		items.forEach(it => this.close(it.id));
+		items.forEach((it) => this.close(it.id));
 		this.onCloseAll(timeout, callBack);
-	};
+	}
 
 	/**
 	 * Handles the callback after closing all menus with a timeout.
@@ -262,14 +274,14 @@ class MenuStore {
 	 * @param {number} timeout - The timeout duration.
 	 * @param {() => void} [callBack] - Optional callback after close.
 	 */
-	onCloseAll (timeout: number, callBack?: () => void) {
+	onCloseAll(timeout: number, callBack?: () => void) {
 		if (!callBack) {
 			return;
-		};
+		}
 
 		this.clearTimeout();
 		this.timeout = window.setTimeout(() => callBack(), timeout);
-	};
+	}
 
 	/**
 	 * Gets the timeout value for a set of menu IDs.
@@ -277,7 +289,7 @@ class MenuStore {
 	 * @param {string[]} [ids] - Menu IDs.
 	 * @returns {number} The timeout value.
 	 */
-	getTimeout (ids?: string[]): number {
+	getTimeout(ids?: string[]): number {
 		const items = this.getItems(ids);
 
 		let t = 0;
@@ -285,10 +297,10 @@ class MenuStore {
 			if (!item.param.noAnimation) {
 				t = J.Constant.delay.menu;
 				break;
-			};
-		};
+			}
+		}
 		return t;
-	};
+	}
 
 	/**
 	 * Gets the menu items, optionally filtered by IDs.
@@ -296,28 +308,30 @@ class MenuStore {
 	 * @param {string[]} [ids] - Menu IDs.
 	 * @returns {I.Menu[]} The menu items.
 	 */
-	getItems (ids?: string[]) {
-		return ids && ids.length ? this.menuList.filter(it => ids.includes(it.id)) : this.menuList;
-	};
+	getItems(ids?: string[]) {
+		return ids && ids.length
+			? this.menuList.filter((it) => ids.includes(it.id))
+			: this.menuList;
+	}
 
 	/**
 	 * Closes the last open menu.
 	 * @private
 	 */
-	closeLast () {
-		const items = this.getItems(null).filter(it => !it.param.noClose);
+	closeLast() {
+		const items = this.getItems(null).filter((it) => !it.param.noClose);
 		if (items.length) {
 			this.close(items[items.length - 1].id);
-		};
-	};
+		}
+	}
 
 	/**
 	 * Clears the menu close timeout.
 	 * @private
 	 */
-	clearTimeout () {
+	clearTimeout() {
 		window.clearTimeout(this.timeout);
-	};
+	}
 
 	/**
 	 * Checks if a menu with a given key is open.
@@ -325,19 +339,22 @@ class MenuStore {
 	 * @param {string} key - The menu key.
 	 * @returns {boolean} True if open, false otherwise.
 	 */
-	checkKey (key: string) {
-		return this.menuList.find(it => it.param.menuKey == key) ? true : false;
-	};
+	checkKey(key: string) {
+		return this.menuList.find((it) => it.param.menuKey == key)
+			? true
+			: false;
+	}
 
 	/**
 	 * Triggers resize events for all open menus.
 	 * @private
 	 */
-	resizeAll () {
+	resizeAll() {
 		const win = $(window);
-		this.list.forEach(it => win.trigger(`resize.${U.String.toCamelCase(`menu-${it.id}`)}`));
-	};
-
-};
+		this.list.forEach((it) =>
+			win.trigger(`resize.${U.String.toCamelCase(`menu-${it.id}`)}`),
+		);
+	}
+}
 
 export const Menu: MenuStore = new MenuStore();

--- a/src/ts/store/record.ts
+++ b/src/ts/store/record.ts
@@ -1,10 +1,10 @@
-import { observable, action, set, makeObservable } from 'mobx';
-import { S, I, M, U, J, Dataview, Relation } from 'Lib';
+import { observable, action, set, makeObservable } from "mobx";
+import { S, I, M, U, J, Dataview, Relation } from "Lib";
 
 enum KeyMapType {
-	Relation = 'relation',
-	Type = 'type',
-};
+	Relation = "relation",
+	Type = "type",
+}
 
 /**
  * RecordStore manages dataview records, views, relations, and groups.
@@ -25,7 +25,6 @@ enum KeyMapType {
  * - spaceMap: targetSpaceId -> spaceViewId
  */
 class RecordStore {
-
 	public relationMap: Map<string, any[]> = observable(new Map());
 	public relationKeyMap: Map<string, Map<string, string>> = new Map();
 	public typeKeyMap: Map<string, Map<string, string>> = new Map();
@@ -61,7 +60,7 @@ class RecordStore {
 	/**
 	 * Clears all record-related maps in the store.
 	 */
-	clearAll () {
+	clearAll() {
 		this.relationMap.clear();
 		this.relationKeyMap.clear();
 		this.typeKeyMap.clear();
@@ -70,7 +69,7 @@ class RecordStore {
 		this.metaMap.clear();
 		this.groupMap.clear();
 		this.spaceMap.clear();
-	};
+	}
 
 	/**
 	 * Gets or creates a key map of the specified type for a space.
@@ -78,17 +77,17 @@ class RecordStore {
 	 * @param {string} spaceId - The space ID.
 	 * @returns {Map<string, string>} The key map.
 	 */
-	keyMapGet (type: string, spaceId: string) {
+	keyMapGet(type: string, spaceId: string) {
 		const key = `${type}KeyMap`;
 
 		let map = this[key].get(spaceId);
 		if (!map) {
 			map = new Map();
 			this[key].set(spaceId, map);
-		};
+		}
 
 		return map;
-	}; 
+	}
 
 	/**
 	 * Sets a relation key map entry for a space.
@@ -96,21 +95,21 @@ class RecordStore {
 	 * @param {string} key - The relation key.
 	 * @param {string} id - The relation ID.
 	 */
-	relationKeyMapSet (spaceId: string, key: string, id: string) {
+	relationKeyMapSet(spaceId: string, key: string, id: string) {
 		if (spaceId && key && id) {
 			this.keyMapGet(KeyMapType.Relation, spaceId).set(key, id);
-		};
-	};
+		}
+	}
 
 	/**
 	 * Gets a relation ID by key for the current space.
 	 * @param {string} key - The relation key.
 	 * @returns {string} The relation ID.
 	 */
-	relationKeyMapGet (key: string): string {
+	relationKeyMapGet(key: string): string {
 		const map = this.keyMapGet(KeyMapType.Relation, S.Common.space);
 		return map?.get(key);
-	};
+	}
 
 	/**
 	 * Sets a type key map entry for a space.
@@ -118,21 +117,21 @@ class RecordStore {
 	 * @param {string} key - The type key.
 	 * @param {string} id - The type ID.
 	 */
-	typeKeyMapSet (spaceId: string, key: string, id: string) {
+	typeKeyMapSet(spaceId: string, key: string, id: string) {
 		if (spaceId && key && id) {
 			this.keyMapGet(KeyMapType.Type, spaceId).set(key, id);
-		};
-	};
+		}
+	}
 
 	/**
 	 * Gets a type ID by key for the current space.
 	 * @param {string} key - The type key.
 	 * @returns {string} The type ID.
 	 */
-	typeKeyMapGet (key: string): string {
+	typeKeyMapGet(key: string): string {
 		const map = this.keyMapGet(KeyMapType.Type, S.Common.space);
 		return map.get(key);
-	};
+	}
 
 	/**
 	 * Sets the relations for a block in a root.
@@ -140,13 +139,22 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @param {any[]} list - The relations list.
 	 */
-	relationsSet (rootId: string, blockId: string, list: any[]) {
+	relationsSet(rootId: string, blockId: string, list: any[]) {
 		const key = this.getId(rootId, blockId);
-		const relations = (this.relationMap.get(this.getId(rootId, blockId)) || []).
-			concat(list.map(it => ({ relationKey: it.relationKey, format: it.format })));
+		const relations = (
+			this.relationMap.get(this.getId(rootId, blockId)) || []
+		).concat(
+			list.map((it) => ({
+				relationKey: it.relationKey,
+				format: it.format,
+			})),
+		);
 
-		this.relationMap.set(key, U.Common.arrayUniqueObjects(relations, 'relationKey'));
-	};
+		this.relationMap.set(
+			key,
+			U.Common.arrayUniqueObjects(relations, "relationKey"),
+		);
+	}
 
 	/**
 	 * Deletes relations by keys for a block in a root.
@@ -154,12 +162,20 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @param {string[]} keys - The relation keys to delete.
 	 */
-	relationListDelete (rootId: string, blockId: string, keys: string[]) {
+	relationListDelete(rootId: string, blockId: string, keys: string[]) {
 		const key = this.getId(rootId, blockId);
-		const relations = this.getDataviewRelations(rootId, blockId).filter(it => !keys.includes(it.relationKey));
-		
-		this.relationMap.set(key, relations.map(it => ({ relationKey: it.relationKey, format: it.format })));
-	};
+		const relations = this.getDataviewRelations(rootId, blockId).filter(
+			(it) => !keys.includes(it.relationKey),
+		);
+
+		this.relationMap.set(
+			key,
+			relations.map((it) => ({
+				relationKey: it.relationKey,
+				format: it.format,
+			})),
+		);
+	}
 
 	/**
 	 * Sets the views for a block in a root.
@@ -167,13 +183,13 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @param {I.View[]} list - The views list.
 	 */
-	viewsSet (rootId: string, blockId: string, list: I.View[]) {
+	viewsSet(rootId: string, blockId: string, list: I.View[]) {
 		const key = this.getId(rootId, blockId);
 		const views = this.getViews(rootId, blockId);
 
-		list = list.map((it: I.View) => { 
+		list = list.map((it: I.View) => {
 			it.relations = Dataview.viewGetRelations(rootId, blockId, it);
-			return new M.View(it); 
+			return new M.View(it);
 		});
 
 		for (const item of list) {
@@ -182,11 +198,11 @@ class RecordStore {
 				this.viewUpdate(rootId, blockId, item);
 			} else {
 				views.push(observable(item));
-			};
-		};
-		
+			}
+		}
+
 		this.viewMap.set(key, observable.array(views));
-	};
+	}
 
 	/**
 	 * Sorts the views for a block in a root by IDs.
@@ -194,29 +210,27 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @param {string[]} ids - The view IDs in order.
 	 */
-	viewsSort (rootId: string, blockId: string, ids: string[]) {
+	viewsSort(rootId: string, blockId: string, ids: string[]) {
 		const views = this.getViews(rootId, blockId);
 
-		views.sort((c1: any, c2: any) => {
-			const i1 = ids.indexOf(c1.id);
-			const i2 = ids.indexOf(c2.id);
-
-			if (i1 > i2) return 1; 
-			if (i1 < i2) return -1;
-			return 0;
-		});
+		const orderMap = new Map(ids.map((id, i) => [id, i]));
+		views.sort(
+			(c1: any, c2: any) =>
+				(orderMap.get(c1.id) ?? Infinity) -
+				(orderMap.get(c2.id) ?? Infinity),
+		);
 
 		this.viewsSet(rootId, blockId, views);
-	};
+	}
 
 	/**
 	 * Clears the views for a block in a root.
 	 * @param {string} rootId - The root ID.
 	 * @param {string} blockId - The block ID.
 	 */
-	viewsClear (rootId: string, blockId: string) {
+	viewsClear(rootId: string, blockId: string) {
 		this.viewMap.delete(this.getId(rootId, blockId));
-	};
+	}
 
 	/**
 	 * Adds a view to a block in a root.
@@ -224,7 +238,7 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @param {any} item - The view item.
 	 */
-	viewAdd (rootId: string, blockId: string, item: any) {
+	viewAdd(rootId: string, blockId: string, item: any) {
 		const views = this.getViews(rootId, blockId);
 		const view = this.getView(rootId, blockId, item.id);
 
@@ -232,8 +246,8 @@ class RecordStore {
 			this.viewUpdate(rootId, blockId, item);
 		} else {
 			views.push(new M.View(item));
-		};
-	};
+		}
+	}
 
 	/**
 	 * Updates a view for a block in a root.
@@ -241,19 +255,19 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @param {any} item - The view item.
 	 */
-	viewUpdate (rootId: string, blockId: string, item: any) {
+	viewUpdate(rootId: string, blockId: string, item: any) {
 		const views = this.getViews(rootId, blockId);
-		const idx = views.findIndex(it => it.id == item.id);
+		const idx = views.findIndex((it) => it.id == item.id);
 
 		if (idx < 0) {
 			return;
-		};
+		}
 
 		if (item.relations) {
 			item.relations = Dataview.viewGetRelations(rootId, blockId, item);
-		};
+		}
 		set(views[idx], item);
-	};
+	}
 
 	/**
 	 * Deletes a view by ID for a block in a root.
@@ -261,9 +275,12 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @param {string} id - The view ID.
 	 */
-	viewDelete (rootId: string, blockId: string, id: string) {
-		this.viewMap.set(this.getId(rootId, blockId), this.getViews(rootId, blockId).filter(it => it.id != id));
-	};
+	viewDelete(rootId: string, blockId: string, id: string) {
+		this.viewMap.set(
+			this.getId(rootId, blockId),
+			this.getViews(rootId, blockId).filter((it) => it.id != id),
+		);
+	}
 
 	/**
 	 * Sets the meta information for a block in a root.
@@ -271,7 +288,7 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @param {any} meta - The meta information.
 	 */
-	metaSet (rootId: string, blockId: string, meta: any) {
+	metaSet(rootId: string, blockId: string, meta: any) {
 		const data = this.metaMap.get(this.getId(rootId, blockId));
 
 		if (data) {
@@ -279,22 +296,22 @@ class RecordStore {
 		} else {
 			meta.total = Number(meta.total) || 0;
 			meta.offset = Math.max(0, Number(meta.offset) || 0);
-			meta.viewId = String(meta.viewId || '');
+			meta.viewId = String(meta.viewId || "");
 			meta.keys = meta.keys || [];
 			meta = observable(meta);
 
 			this.metaMap.set(this.getId(rootId, blockId), meta);
-		};
-	};
+		}
+	}
 
 	/**
 	 * Clears the meta information for a block in a root.
 	 * @param {string} rootId - The root ID.
 	 * @param {string} blockId - The block ID.
 	 */
-	metaClear (rootId: string, blockId: string) {
+	metaClear(rootId: string, blockId: string) {
 		this.metaMap.delete(this.getId(rootId, blockId));
-	};
+	}
 
 	/**
 	 * Sets the record IDs for a block in a root.
@@ -302,18 +319,18 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @param {string[]} list - The record IDs.
 	 */
-	recordsSet (rootId: string, blockId: string, list: string[]) {
+	recordsSet(rootId: string, blockId: string, list: string[]) {
 		this.recordMap.set(this.getId(rootId, blockId), observable.array(list));
-	};
+	}
 
 	/**
 	 * Clears the record IDs for a block in a root.
 	 * @param {string} rootId - The root ID.
 	 * @param {string} blockId - The block ID.
 	 */
-	recordsClear (rootId: string, blockId: string) {
+	recordsClear(rootId: string, blockId: string) {
 		this.recordMap.delete(this.getId(rootId, blockId));
-	};
+	}
 
 	/**
 	 * Adds a record ID at a specific index for a block in a root.
@@ -322,12 +339,12 @@ class RecordStore {
 	 * @param {string} id - The record ID.
 	 * @param {number} index - The index to insert at.
 	 */
-	recordAdd (rootId: string, blockId: string, id: string, index: number) {
+	recordAdd(rootId: string, blockId: string, id: string, index: number) {
 		const records = this.getRecordIds(rootId, blockId);
-		
+
 		records.splice(index, 0, id);
 		this.recordsSet(rootId, blockId, records);
-	};
+	}
 
 	/**
 	 * Deletes a record ID for a block in a root.
@@ -335,9 +352,12 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @param {string} id - The record ID.
 	 */
-	recordDelete (rootId: string, blockId: string, id: string) {
-		this.recordMap.set(this.getId(rootId, blockId), this.getRecordIds(rootId, blockId).filter(it => it != id));
-	};
+	recordDelete(rootId: string, blockId: string, id: string) {
+		this.recordMap.set(
+			this.getId(rootId, blockId),
+			this.getRecordIds(rootId, blockId).filter((it) => it != id),
+		);
+	}
 
 	/**
 	 * Sets the groups for a block in a root.
@@ -345,9 +365,12 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @param {any[]} groups - The groups array.
 	 */
-	groupsSet (rootId: string, blockId: string, groups: any[]) {
-		this.groupMap.set(this.getGroupSubId(rootId, blockId, 'groups'), observable(groups));
-	};
+	groupsSet(rootId: string, blockId: string, groups: any[]) {
+		this.groupMap.set(
+			this.getGroupSubId(rootId, blockId, "groups"),
+			observable(groups),
+		);
+	}
 
 	/**
 	 * Adds groups to a block in a root.
@@ -355,18 +378,17 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @param {any[]} groups - The groups array.
 	 */
-	groupsAdd (rootId: string, blockId: string, groups: any[]) {
+	groupsAdd(rootId: string, blockId: string, groups: any[]) {
 		const list = this.getGroups(rootId, blockId);
 
+		const existingIds = new Set(list.map((it) => it.id));
 		for (const group of groups) {
-			if (list.find(it => it.id == group.id)) {
-				continue;
-			};
+			if (existingIds.has(group.id)) continue;
 			list.push(group);
-		};
+		}
 
-		this.groupMap.set(this.getGroupSubId(rootId, blockId, 'groups'), list);
-	};
+		this.groupMap.set(this.getGroupSubId(rootId, blockId, "groups"), list);
+	}
 
 	/**
 	 * Removes groups by IDs from a block in a root.
@@ -374,25 +396,34 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @param {string[]} ids - The group IDs to remove.
 	 */
-	groupsRemove (rootId: string, blockId: string, ids: string[]) {
+	groupsRemove(rootId: string, blockId: string, ids: string[]) {
 		const groups = this.getGroups(rootId, blockId);
 
 		ids.forEach((id: string) => {
-			const subId = this.getSubId(rootId, [ blockId, id ].join('-'));
-			this.recordsClear(subId, '');
+			const subId = this.getSubId(rootId, [blockId, id].join("-"));
+			this.recordsClear(subId, "");
 		});
 
-		this.groupsSet(rootId, blockId, groups.filter(it => !ids.includes(it.id)));
-	};
+		const idsSet = new Set(ids);
+		this.groupsSet(
+			rootId,
+			blockId,
+			groups.filter((it) => !idsSet.has(it.id)),
+		);
+	}
 
 	/**
 	 * Clears all groups from a block in a root.
 	 * @param {string} rootId - The root ID.
 	 * @param {string} blockId - The block ID.
 	 */
-	groupsClear (rootId: string, blockId: string) {
-		this.groupsRemove(rootId, blockId, this.getGroups(rootId, blockId).map(it => it.id));
-	};
+	groupsClear(rootId: string, blockId: string) {
+		this.groupsRemove(
+			rootId,
+			blockId,
+			this.getGroups(rootId, blockId).map((it) => it.id),
+		);
+	}
 
 	/**
 	 * Gets a type object by its ID.
@@ -400,14 +431,18 @@ class RecordStore {
 	 * @param {string} id - The type ID.
 	 * @returns {any|null} The type object or null.
 	 */
-	getTypeById (id: string) {
+	getTypeById(id: string) {
 		if (!id) {
 			return null;
-		};
+		}
 
-		const object = S.Detail.get(U.Subscription.spaceSubId(J.Constant.subId.type), id, J.Relation.type);
+		const object = S.Detail.get(
+			U.Subscription.spaceSubId(J.Constant.subId.type),
+			id,
+			J.Relation.type,
+		);
 		return object._empty_ ? null : object;
-	};
+	}
 
 	/**
 	 * Gets a type object by its key.
@@ -415,14 +450,14 @@ class RecordStore {
 	 * @param {string} key - The type key.
 	 * @returns {any|null} The type object or null.
 	 */
-	getTypeByKey (key: string): any {
+	getTypeByKey(key: string): any {
 		if (!key) {
 			return null;
-		};
+		}
 
 		const id = this.typeKeyMapGet(key);
 		return id ? this.getTypeById(id) : null;
-	};
+	}
 
 	/**
 	 * Gets the featured relations for a type.
@@ -430,10 +465,12 @@ class RecordStore {
 	 * @param {string} id - The type ID.
 	 * @returns {any[]} The featured relations.
 	 */
-	getTypeFeaturedRelations (id: string) {
+	getTypeFeaturedRelations(id: string) {
 		const type = this.getTypeById(id);
-		return (type?.recommendedFeaturedRelations || []).map(it => this.getRelationById(it)).filter(it => it);
-	};
+		return (type?.recommendedFeaturedRelations || [])
+			.map((it) => this.getRelationById(it))
+			.filter((it) => it);
+	}
 
 	/**
 	 * Gets the recommended relations for a type.
@@ -441,112 +478,125 @@ class RecordStore {
 	 * @param {string} id - The type ID.
 	 * @returns {any[]} The recommended relations.
 	 */
-	getTypeRecommendedRelations (id: string) {
+	getTypeRecommendedRelations(id: string) {
 		const type = this.getTypeById(id);
-		return (type?.recommendedRelations || []).map(it => this.getRelationById(it)).filter(it => it);
-	};
+		return (type?.recommendedRelations || [])
+			.map((it) => this.getRelationById(it))
+			.filter((it) => it);
+	}
 
 	/**
 	 * Gets the template type object.
 	 * @private
 	 * @returns {any|null} The template type object or null.
 	 */
-	getTemplateType () {
+	getTemplateType() {
 		return this.getTypeByKey(J.Constant.typeKey.template);
-	};
+	}
 
 	/**
 	 * Gets the collection type object.
 	 * @private
 	 * @returns {any|null} The collection type object or null.
 	 */
-	getCollectionType () {
+	getCollectionType() {
 		return this.getTypeByKey(J.Constant.typeKey.collection);
-	};
+	}
 
 	/**
 	 * Gets the set type object.
 	 * @private
 	 * @returns {any|null} The set type object or null.
 	 */
-	getSetType () {
+	getSetType() {
 		return this.getTypeByKey(J.Constant.typeKey.set);
-	};
+	}
 
 	/**
 	 * Gets the chat type object.
 	 * @private
 	 * @returns {any|null} The chat type object or null.
 	 */
-	getChatType () {
+	getChatType() {
 		return this.getTypeByKey(J.Constant.typeKey.chatDerived);
-	};
+	}
 
 	/**
 	 * Gets the space type object.
 	 * @private
 	 * @returns {any|null} The space type object or null.
 	 */
-	getSpaceType () {
+	getSpaceType() {
 		return this.getTypeByKey(J.Constant.typeKey.space);
-	};
+	}
 
 	/**
 	 * Gets the type type object.
 	 * @private
 	 * @returns {any|null} The type type object or null.
 	 */
-	getTypeType () {
+	getTypeType() {
 		return this.getTypeByKey(J.Constant.typeKey.type);
-	};
+	}
 
 	/**
 	 * Gets the bookmark type object.
 	 * @private
 	 * @returns {any|null} The bookmark type object or null.
 	 */
-	getBookmarkType () {
+	getBookmarkType() {
 		return this.getTypeByKey(J.Constant.typeKey.bookmark);
-	};
+	}
 
 	/**
 	 * Gets the page type object.
 	 * @private
 	 * @returns {any|null} The page type object or null.
 	 */
-	getPageType () {
+	getPageType() {
 		return this.getTypeByKey(J.Constant.typeKey.page);
-	};
+	}
 
 	/**
 	 * Gets the file type object.
 	 * @private
 	 * @returns {any|null} The file type object or null.
 	 */
-	getFileType () {
+	getFileType() {
 		return this.getTypeByKey(J.Constant.typeKey.file);
-	};
+	}
 
 	/**
 	 * Gets the participant type object.
 	 * @private
 	 * @returns {any|null} The participant type object or null.
 	 */
-	getParticipantType () {
+	getParticipantType() {
 		return this.getTypeByKey(J.Constant.typeKey.participant);
-	};
+	}
 
 	/**
 	 * Gets all type objects.
 	 * @private
 	 * @returns {any[]} The type objects.
 	 */
-	getTypes () {
+	getTypes() {
 		const subId = U.Subscription.spaceSubId(J.Constant.subId.type);
-		return this.sortTypes(this.getRecordIds(subId, '').
-			map(id => S.Detail.get(subId, id, U.Subscription.typeRelationKeys(true))).
-			filter(it => it && !it._empty_ && !it.isArchived && !it.isDeleted));
-	};
+		return this.sortTypes(
+			this.getRecordIds(subId, "")
+				.map((id) =>
+					S.Detail.get(
+						subId,
+						id,
+						U.Subscription.typeRelationKeys(true),
+					),
+				)
+				.filter(
+					(it) =>
+						it && !it._empty_ && !it.isArchived && !it.isDeleted,
+				),
+		);
+	}
 
 	/**
 	 * Sorts a list of types by tmpOrder, orderId, and name.
@@ -554,27 +604,35 @@ class RecordStore {
 	 * @param {any[]} list - The list of types to sort.
 	 * @returns {any[]} The sorted list of types.
 	 */
-	sortTypes (list: any[]) {
+	sortTypes(list: any[]) {
 		const spaceview = U.Space.getSpaceview();
 
 		return (list || []).sort((c1, c2) => {
 			return (
 				U.Data.sortByOrderId(c1, c2) ||
-				U.Data.sortByTypeKey(c1, c2, spaceview.isChat || spaceview.isOneToOne) ||
+				U.Data.sortByTypeKey(
+					c1,
+					c2,
+					spaceview.isChat || spaceview.isOneToOne,
+				) ||
 				U.Data.sortByName(c1, c2)
 			);
 		});
-	};
+	}
 
 	/**
 	 * Gets all relation objects.
 	 * @private
 	 * @returns {any[]} The relation objects.
 	 */
-	getRelations () {
-		return this.getRecordIds(U.Subscription.spaceSubId(J.Constant.subId.relation), '').map(id => this.getRelationById(id)).
-			filter(it => it && !it.isArchived && !it.isDeleted);
-	};
+	getRelations() {
+		return this.getRecordIds(
+			U.Subscription.spaceSubId(J.Constant.subId.relation),
+			"",
+		)
+			.map((id) => this.getRelationById(id))
+			.filter((it) => it && !it.isArchived && !it.isDeleted);
+	}
 
 	/**
 	 * Gets the dataview relation keys for a block in a root.
@@ -583,9 +641,15 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @returns {any[]} The relation keys.
 	 */
-	getDataviewRelationKeys (rootId: string, blockId: string): any[] {
-		return [ 'name' ].concat((this.relationMap.get(this.getId(rootId, blockId)) || []).map(it => it.relationKey)).filter(it => it);
-	};
+	getDataviewRelationKeys(rootId: string, blockId: string): any[] {
+		return ["name"]
+			.concat(
+				(this.relationMap.get(this.getId(rootId, blockId)) || []).map(
+					(it) => it.relationKey,
+				),
+			)
+			.filter((it) => it);
+	}
 
 	/**
 	 * Gets the dataview relations for a block in a root.
@@ -594,9 +658,11 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @returns {any[]} The dataview relations.
 	 */
-	getDataviewRelations (rootId: string, blockId: string): any[] {
-		return this.getDataviewRelationKeys(rootId, blockId).map(it => this.getRelationByKey(it)).filter(it => it);
-	};
+	getDataviewRelations(rootId: string, blockId: string): any[] {
+		return this.getDataviewRelationKeys(rootId, blockId)
+			.map((it) => this.getRelationByKey(it))
+			.filter((it) => it);
+	}
 
 	/**
 	 * Gets the object relations for a root and type.
@@ -605,14 +671,18 @@ class RecordStore {
 	 * @param {string} typeId - The type ID.
 	 * @returns {any[]} The object relations.
 	 */
-	getObjectRelations (rootId: string, typeId: string): any[] {
+	getObjectRelations(rootId: string, typeId: string): any[] {
 		const type = S.Record.getTypeById(typeId);
 		const recommended = Relation.getArrayValue(type?.recommendedRelations);
-		const typeRelations = recommended.map(it => this.getRelationById(it)).filter(it => it);
-		const objectRelations = S.Detail.getKeys(rootId, rootId).map(it => this.getRelationByKey(it)).filter(it => it && !recommended.includes(it.id));
+		const typeRelations = recommended
+			.map((it) => this.getRelationById(it))
+			.filter((it) => it);
+		const objectRelations = S.Detail.getKeys(rootId, rootId)
+			.map((it) => this.getRelationByKey(it))
+			.filter((it) => it && !recommended.includes(it.id));
 
 		return this.checkHiddenObjects(typeRelations.concat(objectRelations));
-	};
+	}
 
 	/**
 	 * Gets the conflict relations for a block in a root and type.
@@ -622,10 +692,14 @@ class RecordStore {
 	 * @param {string} typeId - The type ID.
 	 * @returns {any[]} The conflict relations.
 	 */
-	getConflictRelations (rootId: string, blockId: string, typeId: string): any[] {
+	getConflictRelations(
+		rootId: string,
+		blockId: string,
+		typeId: string,
+	): any[] {
 		const objectKeys = S.Detail.getKeys(rootId, blockId);
 		const typeKeys = U.Object.getTypeRelationKeys(typeId);
-		const skipKeys = [ 'name', 'description' ];
+		const skipKeys = ["name", "description"];
 
 		let conflictKeys = [];
 
@@ -633,17 +707,19 @@ class RecordStore {
 			objectKeys.forEach((key) => {
 				if (!typeKeys.includes(key)) {
 					conflictKeys.push(key);
-				};
+				}
 			});
 		} else {
 			conflictKeys = objectKeys;
-		};
+		}
 
-		conflictKeys = conflictKeys.filter(it => !skipKeys.includes(it));
-		conflictKeys = conflictKeys.map(it => this.getRelationByKey(it)).filter(it => it);
+		conflictKeys = conflictKeys.filter((it) => !skipKeys.includes(it));
+		conflictKeys = conflictKeys
+			.map((it) => this.getRelationByKey(it))
+			.filter((it) => it);
 
 		return this.checkHiddenObjects(conflictKeys);
-	};
+	}
 
 	/**
 	 * Gets a relation object by its key.
@@ -651,14 +727,14 @@ class RecordStore {
 	 * @param {string} relationKey - The relation key.
 	 * @returns {any|null} The relation object or null.
 	 */
-	getRelationByKey (relationKey: string): any {
+	getRelationByKey(relationKey: string): any {
 		if (!relationKey) {
 			return null;
-		};
+		}
 
 		const id = this.relationKeyMapGet(relationKey);
 		return id ? this.getRelationById(id) : null;
-	};
+	}
 
 	/**
 	 * Gets a relation object by its ID.
@@ -666,14 +742,19 @@ class RecordStore {
 	 * @param {string} id - The relation ID.
 	 * @returns {any|null} The relation object or null.
 	 */
-	getRelationById (id: string): any {
+	getRelationById(id: string): any {
 		if (!id) {
 			return null;
-		};
+		}
 
-		const object = S.Detail.get(U.Subscription.spaceSubId(J.Constant.subId.relation), id, J.Relation.relation, true);
+		const object = S.Detail.get(
+			U.Subscription.spaceSubId(J.Constant.subId.relation),
+			id,
+			J.Relation.relation,
+			true,
+		);
 		return object._empty_ ? null : object;
-	};
+	}
 
 	/**
 	 * Gets an option object by its ID.
@@ -681,10 +762,15 @@ class RecordStore {
 	 * @param {string} id - The option ID.
 	 * @returns {any|null} The option object or null.
 	 */
-	getOption (id: string) {
-		const object = S.Detail.get(U.Subscription.spaceSubId(J.Constant.subId.option), id, U.Subscription.optionRelationKeys(true), true);
+	getOption(id: string) {
+		const object = S.Detail.get(
+			U.Subscription.spaceSubId(J.Constant.subId.option),
+			id,
+			U.Subscription.optionRelationKeys(true),
+			true,
+		);
 		return object._empty_ ? null : object;
-	};
+	}
 
 	/**
 	 * Gets the views for a block in a root.
@@ -693,9 +779,9 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @returns {I.View[]} The views.
 	 */
-	getViews (rootId: string, blockId: string): I.View[] {
+	getViews(rootId: string, blockId: string): I.View[] {
 		return this.viewMap.get(this.getId(rootId, blockId)) || [];
-	};
+	}
 
 	/**
 	 * Gets a view by ID for a block in a root.
@@ -705,9 +791,9 @@ class RecordStore {
 	 * @param {string} id - The view ID.
 	 * @returns {I.View} The view.
 	 */
-	getView (rootId: string, blockId: string, id: string): I.View {
-		return this.getViews(rootId, blockId).find(it => it.id == id);
-	};
+	getView(rootId: string, blockId: string, id: string): I.View {
+		return this.getViews(rootId, blockId).find((it) => it.id == id);
+	}
 
 	/**
 	 * Gets the meta information for a block in a root.
@@ -716,16 +802,16 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @returns {any} The meta information.
 	 */
-	getMeta (rootId: string, blockId: string) {
+	getMeta(rootId: string, blockId: string) {
 		const map = this.metaMap.get(this.getId(rootId, blockId)) || {};
 
 		return {
 			total: Number(map.total) || 0,
 			offset: Number(map.offset) || 0,
-			viewId: String(map.viewId || ''),
+			viewId: String(map.viewId || ""),
 			keys: map.keys || [],
 		};
-	};
+	}
 
 	/**
 	 * Gets the record IDs for a block in a root.
@@ -734,9 +820,9 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @returns {string[]} The record IDs.
 	 */
-	getRecordIds (rootId: string, blockId: string) {
+	getRecordIds(rootId: string, blockId: string) {
 		return this.recordMap.get(this.getId(rootId, blockId)) || [];
-	};
+	}
 
 	/**
 	 * Gets the records for a subId.
@@ -746,9 +832,11 @@ class RecordStore {
 	 * @param {boolean} [forceKeys] - Whether to force default keys.
 	 * @returns {any[]} The records.
 	 */
-	getRecords (subId: string, keys?: string[], forceKeys?: boolean): any[] {
-		return this.getRecordIds(subId, '').map(id => S.Detail.get(subId, id, keys, forceKeys));
-	};
+	getRecords(subId: string, keys?: string[], forceKeys?: boolean): any[] {
+		return this.getRecordIds(subId, "").map((id) =>
+			S.Detail.get(subId, id, keys, forceKeys),
+		);
+	}
 
 	/**
 	 * Gets the groups for a block in a root.
@@ -757,9 +845,12 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @returns {any[]} The groups.
 	 */
-	getGroups (rootId: string, blockId: string) {
-		return this.groupMap.get(this.getGroupSubId(rootId, blockId, 'groups')) || [];
-	};
+	getGroups(rootId: string, blockId: string) {
+		return (
+			this.groupMap.get(this.getGroupSubId(rootId, blockId, "groups")) ||
+			[]
+		);
+	}
 
 	/**
 	 * Gets a group by ID for a block in a root.
@@ -769,9 +860,9 @@ class RecordStore {
 	 * @param {string} groupId - The group ID.
 	 * @returns {any} The group.
 	 */
-	getGroup (rootId: string, blockId: string, groupId: string) {
-		return this.getGroups(rootId, blockId).find(it => it.id == groupId);
-	};
+	getGroup(rootId: string, blockId: string, groupId: string) {
+		return this.getGroups(rootId, blockId).find((it) => it.id == groupId);
+	}
 
 	/**
 	 * Gets the combined ID for a block in a root.
@@ -780,9 +871,9 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @returns {string} The combined ID.
 	 */
-	getId (rootId: string, blockId: string) {
-		return [ rootId, blockId ].join('-');
-	};
+	getId(rootId: string, blockId: string) {
+		return [rootId, blockId].join("-");
+	}
 
 	/**
 	 * Gets the sub ID for a block in a root.
@@ -791,9 +882,9 @@ class RecordStore {
 	 * @param {string} blockId - The block ID.
 	 * @returns {string} The sub ID.
 	 */
-	getSubId (rootId: string, blockId: string) {
+	getSubId(rootId: string, blockId: string) {
 		return this.getId(rootId, blockId);
-	};
+	}
 
 	/**
 	 * Gets the group sub ID for a block in a root and group.
@@ -803,9 +894,9 @@ class RecordStore {
 	 * @param {string} groupId - The group ID.
 	 * @returns {string} The group sub ID.
 	 */
-	getGroupSubId (rootId: string, blockId: string, groupId: string): string {
-		return [ rootId, blockId, groupId ].join('-');
-	};
+	getGroupSubId(rootId: string, blockId: string, groupId: string): string {
+		return [rootId, blockId, groupId].join("-");
+	}
 
 	/**
 	 * Filters out hidden objects from a list of records.
@@ -813,17 +904,18 @@ class RecordStore {
 	 * @param {any[]} records - The records to filter.
 	 * @returns {any[]} The filtered records.
 	 */
-	checkHiddenObjects (records: any[]): any[] {
+	checkHiddenObjects(records: any[]): any[] {
 		const { config } = S.Common;
 		const { hiddenObject } = config.debug;
 
 		if (!Array.isArray(records)) {
 			return [];
-		};
+		}
 
-		return records.filter(it => it && (hiddenObject ? true : !it.isHidden));
-	};
-
-};
+		return records.filter(
+			(it) => it && (hiddenObject ? true : !it.isHidden),
+		);
+	}
+}
 
 export const Record: RecordStore = new RecordStore();


### PR DESCRIPTION
Description

  This PR replaces Array.find() / Array.includes() with Set and Map for O(1) lookups inside
   loops across several hot-path stores and components.

  Key optimizations:
  - Convert arrays to Set before filtering loops (new Set(list.map(...)) + .has() instead
  of Array.includes())
  - Use Map for index-based ordering (new Map(ids.map((id, i) => [id, i]))) instead of
  repeated Array.indexOf()
  - Use Set for deduplication checks in chat message and record group operations

  Files changed:
  - src/ts/store/chat.ts — Set-based dedup for message list operations; Map-based
  reply/state lookups
  - src/ts/store/record.ts — Set/Map for view ordering, group filtering, and relation dedup
  - src/ts/store/common.ts — formatting cleanup
  - src/ts/store/menu.ts — formatting cleanup
  - src/ts/component/block/chat.tsx — Set for scroll tracking; Map for section grouping