### PR TITLE
Bugfix/JS-9326: Hide sticky social block on typing even with comments visible

### DIFF
--- a/src/ts/component/comment/section.tsx
+++ b/src/ts/component/comment/section.tsx
@@ -146,12 +146,12 @@ const CommentSection = observer((props: I.CommentSectionProps) => {
 		const onKeyDown = (e: KeyboardEvent) => {
 			const target = e.target as HTMLElement;
 
-			if (!target?.closest('.blocks') || isExpanded) {
+			if (!target?.closest('.blocks')) {
 				return;
 			};
 
-			const posts = S.Comment.getPosts(subId);
-			if (!posts.length) {
+			const canHide = wasStickyRef.current || (!S.Comment.getPosts(subId).length && !isExpanded);
+			if (canHide) {
 				setHidden(true);
 			};
 		};


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
