### PR TITLE
JS-9357: fix graph/pdf workers in web mode

### DIFF
--- a/dist/index.web.html
+++ b/dist/index.web.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<base href="/dist/" />
 		<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Anytype Web</title>


### PR DESCRIPTION
## Summary
- Added `<base href="/dist/">` to `dist/index.web.html` to fix worker loading in web mode
- Worker paths (`workers/graph.js`, `workers/pdf.worker.mjs`) were resolving relative to the current SPA route URL (e.g. `/main/graph/bafyrei.../workers/graph.js`) instead of the app root, causing `Unexpected token '<'` errors because the SPA fallback returned HTML
- The `<base>` tag makes all relative URLs resolve from `/dist/`, which the SPA fallback already passes through to Vite's file serving

## Test plan
- [ ] Open graph view in web mode on a deep route — verify no console errors, graph renders
- [ ] Verify PDF preview works in web mode
- [ ] Verify Electron mode is unaffected (graph + PDF still work)