### PR TITLE
JS-9177: Validate git tag matches package.json version in release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,24 @@ jobs:
             exit 1
           fi
 
+      - name: Verify git tag matches package.json version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag="${GITHUB_REF_NAME}"
+          tag_version="${tag#v}"
+
+          pkg_version="$(jq -r '.version' package.json)"
+
+          echo "git tag version: $tag_version"
+          echo "package.json version: $pkg_version"
+
+          if [[ "$tag_version" != "$pkg_version" ]]; then
+            echo "::error::Git tag version ($tag_version) does not match package.json version ($pkg_version)"
+            exit 1
+          fi
+
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- Adds an early validation step to the release CI workflow that checks the git tag version matches `package.json` version
- Prevents releasing artifacts with the wrong version name when a tag is pushed without bumping `package.json`
- Runs before any expensive steps (middleware download, signing, building) so mismatches are caught in seconds

## Context
A tag was pushed without incrementing `package.json` version, causing the release to build artifacts with the previous version name

## Test plan
- [x] Simulated locally: matching tag (`v0.54.13-alpha` vs `0.54.13-alpha`) passes
- [x] Simulated locally: mismatched tag (`v0.54.12-alpha` vs `0.54.13-alpha`) fails with clear error
- [ ] Only affects normal release flow, nightly builds are unchanged