### PR TITLE
perf: replace Array.find/includes with Set/Map for O(1) lookups in loops

### DIFF
--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -329,15 +329,17 @@ const BlockChat = observer(forwardRef<RefProps, I.BlockComponent>((props, ref) =
 	const getSections = () => {
 		const sections = [];
 
+		const sectionMap = new Map();
 		messages.forEach(item => {
 			const key = U.Date.dateWithFormat(I.DateFormat.ShortUS, item.createdAt);
-			const section = sections.find(it => it.key == key);
+			let section = sectionMap.get(key);
 
 			if (!section) {
-				sections.push({ createdAt: item.createdAt, key, isSection: true, list: [ item ] });
-			} else {
-				section.list.push(item);
+				section = { createdAt: item.createdAt, key, isSection: true, list: [] };
+				sectionMap.set(key, section);
+				sections.push(section);
 			};
+			section.list.push(item);
 		});
 
 		// Message groups by author/time

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -38,9 +38,9 @@ class ChatStore {
 	 * @param {I.ChatMessage[]} add - The chat messages to prepend.
 	 */
 	prepend (subId: string, add: I.ChatMessage[]): void {
-		const ids = this.getList(subId).map(it => it.id);
+		const ids = new Set(this.getList(subId).map(it => it.id));
 
-		add = (add || []).filter(it => !ids.includes(it.id));
+		add = (add || []).filter(it => !ids.has(it.id));
 		add = add.map(it => new M.ChatMessage(it));
 
 		this.getList(subId).unshift(...add);
@@ -52,9 +52,9 @@ class ChatStore {
 	 * @param {I.ChatMessage[]} add - The chat messages to append.
 	 */
 	append (subId: string, add: I.ChatMessage[]): void {
-		const ids = this.getList(subId).map(it => it.id);
+		const ids = new Set(this.getList(subId).map(it => it.id));
 
-		add = (add || []).filter(it => !ids.includes(it.id));
+		add = (add || []).filter(it => !ids.has(it.id));
 		add = add.map(it => new M.ChatMessage(it));
 
 		this.getList(subId).push(...add);

--- a/src/ts/store/menu.ts
+++ b/src/ts/store/menu.ts
@@ -128,7 +128,8 @@ class MenuStore {
 		if (!id) {
 			let length = 0;
 			if (filter) {
-				length = this.menuList.filter(it => filter ? !filter.includes(it.id) && !filter.includes(it.param.component) : true).length;
+				const filterSet = new Set(filter);
+				length = this.menuList.filter(it => !filterSet.has(it.id) && !filterSet.has(it.param.component)).length;
 			} else {
 				length = this.menuList.length;
 			};

--- a/src/ts/store/record.ts
+++ b/src/ts/store/record.ts
@@ -197,14 +197,8 @@ class RecordStore {
 	viewsSort (rootId: string, blockId: string, ids: string[]) {
 		const views = this.getViews(rootId, blockId);
 
-		views.sort((c1: any, c2: any) => {
-			const i1 = ids.indexOf(c1.id);
-			const i2 = ids.indexOf(c2.id);
-
-			if (i1 > i2) return 1; 
-			if (i1 < i2) return -1;
-			return 0;
-		});
+		const orderMap = new Map(ids.map((id, i) => [id, i]));
+		views.sort((c1: any, c2: any) => (orderMap.get(c1.id) ?? Infinity) - (orderMap.get(c2.id) ?? Infinity));
 
 		this.viewsSet(rootId, blockId, views);
 	};
@@ -358,8 +352,9 @@ class RecordStore {
 	groupsAdd (rootId: string, blockId: string, groups: any[]) {
 		const list = this.getGroups(rootId, blockId);
 
+		const existingIds = new Set(list.map(it => it.id));
 		for (const group of groups) {
-			if (list.find(it => it.id == group.id)) {
+			if (existingIds.has(group.id)) {
 				continue;
 			};
 			list.push(group);
@@ -382,7 +377,8 @@ class RecordStore {
 			this.recordsClear(subId, '');
 		});
 
-		this.groupsSet(rootId, blockId, groups.filter(it => !ids.includes(it.id)));
+		const idsSet = new Set(ids);
+		this.groupsSet(rootId, blockId, groups.filter(it => !idsSet.has(it.id)));
 	};
 
 	/**


### PR DESCRIPTION
## Summary

Replace O(n) array lookups (`Array.includes`, `Array.find`, `Array.indexOf`) with O(1) `Set`/`Map` lookups in hot paths where these calls happen inside loops or `.filter()`.

## Changes

**`store/chat.ts`** — `prepend` / `append`: build a `Set` of existing message IDs before filtering duplicates

**`store/record.ts`** — 3 methods:
- `viewsSort`: replace `ids.indexOf()` inside `.sort()` with a pre-built `Map` (O(n^2 log n) → O(n log n))
- `groupsAdd`: replace `list.find()` inside loop with a `Set`
- `groupsRemove`: replace `ids.includes()` inside `.filter()` with a `Set`

**`store/menu.ts`** — `isOpen`: replace `filter.includes()` (called twice per item) with a `Set`

**`component/block/chat.tsx`** — `getSections`: replace `sections.find()` inside `.forEach()` with a `Map` for date-based grouping

## Note

This is a clean re-submission of #1998 with only the semantic changes — no formatting modifications.