### PR TITLE
Bugfix/JS-9125: Fix paste in code block scrolling page up

### DIFF
--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -2070,13 +2070,13 @@ const EditorPage = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 				from = to = block.getLength();
 
 				keyboard.setFocus(false);
-			} else 
+			} else
 			if (message.caretPosition >= 0) {
 				id = focused;
 				from = to = message.caretPosition;
 			};
 
-			focusSet(id, from, to, !message.isSameBlockCaret);
+			focusSet(id, from, to, id != focused);
 			analytics.event('PasteBlock', { count });
 		});
 	};


### PR DESCRIPTION
## Summary
- Fix page jumping to the top of a code block when pasting text while the top of the block is off-screen
- Changed the scroll condition in `onPaste` from `!message.isSameBlockCaret` to `id != focused` — only scroll when focus actually moves to a different block (e.g. pasting multiple blocks that create new block IDs)
- When pasting within the same block (code snippets, text blocks), the cursor stays in place and the page doesn't jump

## Test plan
- [ ] Insert a code snippet, type several lines, scroll down so top of block is off-screen, paste text — page should NOT scroll up
- [ ] Paste content that creates new blocks (e.g. paste multiple paragraphs into a text block) — focus should still scroll to the new block
- [ ] Paste within a regular text block — no unexpected scroll
- [ ] Verified on macOS, should also fix Windows/Linux per the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)