### PR TITLE
JS-9308: Web mode browser history and URL routing

### DIFF
--- a/scripts/start-web.js
+++ b/scripts/start-web.js
@@ -9,7 +9,7 @@ const os = require('os');
 const stdoutWebProxyPrefix = 'gRPC Web proxy started at: ';
 const winShutdownStdinMessage = 'shutdown\n';
 
-const webPort = process.env.WEB_PORT || 9090;
+const webPort = process.env.WEB_PORT || 3030;
 const openBrowserAuto = process.env.WEB_OPEN_BROWSER === '1' || process.env.WEB_OPEN_BROWSER === 'true';
 
 // Use the same Application Support / AppData folder as Electron

--- a/scripts/start-web.js
+++ b/scripts/start-web.js
@@ -10,6 +10,7 @@ const stdoutWebProxyPrefix = 'gRPC Web proxy started at: ';
 const winShutdownStdinMessage = 'shutdown\n';
 
 const webPort = process.env.WEB_PORT || 3030;
+const grpcWebAddr = process.env.ANYTYPE_GRPCWEB_ADDR || '127.0.0.1:31008';
 const openBrowserAuto = process.env.WEB_OPEN_BROWSER === '1' || process.env.WEB_OPEN_BROWSER === 'true';
 
 // Use the same Application Support / AppData folder as Electron
@@ -75,7 +76,7 @@ function startHelper() {
 			}
 		};
 
-		helperProcess = childProcess.spawn(binPath, ['127.0.0.1:0', '127.0.0.1:0'], {
+		helperProcess = childProcess.spawn(binPath, ['127.0.0.1:0', grpcWebAddr], {
 			windowsHide: false,
 			env: process.env,
 		});
@@ -129,6 +130,9 @@ function startHelper() {
 				const msg = `anytypeHelper exited unexpectedly with code ${code}`;
 				console.error(`[Web] ${msg}`);
 				reject(new Error(msg));
+			} else {
+				console.error(`[Web] anytypeHelper crashed with code ${code}, shutting down`);
+				process.exit(1);
 			}
 			helperProcess = null;
 		});

--- a/src/ts/app.tsx
+++ b/src/ts/app.tsx
@@ -269,16 +269,6 @@ const App: FC = () => {
 		// Validate tab route — don't restore blank/void/auth routes
 		let route = String(data.route || redirect || '');
 
-		// Web deep link: use browser URL path as route (first load only,
-		// skip on HMR re-renders to avoid re-triggering auth/space switch)
-		if (!route && window.isWebVersion && !(window as any).__WEB_ROUTE_LOADED__) {
-			const initialPath = window.location.pathname;
-			if (initialPath && (initialPath !== '/')) {
-				route = initialPath;
-			}
-		}
-		(window as any).__WEB_ROUTE_LOADED__ = true;
-
 		if (route) {
 			const rp = U.Router.getParam(route);
 			if (

--- a/src/ts/app.tsx
+++ b/src/ts/app.tsx
@@ -132,6 +132,10 @@ const App: FC = () => {
 		U.Router.init(history);
 		U.Smile.init();
 
+		if (window.isWebVersion) {
+			import('./lib/web/routeSync').then(({ initRouteSync }) => initRouteSync(history, U.Router));
+		}
+
 		console.log('[App] Init', getGlobal('serverAddress'));
 
 		dispatcher.init(getGlobal('serverAddress'));
@@ -264,6 +268,17 @@ const App: FC = () => {
 
 		// Validate tab route — don't restore blank/void/auth routes
 		let route = String(data.route || redirect || '');
+
+		// Web deep link: use browser URL path as route (first load only,
+		// skip on HMR re-renders to avoid re-triggering auth/space switch)
+		if (!route && window.isWebVersion && !(window as any).__WEB_ROUTE_LOADED__) {
+			const initialPath = window.location.pathname;
+			if (initialPath && (initialPath !== '/')) {
+				route = initialPath;
+			}
+		}
+		(window as any).__WEB_ROUTE_LOADED__ = true;
+
 		if (route) {
 			const rp = U.Router.getParam(route);
 			if (

--- a/src/ts/entry.web.tsx
+++ b/src/ts/entry.web.tsx
@@ -28,6 +28,12 @@ if (dataPath) {
 	localStorage.setItem('anytype_dataPath', dataPath);
 }
 
+// Clean config params from URL, keep the pathname
+if (urlParams.has('server') || urlParams.has('dataPath')) {
+	const cleanUrl = window.location.pathname || '/';
+	window.history.replaceState({}, '', cleanUrl);
+}
+
 // Configure the global config object
 (window as any).AnytypeGlobalConfig = {
 	serverAddress,

--- a/src/ts/entry.web.tsx
+++ b/src/ts/entry.web.tsx
@@ -34,6 +34,12 @@ if (urlParams.has('server') || urlParams.has('dataPath')) {
 	window.history.replaceState({}, '', cleanUrl);
 }
 
+// Deep link: save initial URL path as redirect for the app to pick up after auth
+const initialPath = window.location.pathname;
+if (initialPath && (initialPath !== '/')) {
+	localStorage.setItem('anytype_redirect', JSON.stringify(initialPath));
+}
+
 // Configure the global config object
 (window as any).AnytypeGlobalConfig = {
 	serverAddress,

--- a/src/ts/lib/web/electronMock.ts
+++ b/src/ts/lib/web/electronMock.ts
@@ -303,6 +303,10 @@ class ElectronMock {
 			});
 		});
 
+		// Single tab in web mode — always return false (no tab to switch to)
+		handlers.set('switchToTabByRoute', () => false);
+		handlers.set('openRouteInTab', () => false);
+
 		['openTab', 'openWindow', 'setActiveTab', 'removeTab', 'closeOtherTabs', 'closeOtherWindows',
 			'reorderTabs', 'setTabsDimmer', 'winCommand', 'setAlwaysShowTabs'].forEach(cmd => {
 			handlers.set(cmd, () => {
@@ -319,6 +323,8 @@ class ElectronMock {
 		});
 
 		handlers.set('payloadBroadcast', noopTrue);
+		handlers.set('setBackground', noopTrue);
+		handlers.set('setHasPinSet', noopTrue);
 
 		// No-op handlers that return empty object
 		['linuxDistro', 'shortcutExport', 'shortcutImport'].forEach(cmd => {

--- a/src/ts/lib/web/routeSync.ts
+++ b/src/ts/lib/web/routeSync.ts
@@ -1,0 +1,86 @@
+/**
+ * Syncs memory history ↔ browser URL.
+ * Memory history is the source of truth for the app.
+ * Browser URL is kept in sync for display and sharing.
+ *
+ * Key behaviors:
+ * - Intermediate routes (/main/blank, /main/void) are skipped entirely
+ *   so they never appear in browser history.
+ * - When browser back/forward triggers a cross-space route, U.Router.go()
+ *   handles space switching. During the async switch, all syncs use
+ *   replaceState to avoid duplicating browser history entries.
+ * - After memory history reset (e.g. logout), browser back is blocked.
+ */
+export function initRouteSync (memoryHistory: any, router: any) {
+	let isPopstateNavigation = false;
+
+	// Memory history → browser URL
+	memoryHistory.listen((location: any, action: string) => {
+		const url = location.pathname + (location.search || '') + (location.hash || '');
+		const parts = location.pathname.split('/').filter(Boolean);
+		const page = parts[0] || '';
+		const routeAction = parts[1] || '';
+
+		// Intermediate routes are transient navigation steps during space
+		// switching — skip browser history entirely so they never appear
+		// as entries (neither pushState nor replaceState).
+		if ((page === 'main') && [ 'blank', 'void' ].includes(routeAction)) {
+			return;
+		}
+
+		// During popstate-triggered navigation (browser back/forward),
+		// use replaceState for everything to avoid creating duplicate
+		// browser history entries. The browser already moved its position
+		// in the history stack.
+		if (isPopstateNavigation) {
+			window.history.replaceState(null, '', url);
+
+			// Once space switching is complete, exit popstate mode
+			if (!router.isOpening) {
+				isPopstateNavigation = false;
+			}
+			return;
+		}
+
+		if (action === 'PUSH') {
+			window.history.pushState(null, '', url);
+		} else
+		if (action === 'REPLACE') {
+			window.history.replaceState(null, '', url);
+		}
+	});
+
+	// Browser back/forward → app navigation
+	window.addEventListener('popstate', () => {
+		// index < 0 means memory history was reset (e.g. after logout
+		// via go() with replace: true which sets entries=[], index=-1).
+		// Push current route forward to block browser back into stale history.
+		if (memoryHistory.index < 0) {
+			const current = memoryHistory.entries[0]?.pathname || '/';
+			window.history.pushState(null, '', current);
+			return;
+		}
+
+		isPopstateNavigation = true;
+
+		// Use router.go() which handles space switching when the route
+		// contains a different spaceId than the current space.
+		router.go(window.location.pathname, {});
+
+		// For cross-space navigation, router.isOpening stays true during
+		// the async WorkspaceOpen call. Poll until it settles, then
+		// allow normal pushState sync to resume. Cap at 10s to prevent
+		// infinite polling if isOpening gets stuck.
+		let attempts = 0;
+		const maxAttempts = 200;
+		const waitForSettle = () => {
+			attempts++;
+			if (!router.isOpening || (attempts >= maxAttempts)) {
+				isPopstateNavigation = false;
+			} else {
+				window.setTimeout(waitForSettle, 50);
+			}
+		};
+		window.setTimeout(waitForSettle, 50);
+	});
+}

--- a/vite.web.config.ts
+++ b/vite.web.config.ts
@@ -12,6 +12,55 @@ const wasmDir = path.join(pdfjsDistPath, 'wasm');
 const srcImgDir = path.resolve(__dirname, 'src/img');
 const distImgDir = path.resolve(__dirname, 'dist/img');
 
+function spaFallbackPlugin(): Plugin {
+	return {
+		name: 'spa-fallback',
+		configureServer(server) {
+			// Return function so this runs AFTER Vite's internal middleware
+			return () => {
+				server.middlewares.use(async (req, res, next) => {
+					const url = req.url || '';
+					const pathname = url.split('?')[0];
+
+					if (
+						pathname.startsWith('/@') ||
+						pathname.startsWith('/node_modules/') ||
+						pathname.startsWith('/src/') ||
+						pathname.startsWith('/dist/') ||
+						pathname.startsWith('/api/') ||
+						pathname.startsWith('/cmaps/') ||
+						pathname.startsWith('/wasm/')
+					) {
+						return next();
+					}
+
+					const htmlPath = path.resolve(__dirname, 'dist/index.web.html');
+
+					if (!fs.existsSync(htmlPath)) {
+						return next();
+					}
+
+					try {
+						const raw = fs.readFileSync(htmlPath, 'utf-8');
+						const html = await server.transformIndexHtml(
+							'/dist/index.web.html',
+							raw,
+							req.originalUrl
+						);
+
+						res.statusCode = 200;
+						res.setHeader('Content-Type', 'text/html');
+						res.end(html);
+					} catch (err) {
+						console.error('[SPA Fallback] Error:', err);
+						next(err);
+					}
+				});
+			};
+		},
+	};
+}
+
 function webUploadPlugin(): Plugin {
 	const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB
 
@@ -88,11 +137,13 @@ function webUploadPlugin(): Plugin {
 }
 
 export default defineConfig(({ mode }) => {
-	const webPort = parseInt(process.env.WEB_PORT || '9090', 10);
+	const webPort = parseInt(process.env.WEB_PORT || '3030', 10);
 
 	return {
+		base: '/',
 		root: '.',
 		publicDir: false,
+		appType: 'mpa',
 
 		resolve: {
 			extensions: ['.ts', '.tsx', '.js', '.jsx'],
@@ -225,6 +276,7 @@ export default defineConfig(({ mode }) => {
 		},
 
 		plugins: [
+			spaFallbackPlugin(),
 			react(),
 			webUploadPlugin(),
 
@@ -236,7 +288,7 @@ export default defineConfig(({ mode }) => {
 					const dest = path.resolve(__dirname, 'dist-web/index.html');
 					if (fs.existsSync(src)) {
 						let html = fs.readFileSync(src, 'utf8');
-						html = html.replace(/(?:\.\.\/)+(?=js\/|css\/|assets\/)/g, './');
+						html = html.replace(/(?:\.\.\/)+(?=js\/|css\/|assets\/)/g, '/');
 						fs.writeFileSync(dest, html);
 						fs.unlinkSync(src);
 						try { fs.rmdirSync(path.resolve(__dirname, 'dist-web/dist')); } catch {}


### PR DESCRIPTION
## Summary
- SPA fallback plugin serves app at `/` with prefix-based whitelist
- Route sync layer mirrors memory history ↔ browser URL (pushState/replaceState)
- Browser back/forward works, including cross-space navigation
- Deep linking via localStorage redirect (set in entry.web.tsx)
- Intermediate routes (`/main/blank`, `/main/void`) excluded from browser history
- Browser back blocked after history reset (logout)
- Fixed gRPC-web proxy port `127.0.0.1:31008` (configurable via `ANYTYPE_GRPCWEB_ADDR`)
- Default dev port changed from 9090 to 3030
- Production build uses absolute asset paths for SPA compatibility
- Polyfilled missing electron mock handlers (`switchToTabByRoute`, `openRouteInTab`, `setBackground`, `setHasPinSet`)

## Files changed
- `vite.web.config.ts` — SPA fallback plugin, `base: '/'`, `appType: 'mpa'`, asset path fix
- `src/ts/lib/web/routeSync.ts` — new file, bidirectional history sync
- `src/ts/app.tsx` — 3-line init of route sync in web mode
- `src/ts/entry.web.tsx` — config param stripping, deep link redirect
- `src/ts/lib/web/electronMock.ts` — handler polyfills
- `scripts/start-web.js` — fixed gRPC port, port change, crash handling

## Test plan
- [x] `bun run start:web` — app loads at `http://127.0.0.1:3030/`
- [x] Navigate between pages — browser URL updates
- [x] Browser back/forward works within and across spaces
- [x] Open deep link URL directly in new tab
- [x] Restart dev server — app reconnects without changing localStorage
- [x] Logout — browser back is blocked
- [x] `bun run typecheck` passes