### PR TITLE
Bugfix/JS-8844: Add unread message preview styling in widget list

### DIFF
--- a/src/scss/widget/view/list.scss
+++ b/src/scss/widget/view/list.scss
@@ -32,6 +32,10 @@
 			.descr { @include text-small; @include text-overflow-nw; color: var(--color-text-secondary); }
 			.descr b { font-weight: 500; }
 
+			&.hasUnread {
+				.descr { color: var(--color-text-primary); }
+			}
+
 			.info { flex-grow: 1; overflow: hidden; }
 			.chatInfo { 
 				flex-shrink: 0; display: flex; flex-direction: column; align-items: flex-end; justify-content: center; @include text-small;

--- a/src/ts/component/widget/view/list/item.tsx
+++ b/src/ts/component/widget/view/list/item.tsx
@@ -136,6 +136,9 @@ const WidgetListItem = observer(forwardRef<{}, Props>((props, ref) => {
 
 			const last = list.length ? list[0] : null;
 			const text = last ? S.Chat.getMessageSimpleText(space, last, true) : translate('widgetNoMessages');
+			if (U.Object.chatHasUnread(space, id)) {
+				cn.push('hasUnread');
+			};
 
 			descr = <Label className="descr" text={text} />;
 			time = last ? <div className="time">{U.Date.timeAgo(last.createdAt)}</div> : '';

--- a/src/ts/lib/util/object.ts
+++ b/src/ts/lib/util/object.ts
@@ -1050,6 +1050,17 @@ class UtilObject {
 		return src;
 	};
 
+	chatHasUnread (spaceId: string, chatId: string): boolean {
+		const counters = S.Chat.getChatCounters(spaceId, chatId);
+		const spaceview = U.Space.getSpaceviewBySpaceId(spaceId);
+		const mode = this.getChatNotificationMode(spaceview, chatId);
+
+		return (
+			((mode == I.NotificationMode.All) && !!(counters.messageCounter || counters.mentionCounter || counters.reactionCounter)) ||
+			((mode == I.NotificationMode.Mentions) && !!counters.mentionCounter)
+		);
+	};
+
 	getChatNotificationMode (spaceview: any, chatId: string): I.NotificationMode {
 		if (!spaceview) {
 			return I.NotificationMode.All;


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
