### PR TITLE
Bugfix/JS-8746: Fix focus lost when creating item in full kanban column

### DIFF
--- a/src/ts/component/block/dataview.tsx
+++ b/src/ts/component/block/dataview.tsx
@@ -1422,11 +1422,16 @@ const BlockDataview = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 		};
 	};
 
-	const setRecordEditingOn = (e: any, id: string) => {
+	const setRecordEditingOn = (e: any, id: string, retries?: number) => {
 		const ref = recordRefs.current.get(id);
 		const nameId = Relation.cellId(getIdPrefix(), 'name', id);
 		const nameRef = cellRefs.current.get(nameId);
 		const win = $(window);
+
+		if (!nameRef && (retries === undefined || retries > 0)) {
+			window.setTimeout(() => setRecordEditingOn(e, id, (retries ?? 5) - 1), 50);
+			return;
+		};
 
 		if (ref && ref.setIsEditing) {
 			ref.setIsEditing(true);


### PR DESCRIPTION
## Summary
- Fix title input not receiving focus when creating a new item in a scrollable kanban column
- The issue was a race condition: the 15ms timeout for `setRecordEditingOn` wasn't enough for the new card's cell refs to be registered in columns with many items (React render + scroll takes longer)
- Added retry logic (up to 5 retries at 50ms intervals) that waits for the name cell ref to become available before applying focus
- Empty columns still work instantly since the card mounts quickly

## Test plan
- [ ] In Kanban view, click "+" in a column with many items (scrollable) — new item should get focus for typing
- [ ] Click "+" in an empty column — should still get focus immediately
- [ ] Create item via keyboard in Kanban — should get focus
- [ ] Grid/Gallery/List views unaffected (different code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)