### PR TITLE
Bugfix/JS-8879: Navigate back after deleting viewed object

### DIFF
--- a/src/ts/lib/action.ts
+++ b/src/ts/lib/action.ts
@@ -436,7 +436,14 @@ class Action {
 						if (isPopup) {
 							S.Popup.close('page');
 						} else {
-							U.Space.openDashboard();
+							const history = U.Router.history;
+							const prev = history.entries[history.index - 1];
+
+							if (prev) {
+								history.goBack();
+							} else {
+								U.Space.openDashboard();
+							};
 						};
 					};
 


### PR DESCRIPTION
## Summary
- When permanently deleting an object you're currently viewing (e.g. an image opened from a note), the app now navigates back in history instead of always redirecting to the dashboard
- Falls back to dashboard only when there's no previous history entry

## Test plan
- [ ] Open a note, click on an image to open it as media page, permanently delete the image — should return to the note
- [ ] Delete an object from the dashboard — should stay on dashboard
- [ ] Delete an object opened directly (no previous history) — should go to dashboard
- [ ] Popup context deletion still closes the popup as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)