### PR TITLE
Bugfix/JS-9148: Fix block action menu section name for non-text blocks

### DIFF
--- a/src/json/text.json
+++ b/src/json/text.json
@@ -269,6 +269,7 @@
 	"commonShare": "Share",
 	"commonOpenInNewTab": "Open in New Tab",
 	"commonText": "Text",
+	"commonBlock": "Block",
 
 	"pluralDay": "day|days",
 	"pluralObject": "Object|Objects",

--- a/src/ts/component/menu/block/action.tsx
+++ b/src/ts/component/menu/block/action.tsx
@@ -248,20 +248,29 @@ const MenuBlockAction = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 				};
 			};
 
-			let sectionName = 'commonText';
+			let sectionName = '';
+			const count = blockIds.length;
 
+			if (count > 1) {
+				sectionName = `${count} ${U.Common.plural(count, translate('pluralBlock'))}`;
+			} else
+			if (hasText) {
+				sectionName = translate('commonText');
+			} else
 			if (hasLink) {
-				sectionName = 'commonObject';
+				sectionName = translate('commonObject');
 			} else
 			if (hasFile) {
-				sectionName = (content.type == I.FileType.Image) ? 'commonImage' : 'commonFile';
+				sectionName = translate((content.type == I.FileType.Image) ? 'commonImage' : 'commonFile');
 			} else
 			if (hasBookmark) {
-				sectionName = 'commonBookmark';
+				sectionName = translate('commonBookmark');
+			} else {
+				sectionName = translate('commonBlock');
 			};
 
 			sections = [
-				{ name: translate(sectionName), className: 'settingsText', children: c1 },
+				{ name: sectionName, className: 'settingsText', children: c1 },
 				...actionSections,
 			];
 		};


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
