### PR TITLE
Bugfix/JS-9315: Fix object name lost when created via Enter in relation cell

### DIFF
--- a/src/ts/component/cell/object.tsx
+++ b/src/ts/component/cell/object.tsx
@@ -207,8 +207,8 @@ const CellObject = observer(forwardRef<I.CellRef, I.Cell>((props, ref) => {
 			return;
 		};
 
-		const { details, flags } = Relation.getParamForNewObject(text, relation);
-		U.Object.create('', '', details, I.BlockPosition.Bottom, '', flags, analytics.route.relation, message => onValueAdd(message.targetId));
+		const { details } = Relation.getParamForNewObject(text, relation);
+		U.Object.create('', '', details, I.BlockPosition.Bottom, '', [], analytics.route.relation, message => onValueAdd(message.targetId));
 	};
 
 	const onFocus = () => {


### PR DESCRIPTION
## Summary
- Fix new object name not being saved when creating through a relation cell by pressing Enter (keyboard)
- The `SelectTemplate` flag in `onOptionAdd` caused the middleware to apply a default template, which could override the typed name
- Removed the flag to match the mouse-click creation path (`onObjectAdd` in `optionSelect.tsx`), which passes empty flags and correctly preserves the name
- Mouse-click creation was already working because it didn't use the `SelectTemplate` flag

## Test plan
- [ ] In a set grid view, click on an Object relation cell, type a name, press Enter — new object should have the typed name
- [ ] Same test but click "Create object 'xxx'" with mouse — should still work (was already working)
- [ ] Create object through relation in a collection — name preserved
- [ ] Verify templates still apply correctly when creating objects through other paths (e.g., "+" button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)