### PR TITLE
feat: add setting to hide media file objects in sidebar page tree

### DIFF
--- a/src/json/text.json
+++ b/src/json/text.json
@@ -895,6 +895,7 @@
 	"popupSettingsPersonalSidebar": "Automatically show and hide sidebar",
 	"popupSettingsPersonalAlwaysShowTabbar": "Always show tab bar",
 	"popupSettingsPersonalHardwareAcceleration": "Hardware acceleration",
+	"popupSettingsPersonalHideFileObjectsInTree": "Hide media files in page tree",
 	"popupConfirmHardwareAccelerationTitle": "Restart Required",
 	"popupConfirmHardwareAccelerationText": "Changing hardware acceleration requires restarting the app. Do you want to restart now?",
 	"popupSettingsPersonalRelativeDates": "Use relative dates",

--- a/src/json/text.json
+++ b/src/json/text.json
@@ -908,6 +908,7 @@
 	"popupSettingsPersonalSectionLists": "Lists",
 	"popupSettingsPersonalGridTitleClick": "Click to edit title in Grid",
 	"popupSettingsPersonalSectionApp": "App Appearance",
+	"popupSettingsPersonalSectionSidebar": "Sidebar",
 	"popupSettingsPersonalSectionDateTime": "Date & Time",
 	"popupSettingsPersonalSectionAdvanced": "Advanced",
 	"popupSettingsPersonalTimeFormat": "Time format",

--- a/src/ts/component/page/main/settings/personal.tsx
+++ b/src/ts/component/page/main/settings/personal.tsx
@@ -10,7 +10,7 @@ enum ChatKey {
 
 const PageMainSettingsPersonal = observer(forwardRef<I.PageRef, I.PageSettingsComponent>((props, ref) => {
 
-	const { config, linkStyle, fileStyle, fullscreenObject, hideSidebar, vaultMessages, gridTitleClick } = S.Common;
+	const { config, linkStyle, fileStyle, fullscreenObject, hideSidebar, vaultMessages, gridTitleClick, hideFileObjectsInTree } = S.Common;
 	const { hideTray, showMenuBar, alwaysShowTabs, hardwareAcceleration } = config;
 	const { theme, chatCmdSend } = S.Common;
 	const cmd = keyboard.cmdSymbol();
@@ -126,6 +126,15 @@ const PageMainSettingsPersonal = observer(forwardRef<I.PageRef, I.PageSettingsCo
 							analytics.event('ShowInSystemTray', { type: v });
 						}}
 					/>
+				</div>
+
+				<div className="item">
+    				<Label text={translate('popupSettingsPersonalHideFileObjectsInTree')} />
+    				<Switch
+						className="big"
+						value={hideFileObjectsInTree}
+						onChange={(e: any, v: boolean) => S.Common.hideFileObjectsInTreeSet(v)}
+    				/>
 				</div>
 
 				{canHideMenu ? (

--- a/src/ts/component/page/main/settings/personal.tsx
+++ b/src/ts/component/page/main/settings/personal.tsx
@@ -97,14 +97,6 @@ const PageMainSettingsPersonal = observer(forwardRef<I.PageRef, I.PageSettingsCo
 				</div>
 
 				<div className="item">
-					<Label text={translate('popupSettingsPersonalSidebar')} />
-					<Switch className="big" value={hideSidebar} onChange={(e: any, v: boolean) => {
-						S.Common.hideSidebarSet(v);
-						Renderer.send('setHideSidebar', v);
-					}} />
-				</div>
-
-				<div className="item">
 					<Label text={translate('popupSettingsPersonalAlwaysShowTabbar')} />
 					<Switch 
 						className="big" 
@@ -128,15 +120,6 @@ const PageMainSettingsPersonal = observer(forwardRef<I.PageRef, I.PageSettingsCo
 					/>
 				</div>
 
-				<div className="item">
-    				<Label text={translate('popupSettingsPersonalHideFileObjectsInTree')} />
-    				<Switch
-						className="big"
-						value={hideFileObjectsInTree}
-						onChange={(e: any, v: boolean) => S.Common.hideFileObjectsInTreeSet(v)}
-    				/>
-				</div>
-
 				{canHideMenu ? (
 					<div className="item">
 						<Label text={translate('electronMenuShowMenu')} />
@@ -149,6 +132,31 @@ const PageMainSettingsPersonal = observer(forwardRef<I.PageRef, I.PageSettingsCo
 						/>
 					</div>
 				) : ''}
+			</div>
+
+			<Label className="section" text={translate('popupSettingsPersonalSectionSidebar')} />
+
+			<div className="actionItems">
+				<div className="item">
+					<Label text={translate('popupSettingsPersonalSidebar')} />
+					<Switch
+						className="big"
+						value={hideSidebar}
+						onChange={(e: any, v: boolean) => {
+							S.Common.hideSidebarSet(v);
+							Renderer.send('setHideSidebar', v);
+						}}
+					/>
+				</div>
+
+				<div className="item">
+    				<Label text={translate('popupSettingsPersonalHideFileObjectsInTree')} />
+    				<Switch
+						className="big"
+						value={hideFileObjectsInTree}
+						onChange={(e: any, v: boolean) => S.Common.hideFileObjectsInTreeSet(v)}
+    				/>
+				</div>
 			</div>
 
 			<Label className="section" text={translate('popupSettingsPersonalSectionChat')} />

--- a/src/ts/component/widget/tree/index.tsx
+++ b/src/ts/component/widget/tree/index.tsx
@@ -154,10 +154,16 @@ const WidgetTree = observer(forwardRef<WidgetTreeRefProps, I.WidgetComponent>((p
 
 	// return the child nodes details for the given subId
 	const getChildNodesDetails = (nodeId: string): I.WidgetTreeDetails[] => {
-		return S.Record.getRecords(getSubId(nodeId), [ 'id', 'layout', 'links' ], true).map(it => mapper(it));
+		return S.Record.getRecords(getSubId(nodeId), [ 'id', 'layout', 'links' ], true)
+			.filter(it => !Storage.get('hideFileObjectsInTree') || !U.Object.isInFileLayouts(it.layout))
+			.map(it => mapper(it));
 	};
 
 	const mapper = (o) => {
+		if (Storage.get('hideFileObjectsInTree') && U.Object.isInFileLayouts(o.layout)) {
+			o.links = [];
+			return o;
+		};
 		o.links = U.Object.isSetLayout(o.layout) ? [] : filterDeletedLinks(Relation.getArrayValue(o.links));
 		return o;
 	};

--- a/src/ts/component/widget/tree/index.tsx
+++ b/src/ts/component/widget/tree/index.tsx
@@ -155,16 +155,16 @@ const WidgetTree = observer(forwardRef<WidgetTreeRefProps, I.WidgetComponent>((p
 	// return the child nodes details for the given subId
 	const getChildNodesDetails = (nodeId: string): I.WidgetTreeDetails[] => {
 		return S.Record.getRecords(getSubId(nodeId), [ 'id', 'layout', 'links' ], true)
-			.filter(it => !Storage.get('hideFileObjectsInTree') || !U.Object.isInFileLayouts(it.layout))
+			.filter(it => !S.Common.hideFileObjectsInTree || !U.Object.isInFileLayouts(it.layout))
 			.map(it => mapper(it));
 	};
 
 	const mapper = (o) => {
-		if (Storage.get('hideFileObjectsInTree') && U.Object.isInFileLayouts(o.layout)) {
+		if (U.Object.isSetLayout(o.layout) || (S.Common.hideFileObjectsInTree && U.Object.isInFileLayouts(o.layout))) {
 			o.links = [];
-			return o;
+		} else {
+			o.links = filterDeletedLinks(Relation.getArrayValue(o.links));
 		};
-		o.links = U.Object.isSetLayout(o.layout) ? [] : filterDeletedLinks(Relation.getArrayValue(o.links));
 		return o;
 	};
 

--- a/src/ts/store/common.ts
+++ b/src/ts/store/common.ts
@@ -52,6 +52,7 @@ class CommonStore {
 
 	public recentEditModeValue: I.RecentEditMode = null;
 	public hideSidebarValue = null;
+	public hideFileObjectsInTreeValue = null;
 	public autoDownloadValue = null;
 	public pinValue = null;
 	public firstDayValue = null;
@@ -146,6 +147,7 @@ class CommonStore {
 			fileStyleValue: observable,
 			isOnlineValue: observable,
 			hideSidebarValue: observable,
+			hideFileObjectsInTreeValue: observable,
 			autoDownloadValue: observable,
 			spaceId: observable,
 			leftSidebarStateValue: observable,
@@ -316,6 +318,10 @@ class CommonStore {
 
 	get hideSidebar (): boolean {
 		return this.boolGet('hideSidebar');
+	};
+
+	get hideFileObjectsInTree (): boolean {
+		return this.boolGet('hideFileObjectsInTree');
 	};
 
 	get autoDownload (): number {
@@ -703,6 +709,10 @@ class CommonStore {
 	 */
 	hideSidebarSet (v: boolean) {
 		this.boolSet('hideSidebar', v);
+	};
+
+	hideFileObjectsInTreeSet (v: boolean) {
+		this.boolSet('hideFileObjectsInTree', v);
 	};
 
 	autoDownloadSet (v: number) {


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
Adds a toggle setting to hide media file objects (images, video, audio, etc) from appearing as child items in sidebar page trees. Inline-embedded files are treated as first-class objects in Anytype and show up as sub-pages alongside actual pages, which clutters the tree navigation if you want a hierarchical "Notion-like" experience. This adds a toggle in Settings > Personal to hide/demote them.

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
[https://www.reddit.com/r/Anytype/comments/1ry40pe/hide_images_from_tree_view/](https://www.reddit.com/r/Anytype/comments/1ry40pe/hide_images_from_tree_view/)
Disclosure: This is my own post! But someone else agreed in the comments.

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

UI Toggle:
<img width="817" height="456" alt="image" src="https://github.com/user-attachments/assets/004c325a-d147-4221-b9ef-e53a92cbe1a0" />

Before:
<img width="1449" height="852" alt="image" src="https://github.com/user-attachments/assets/9d79ed9a-29f6-4ac0-88ce-fe7c9e33b59c" />


After:
<img width="1433" height="897" alt="image" src="https://github.com/user-attachments/assets/b8708f42-b2c2-4735-867f-bd23a5017785" />



### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->

Not that I'm aware of. This is my first contribution to a community/FOSS project, please be kind :) open to any feedback/changes.