### PR TITLE
Bugfix/JS-9085: Support middle-click to open objects in new tab

### DIFF
--- a/src/ts/component/list/object.tsx
+++ b/src/ts/component/list/object.tsx
@@ -153,7 +153,7 @@ const ListObjectRow = ({ item, columnList, css, subId, rootId, onContext, select
 
 				return (
 					<div key={`cell-${column.relationKey}`} className={cn.join(' ')}>
-						{content ? <div className={cnc.join(' ')} onClick={onClick}>{content}</div> : ''}
+						{content ? <div className={cnc.join(' ')} onClick={onClick} onAuxClick={onClick}>{content}</div> : ''}
 					</div>
 				);
 			})}

--- a/src/ts/component/list/objectManager.tsx
+++ b/src/ts/component/list/objectManager.tsx
@@ -344,7 +344,7 @@ const ObjectManager = observer(forwardRef<ObjectManagerRefProps, Props>(({
 					onChange={e => onClick(e, item)}
 				/>
 			)}
-			<div className="objectClickArea" onClick={e => U.Object.openEvent(e, item)}>
+			<div className="objectClickArea" onClick={e => U.Object.openEvent(e, item)} onAuxClick={e => U.Object.openEvent(e, item)}>
 				<IconObject object={item} size={iconSize} />
 
 				<div className="info">

--- a/src/ts/component/page/main/settings/space/share/members.tsx
+++ b/src/ts/component/page/main/settings/space/share/members.tsx
@@ -173,7 +173,7 @@ const Members = observer(forwardRef<I.PageRef, I.PageSettingsComponent>((props, 
 
 		return (
 			<div id={`item-${id}`} className={[ 'row', isJoining ? 'isNew' : '' ].join(' ')}>
-				<div className="side left" onClick={e => U.Object.openEvent(e, item)}>
+				<div className="side left" onClick={e => U.Object.openEvent(e, item)} onAuxClick={e => U.Object.openEvent(e, item)}>
 					<IconObject size={48} object={item} />
 					<div className="text">
 						<ObjectName object={item} withPronoun={item.id == participant?.id} withBadge={true} />

--- a/src/ts/component/popup/search.tsx
+++ b/src/ts/component/popup/search.tsx
@@ -807,6 +807,7 @@ const PopupSearch = observer(forwardRef<{}, I.Popup>((props, ref) => {
 				className={cn.join(' ')}
 				onMouseEnter={e => onOver(e, item)}
 				onClick={e => onClick(e, item)}
+				onAuxClick={e => onClick(e, item)}
 			>
 				{icon}
 				{content}

--- a/src/ts/component/widget/object.tsx
+++ b/src/ts/component/widget/object.tsx
@@ -237,6 +237,7 @@ const WidgetObject = observer(forwardRef<{}, I.WidgetComponent>((props, ref) => 
 				{...listeners}
 				style={style}
 				onClick={e => U.Object.openEvent(e, item)}
+				onAuxClick={e => U.Object.openEvent(e, item)}
 				onContextMenu={e => onContextHandler(e, item, false)}
 			>
 				<div className="side left">


### PR DESCRIPTION
## Summary
- Add `onAuxClick` handlers to components that use React's `onClick` (which only fires for left-click, not middle-click)
- The core `U.Object.openEvent()` already handles `e.button == 1` to open in a new tab — this just ensures the event reaches it
- Components using `onMouseDown` (widgets list/gallery/board, sidebar tree, block links) already supported middle-click

**Updated components:**
- `list/objectManager` — All Objects tab
- `list/object` — object list rows
- `widget/object` — widget single object items
- `popup/search` — global search results
- `settings/share/members` — space member list

## Test plan
- [ ] Middle-click on an object in the All Objects list → opens in new tab
- [ ] Middle-click on a search result in global search (Cmd+S) → opens in new tab
- [ ] Middle-click on a widget object item → opens in new tab
- [ ] Middle-click on an object list row → opens in new tab
- [ ] Left-click still works as before (opens in current tab)
- [ ] Ctrl/Cmd+click still opens in new tab
- [ ] Right-click still shows context menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)