### PR TITLE
PROD-2601: Fix inline code marker in markdown shortcuts panel

### DIFF
--- a/src/json/shortcut.ts
+++ b/src/json/shortcut.ts
@@ -188,7 +188,7 @@ const getSections = () => {
 				{
 					name: translate('popupShortcutMarkdownWhileTyping'),
 					children: [
-						{ name: translate('popupShortcutMarkdownWhileTyping1'), text: '` `' },
+						{ name: translate('popupShortcutMarkdownWhileTyping1'), text: '`' },
 						{ name: translate('popupShortcutMarkdownWhileTyping2'), text: `_ _ ${or} * *` },
 						{ name: translate('popupShortcutMarkdownWhileTyping3'), text: `_ ${or} *` },
 						{ name: translate('popupShortcutMarkdownWhileTyping4'), text: '~ ~' },


### PR DESCRIPTION
## Summary
- Fix misleading inline code marker in the markdown shortcuts panel: show a single backtick (`` ` ``) instead of two spaced backticks (`` ` ` ``), which was confusing users into thinking double backticks were required.

## Test plan
- [ ] Open the shortcuts popup → Markdown tab → "While typing" section
- [ ] Verify "Inline code" row shows a single `` ` `` marker
- [ ] Verify bold, italic, and strikethrough rows are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)