### PR TITLE
JS-9109: Fix sidebar missing in web mode

### DIFF
--- a/src/ts/lib/web/electronMock.ts
+++ b/src/ts/lib/web/electronMock.ts
@@ -144,6 +144,7 @@ class ElectronMock {
 			css: '',
 			activeIndex: 0,
 			isSingleTab: true,
+			activeTabId: this.tabId_,
 		}));
 
 		handlers.set('setConfig', (args) => {


### PR DESCRIPTION
Add `activeTabId` to web mock's `getInitData` response.

Without it, `isActiveTabSet(undefined === tabId)` evaluated to `false`, pausing all MobX observer reactions via `reactionScheduler`. Introduced by e0307b0508.