### PR TITLE
Bugfix/JS-8678: Redirect to dashboard when opening deleted object

### DIFF
--- a/src/ts/lib/util/common.ts
+++ b/src/ts/lib/util/common.ts
@@ -580,6 +580,11 @@ class UtilCommon {
 			return false;
 		};
 
+		if ([ J.Error.Code.NOT_FOUND, J.Error.Code.OBJECT_DELETED ].includes(code)) {
+			U.Space.openDashboard({ replace: true });
+			return false;
+		};
+
 		S.Popup.open('confirm', {
 			data: {
 				iconParam: { name: 'popup/header/error', color: 'orange' },


### PR DESCRIPTION
## Summary
- When navigating back to a deleted/auto-removed object, the app now silently redirects to the dashboard instead of showing a confusing error popup and blank screen
- Handles `NOT_FOUND` and `OBJECT_DELETED` error codes from `ObjectOpen` by redirecting with `replace: true` so the broken history entry is replaced

## Test plan
- [ ] Create a new object, don't edit it, switch to another object, navigate back — should land on dashboard, no error popup
- [ ] Navigate to a permanently deleted object via history — should redirect to dashboard
- [ ] Normal object navigation still works as before
- [ ] Objects that fail to open for other reasons still show the error popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)