### PR TITLE
Feature/JS-8906: Replace right-side checkmark with left-side checkbox in opti…

### DIFF
--- a/src/img/theme/dark/icon/menu/checkbox1.svg
+++ b/src/img/theme/dark/icon/menu/checkbox1.svg
@@ -1,4 +1,4 @@
 <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="1" y="1" width="16" height="16" rx="4" fill="#252525"/>
+<rect x="1" y="1" width="16" height="16" rx="4" fill="#464646"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M13.6094 5.43631L8.09478 13.1567L4.46875 9.53071L5.52941 8.47005L7.90338 10.844L12.3888 4.56445L13.6094 5.43631Z" fill="white"/>
 </svg>

--- a/src/scss/component/optionSelect.scss
+++ b/src/scss/component/optionSelect.scss
@@ -14,19 +14,17 @@
             .icon.more { display: none; }
         }
 
-        &.withCheckbox {
-            .clickable { width: calc(100% - 24px); }
+        .icon.checkbox {
+            width: 18px; height: 18px; flex-shrink: 0;
+            background-image: url('~img/icon/menu/checkbox0.svg');
         }
+        .icon.checkbox.active { background-image: url('~img/icon/menu/checkbox1.svg'); }
 
         &:hover, &.hover {
             .clickable { width: calc(100% - 28px); }
             .buttons {
                 .icon.more { display: block; }
             }
-        }
-
-        &.withCheckbox:hover, &.withCheckbox.hover {
-            .clickable { width: calc(100% - 50px); }
         }
 
         &.add {
@@ -42,14 +40,9 @@
         }
     }
 
-    &.canEdit.canSelect {
-        .item {
-            .buttons,
-            .icon.chk { right: 14px; }
-
-            &:hover, &.hover {
-                .icon.chk { right: 40px; }
-            }
+    &:not(.canEdit) {
+        .item:hover, .item.hover {
+            .clickable { width: 100%; }
         }
     }
 }

--- a/src/scss/menu/dataview/filter.scss
+++ b/src/scss/menu/dataview/filter.scss
@@ -173,12 +173,6 @@
 					}
 				}
 
-				.item.isSelected {
-					> .clickable {
-						> .name { padding-right: 16px; }
-					}
-				}
-
 				.calendarSelect {
 					.head, .body { padding: 0px 16px; }
 					.day.weekend:not(.active) { background: none; }

--- a/src/scss/theme/dark/common.scss
+++ b/src/scss/theme/dark/common.scss
@@ -112,6 +112,11 @@ html.themeDark {
 		.icon.search { background-image: url('#{$themePath}/icon/menu/action/search0.svg'); }
 	}
 
+	.utilOptionSelect {
+		.icon.checkbox { background-image: url('#{$themePath}/icon/menu/checkbox0.svg'); }
+		.icon.checkbox.active { background-image: url('#{$themePath}/icon/menu/checkbox1.svg'); }
+	}
+
 	#root-loader {
 		.logo { background-image: url('~img/logo/white.svg'); }
 	}

--- a/src/ts/component/util/menu/optionSelect.tsx
+++ b/src/ts/component/util/menu/optionSelect.tsx
@@ -237,6 +237,14 @@ const OptionSelect = observer(forwardRef<OptionSelectRefProps, Props>((props, re
 		};
 	};
 
+	const sortByInitialValue = (items: SelectItem[]): SelectItem[] => {
+		const iv = initialValueRef.current;
+		return [
+			...items.filter(it => iv.includes(it.id)),
+			...items.filter(it => !iv.includes(it.id)),
+		];
+	};
+
 	const getObjectItems = (): SelectItem[] => {
 		if (!searchParam) {
 			return [];
@@ -266,10 +274,7 @@ const OptionSelect = observer(forwardRef<OptionSelectRefProps, Props>((props, re
 				};
 			};
 		} else {
-			const iv = initialValueRef.current;
-			const selected = items.filter(it => iv.includes(it.id));
-			const unselected = items.filter(it => !iv.includes(it.id));
-			items = selected.concat(unselected);
+			items = sortByInitialValue(items);
 		};
 
 		return items.concat(ret);
@@ -304,10 +309,7 @@ const OptionSelect = observer(forwardRef<OptionSelectRefProps, Props>((props, re
 				});
 			};
 		} else {
-			const iv = initialValueRef.current;
-			const selected = items.filter(it => iv.includes(it.id));
-			const unselected = items.filter(it => !iv.includes(it.id));
-			items = selected.concat(unselected);
+			items = sortByInitialValue(items);
 		};
 
 		return items.concat(ret);

--- a/src/ts/component/util/menu/optionSelect.tsx
+++ b/src/ts/component/util/menu/optionSelect.tsx
@@ -124,6 +124,7 @@ const OptionSelect = observer(forwardRef<OptionSelectRefProps, Props>((props, re
 	const hasMoreRef = useRef(true);
 	const timeoutFilterRef = useRef(0);
 	const objectFilterRef = useRef('');
+	const initialValueRef = useRef<string[]>([...value]);
 
 	const isObjectMode = !!searchParam;
 
@@ -264,6 +265,11 @@ const OptionSelect = observer(forwardRef<OptionSelectRefProps, Props>((props, re
 					});
 				};
 			};
+		} else {
+			const iv = initialValueRef.current;
+			const selected = items.filter(it => iv.includes(it.id));
+			const unselected = items.filter(it => !iv.includes(it.id));
+			items = selected.concat(unselected);
 		};
 
 		return items.concat(ret);
@@ -297,6 +303,11 @@ const OptionSelect = observer(forwardRef<OptionSelectRefProps, Props>((props, re
 					name: U.String.sprintf(isSelect && !noSelect ? translate('menuDataviewOptionListSetStatus') : translate('menuDataviewOptionListCreateOption'), filter),
 				});
 			};
+		} else {
+			const iv = initialValueRef.current;
+			const selected = items.filter(it => iv.includes(it.id));
+			const unselected = items.filter(it => !iv.includes(it.id));
+			items = selected.concat(unselected);
 		};
 
 		return items.concat(ret);
@@ -723,7 +734,7 @@ const OptionSelect = observer(forwardRef<OptionSelectRefProps, Props>((props, re
 				{canSort && !isReadonly ? <Icon className="dnd" /> : ''}
 
 				<div className="clickable" onClick={e => onClick(e, item)}>
-					{!noSelect && isSelected ? <Icon className="chk" /> : ''}
+					{!noSelect ? <Icon className={[ 'checkbox', (isSelected ? 'active' : '') ].join(' ')} /> : ''}
 					{isObjectMode ? (
 						<>
 							{icon}
@@ -768,7 +779,7 @@ const OptionSelect = observer(forwardRef<OptionSelectRefProps, Props>((props, re
 			>
 				{canSort && !isReadonly ? <Icon className="dnd" /> : ''}
 				<div className="clickable">
-					{!noSelect ? <Icon className={isSelected ? 'chk' : 'chk empty'} /> : ''}
+					{!noSelect ? <Icon className={[ 'checkbox', (isSelected ? 'active' : '') ].join(' ')} /> : ''}
 					{isObjectMode ? (
 						<>
 							<IconObject object={item} />


### PR DESCRIPTION
…on select menus

Show selected options at top when menu opens, add always-visible checkbox on the left to avoid visual clash with the edit button on hover.

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
