### PR TITLE
Refactoring/jQuery migration

### DIFF
--- a/src/ts/component/block/bookmark.tsx
+++ b/src/ts/component/block/bookmark.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useEffect, useRef, MouseEvent } from 'react';
-import $ from 'jquery';
 import raf from 'raf';
 import { observer } from 'mobx-react';
 import { InputWithFile, ObjectName, ObjectDescription, Loader, Error, Icon } from 'Component';
@@ -95,8 +94,10 @@ const BlockBookmark = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, 
 	
 	const resize = () => {
 		window.setTimeout(() => {
-			const inner = $(innerRef.current);
-			inner.toggleClass('isVertical', inner.width() <= getWrapperWidth() / 2);
+			const inner = innerRef.current;
+			if (inner) {
+				U.Dom.toggleClass(inner, 'isVertical', inner.offsetWidth <= getWrapperWidth() / 2);
+			};
 		}, 0);
 	};
 

--- a/src/ts/component/block/dataview/view/grid/foot/cell.tsx
+++ b/src/ts/component/block/dataview/view/grid/foot/cell.tsx
@@ -144,9 +144,9 @@ const FootCell = observer(forwardRef<Ref, Props>((props, ref) => {
 			return;
 		};
 
-		const node = $(nodeRef.current);
+		const node = nodeRef.current;
 
-		node.addClass('hover');
+		U.Dom.addClass(node, 'hover');
 
 		if ((result === null) || S.Menu.isOpen()) {
 			return;
@@ -154,12 +154,12 @@ const FootCell = observer(forwardRef<Ref, Props>((props, ref) => {
 
 		const t = Preview.tooltipCaption(name, result);
 		if (t) {
-			Preview.tooltipShow({ text: t, element: node, typeY: I.MenuDirection.Top });
+			Preview.tooltipShow({ text: t, element: $(nodeRef.current), typeY: I.MenuDirection.Top });
 		};
 	};
 
 	const onMouseLeave = () => {
-		$(nodeRef.current).removeClass('hover');
+		U.Dom.removeClass(nodeRef.current, 'hover');
 		Preview.tooltipHide();
 	};
 

--- a/src/ts/component/block/featured.tsx
+++ b/src/ts/component/block/featured.tsx
@@ -46,14 +46,17 @@ const BlockFeatured = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 
 	const init = () => {
 		const items = getItems().filter(it => it.relationKey != 'description');
-		const node = $(nodeRef.current);
-		const obj = $(`#block-${U.Common.esc(block.id)}`);
+		const node = nodeRef.current;
+		const obj = U.Dom.get(`block-${U.Common.esc(block.id)}`);
 
-		obj.toggleClass('isHidden', !items.length);
+		U.Dom.toggleClass(obj, 'isHidden', !items.length);
 
 		if (node) {
-			node.find('.cell.first').removeClass('first');
-			node.find('.cell').first().addClass('first');
+			node.querySelectorAll('.cell.first').forEach(el => U.Dom.removeClass(el as HTMLElement, 'first'));
+			const firstCell = node.querySelector('.cell');
+			if (firstCell) {
+				U.Dom.addClass(firstCell as HTMLElement, 'first');
+			};
 		};
 	};
 

--- a/src/ts/component/block/media/audio.tsx
+++ b/src/ts/component/block/media/audio.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useEffect, forwardRef, useImperativeHandle } from 'react';
-import $ from 'jquery';
 import raf from 'raf';
 import { observer } from 'mobx-react';
 import { InputWithFile, Error, MediaAudio, Icon } from 'Component';
@@ -26,11 +25,11 @@ const BlockAudio = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref
 	};
 
 	const onPlay = () => {
-		$(nodeRef.current).addClass('isPlaying');
+		U.Dom.addClass(nodeRef.current, 'isPlaying');
 	};
 
 	const onPause = () => {
-		$(nodeRef.current).removeClass('isPlaying');
+		U.Dom.removeClass(nodeRef.current, 'isPlaying');
 	};
 
 	const onKeyDownHandler = (e: any) => {

--- a/src/ts/component/cell/file.tsx
+++ b/src/ts/component/cell/file.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useState, useImperativeHandle, useEffect } from 'react';
-import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { IconObject, ObjectName } from 'Component';
 import * as I from 'Interface';
@@ -47,7 +46,7 @@ const CellFile = observer(forwardRef<I.CellRef, I.Cell>((props, ref) => {
 	};
 
 	useEffect(() => {
-		$(`#${U.Common.esc(id)}`).toggleClass('isEditing', isEditing);
+		U.Dom.toggleClass(U.Dom.get(U.Common.esc(id)), 'isEditing', isEditing);
 	}, [ isEditing ]);
 
 	useImperativeHandle(ref, () => ({

--- a/src/ts/component/cell/text.tsx
+++ b/src/ts/component/cell/text.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useRef, useState, useEffect, useImperativeHandle } from 'react';
-import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { Input, IconObject, ChatCounter, Icon } from 'Component';
 import * as I from 'Interface';
@@ -343,8 +342,8 @@ const CellText = observer(forwardRef<I.CellRef, I.Cell>((props, ref: any) => {
 	}, []);
 
 	useEffect(() => {
-		const cell = $(`#${U.Common.esc(id)}`);
-		const card = viewType == I.ViewType.Grid ? null : $(`#record-${U.Common.esc(record.id)}`);
+		const cell = U.Dom.get(U.Common.esc(id));
+		const card = viewType == I.ViewType.Grid ? null : U.Dom.get(`record-${U.Common.esc(record.id)}`);
 
 		if (isEditing) {
 			let val = value.current;
@@ -392,16 +391,20 @@ const CellText = observer(forwardRef<I.CellRef, I.Cell>((props, ref: any) => {
 		} else {
 			setValue(Relation.formatValue(relation, record[relation.relationKey], true));
 
-			cell.find('.cellContent').css({ left: '', right: '' });
+			const cellContent = cell?.querySelector('.cellContent') as HTMLElement;
+			if (cellContent) {
+				cellContent.style.left = '';
+				cellContent.style.right = '';
+			};
 		};
 
-		cell.toggleClass('isEditing', isEditing);
-		if (card && card.length) {
-			card.toggleClass('isEditing', isEditing);
+		U.Dom.toggleClass(cell, 'isEditing', isEditing);
+		if (card) {
+			U.Dom.toggleClass(card, 'isEditing', isEditing);
 		};
 
 		if (S.Common.cellId) {
-			$(`#${U.Common.esc(S.Common.cellId)}`).addClass('isEditing');
+			U.Dom.addClass(U.Dom.get(U.Common.esc(S.Common.cellId)), 'isEditing');
 		};
 	});
 

--- a/src/ts/component/form/textarea.tsx
+++ b/src/ts/component/form/textarea.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useRef, useState, useEffect, useImperativeHandle } from 'react';
-import $ from 'jquery';
+
 
 interface Props {
 	id?: string;
@@ -95,7 +95,7 @@ const Textarea = forwardRef<TextareaRefProps, Props>(({
 			onFocus(e, value);
 		};
 		keyboard.setFocus(true);
-		$(nodeRef.current).addClass('isFocused');
+		U.Dom.addClass(nodeRef.current, 'isFocused');
 	};
 
 	const onBlurHandler = (e: any) => {
@@ -103,7 +103,7 @@ const Textarea = forwardRef<TextareaRefProps, Props>(({
 			onBlur(e, value);
 		};
 		keyboard.setFocus(false);
-		$(nodeRef.current).removeClass('isFocused');
+		U.Dom.removeClass(nodeRef.current, 'isFocused');
 	};
 
 	const onCopyHandler = (e: any) => {
@@ -127,15 +127,15 @@ const Textarea = forwardRef<TextareaRefProps, Props>(({
 	};
 	
 	const setError = (v: boolean) => {
-		$(nodeRef.current).toggleClass('withError', v);
+		U.Dom.toggleClass(nodeRef.current, 'withError', v);
 	};
 
 	const addClass = (v: string) => {
-		$(nodeRef.current).addClass(v);
+		U.Dom.addClass(nodeRef.current, v);
 	};
 	
 	const removeClass = (v: string) => {
-		$(nodeRef.current).removeClass(v);
+		U.Dom.removeClass(nodeRef.current, v);
 	};
 	
 	useEffect(() => setValue(initialValue));

--- a/src/ts/component/list/popup.tsx
+++ b/src/ts/component/list/popup.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useEffect } from 'react';
-import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { Popup } from 'Component';
 import * as I from 'Interface';
@@ -8,7 +7,7 @@ const ListPopup: FC<I.PageComponent> = observer(() => {
 	const { list } = S.Popup;
 
 	useEffect(() => {
-		$('body').toggleClass('overPopup', S.Popup.list.length > 0);
+		U.Dom.toggleClass(document.body, 'overPopup', S.Popup.list.length > 0);
 	}, [ list.length ]);
 
 	return (

--- a/src/ts/component/menu/item/vertical.tsx
+++ b/src/ts/component/menu/item/vertical.tsx
@@ -187,10 +187,10 @@ const MenuItemVertical = forwardRef<{}, I.MenuItem>((props, ref) => {
 	};
 
 	const resize = () => {
-		const node = $(nodeRef.current);
-		
-		if (!node.hasClass('withIcon')) {
-			node.toggleClass('withIconObject', !!node.find('.iconObject').length);
+		const node = nodeRef.current;
+
+		if (node && !U.Dom.hasClass(node, 'withIcon')) {
+			U.Dom.toggleClass(node, 'withIconObject', !!node.querySelectorAll('.iconObject').length);
 		};
 	};
 

--- a/src/ts/component/page/auth/login.tsx
+++ b/src/ts/component/page/auth/login.tsx
@@ -1,6 +1,5 @@
 import React, { forwardRef, useState, useRef, useEffect, KeyboardEvent } from 'react';
 import { observer } from 'mobx-react';
-import $ from 'jquery';
 import { Frame, Error, Button, Header, Phrase, Title, Label } from 'Component';
 import * as I from 'Interface';
 import Storage from 'Lib/storage';
@@ -152,7 +151,7 @@ const PageAuthLogin = observer(forwardRef<I.PageRef, I.PageComponent>((props, re
 	};
 
 	useEffect(() => {
-		$(frameRef.current.getNode()).removeClass('invisible');
+		U.Dom.removeClass(frameRef.current.getNode(), 'invisible');
 		focus();
 	}, []);
 

--- a/src/ts/component/page/main/settings/api.tsx
+++ b/src/ts/component/page/main/settings/api.tsx
@@ -24,7 +24,8 @@ const PageMainSettingsApi = observer(forwardRef<I.PageRef, I.PageSettingsCompone
 	};
 
 	const onMore = (item: any) => {
-		const element = $(`#${getId()} #icon-more-${item.hash}`);
+		const element = `#${getId()} #icon-more-${item.hash}`;
+		const el = U.Dom.select(element);
 		const options: any[] = [
 			{ id: 'copyKey', name: translate('popupSettingsApiCopyKey') },
 			{ id: 'copyMcp', name: translate('popupSettingsApiCopyMcp') },
@@ -35,8 +36,8 @@ const PageMainSettingsApi = observer(forwardRef<I.PageRef, I.PageSettingsCompone
 			element,
 			horizontal: I.MenuDirection.Right,
 			offsetY: 4,
-			onOpen: () => element.addClass('active'),
-			onClose: () => element.removeClass('active'),
+			onOpen: () => U.Dom.addClass(el, 'active'),
+			onClose: () => U.Dom.removeClass(el, 'active'),
 			data: {
 				options,
 				onSelect: (e: any, element: any) => {
@@ -75,7 +76,7 @@ const PageMainSettingsApi = observer(forwardRef<I.PageRef, I.PageSettingsCompone
 				</div>
 				<div 
 					className="col" 
-					onMouseEnter={e => Preview.tooltipShow({ text: item.apiKey, element: $(e.currentTarget) })} 
+					onMouseEnter={e => Preview.tooltipShow({ text: item.apiKey, element: e.currentTarget as HTMLElement })}
 					onMouseLeave={() => Preview.tooltipHide()}
 				>
 					{U.String.shortMask(item.apiKey, 3)}

--- a/src/ts/component/page/main/settings/membership/intro.tsx
+++ b/src/ts/component/page/main/settings/membership/intro.tsx
@@ -1,6 +1,5 @@
 import React, { forwardRef, useState, useRef, useImperativeHandle } from 'react';
 import { observer } from 'mobx-react';
-import $ from 'jquery';
 import { Title, Label, Button, Icon } from 'Component';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Pagination, Mousewheel } from 'swiper/modules';
@@ -173,7 +172,7 @@ const PageMainSettingsMembershipIntro = observer(forwardRef<I.PageRef, I.PageSet
 		};
 
 		for (const key of Object.keys(breakpoint)) {
-			$(nodeRef.current).toggleClass(key, pw <= breakpoint[key]);
+			U.Dom.toggleClass(nodeRef.current, key, pw <= breakpoint[key]);
 		};
 	};
 

--- a/src/ts/component/page/main/settings/membership/loader.tsx
+++ b/src/ts/component/page/main/settings/membership/loader.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useEffect, useRef } from 'react';
-import $ from 'jquery';
 import { Icon, Label } from 'Component';
 
 const PageMainSettingsMembershipLoader = forwardRef<HTMLDivElement, {}>((props, ref) => {
@@ -9,7 +8,7 @@ const PageMainSettingsMembershipLoader = forwardRef<HTMLDivElement, {}>((props, 
 
 	useEffect(() => {
 		timeoutRef.current = window.setTimeout(() => {
-			$(nodeRef.current).addClass('longWait');
+			U.Dom.addClass(nodeRef.current, 'longWait');
 		}, 5000);
 
 		return () => {

--- a/src/ts/component/page/main/settings/space/list.tsx
+++ b/src/ts/component/page/main/settings/space/list.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef } from 'react';
-import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { Title, IconObject, ObjectName, Icon } from 'Component';
 import * as I from 'Interface';
@@ -49,12 +48,14 @@ const PageMainSettingsSpacesList = observer(forwardRef<I.PageRef, I.PageSettings
 	const onMore = (space: any) => {
 		const element = `#${getId()} #icon-more-${space.id}`;
 
+		const el = U.Dom.select(element);
+
 		U.Menu.spaceContext(space, {
 			element,
 			horizontal: I.MenuDirection.Right,
 			offsetY: 4,
-			onOpen: () => $(element).addClass('active'),
-			onClose: () => $(element).removeClass('active'),
+			onOpen: () => U.Dom.addClass(el, 'active'),
+			onClose: () => U.Dom.removeClass(el, 'active'),
 		}, { 
 			withPin: true,
 			withDelete: true,

--- a/src/ts/component/popup/introduceChats.tsx
+++ b/src/ts/component/popup/introduceChats.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useState, useRef, useEffect } from 'react';
-import $ from 'jquery';
 import { Title, Label, Button, Icon, } from 'Component';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Keyboard, Navigation } from 'swiper/modules';
@@ -25,10 +24,10 @@ const PopupIntroduceChats = forwardRef<{}, I.Popup>(({ param, close }, ref) => {
 	};
 
 	const initGallery = () => {
-		const wrapper = $(nodeRef.current).find('.step1');
+		const wrapper = nodeRef.current?.querySelector('.step1');
 
 		window.clearTimeout(timeout.current);
-		timeout.current = window.setTimeout(() => wrapper.removeClass('init'), 600);
+		timeout.current = window.setTimeout(() => U.Dom.removeClass(wrapper, 'init'), 600);
 	};
 
 	const onSlideChange = () => {
@@ -41,7 +40,7 @@ const PopupIntroduceChats = forwardRef<{}, I.Popup>(({ param, close }, ref) => {
 
 	useEffect(() => {
 		onStepChange(0, () => {
-			$(nodeRef.current).find('.step0').removeClass('init');
+			U.Dom.removeClass(nodeRef.current?.querySelector('.step0'), 'init');
 		});
 
 		return () => {

--- a/src/ts/component/popup/membership/activation.tsx
+++ b/src/ts/component/popup/membership/activation.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useRef, useState, useEffect } from 'react';
-import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { Title, Label, Button, Loader, Error, Icon, Input } from 'Component';
 import * as I from 'Interface';
@@ -24,14 +23,14 @@ const PopupMembershipActivation = observer(forwardRef<{}, I.Popup>((props, ref) 
 		inputRef.current?.setValue('');
 		setError('');
 		buttonRef.current?.setDisabled(true);
-		$(inputWrapperRef.current).removeClass('canClear');
+		U.Dom.removeClass(inputWrapperRef.current, 'canClear');
 	};
 
 	const checkButton = () => {
 		const v = inputRef.current?.getValue();
 
 		buttonRef.current?.setDisabled(!v.length);
-		$(inputWrapperRef.current).toggleClass('canClear', v.length > 0);
+		U.Dom.toggleClass(inputWrapperRef.current, 'canClear', v.length > 0);
 	};
 
 	const onSubmit = (e: any) => {

--- a/src/ts/component/popup/space/joinByLink.tsx
+++ b/src/ts/component/popup/space/joinByLink.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef, useRef, useState, } from 'react';
 import { observer } from 'mobx-react';
 import { Label, Button, Error, Icon, Input } from 'Component';
-import $ from 'jquery';
 import * as I from 'Interface';
 
 const PopupSpaceJoinByLink = observer(forwardRef<{}, I.Popup>(({ param = {}, getId, close }, ref) => {
@@ -12,7 +11,7 @@ const PopupSpaceJoinByLink = observer(forwardRef<{}, I.Popup>(({ param = {}, get
 	const onKeyUp = () => {
 		const v = inputRef.current.getValue();
 
-		$(`#${getId()} .button`).toggleClass('disabled', !v.length);
+		U.Dom.toggleClass(U.Dom.select(`#${getId()} .button`), 'disabled', !v.length);
 		setError('');
 	};
 

--- a/src/ts/component/sidebar/page/settings/library.tsx
+++ b/src/ts/component/sidebar/page/settings/library.tsx
@@ -272,10 +272,13 @@ const SidebarPageSettingsLibrary = observer(forwardRef<{}, I.SidebarPageComponen
 	};
 
 	const setActive = (id: string) => {
-		const body = $(bodyRef.current);
+		const body = bodyRef.current;
+		if (!body) {
+			return;
+		};
 
-		body.find('.item.active').removeClass('active');
-		body.find(`#item-${U.Common.esc(id)}`).addClass('active');
+		U.Dom.removeClass(body.querySelector('.item.active'), 'active');
+		U.Dom.addClass(body.querySelector(`#item-${U.Common.esc(id)}`), 'active');
 	};
 
 	const onContext = (item: any) => {

--- a/src/ts/component/sidebar/page/type.tsx
+++ b/src/ts/component/sidebar/page/type.tsx
@@ -41,7 +41,7 @@ const SidebarPageType = observer(forwardRef<{}, I.SidebarPageComponent>((props, 
 	};
 
 	const disableButton = (v: boolean) => {
-		$(buttonSaveRef.current?.getNode()).toggleClass('disabled', v);
+		U.Dom.toggleClass(buttonSaveRef.current?.getNode(), 'disabled', v);
 	};
 
 	const getType = () => {

--- a/src/ts/component/sidebar/section/type/template.tsx
+++ b/src/ts/component/sidebar/section/type/template.tsx
@@ -42,7 +42,7 @@ const SidebarSectionTypeTemplate = observer(forwardRef<I.SidebarSectionRef, I.Si
 
 	const onMore = (e: any, template: any) => {
 		const item = U.Common.objectCopy(template);
-		const node = $(`#sidebarRight #preview-${U.Common.esc(item.id)}`);
+		const node = U.Dom.select(`#sidebarRight #preview-${U.Common.esc(item.id)}`);
 
 		e.preventDefault();
 		e.stopPropagation();
@@ -64,8 +64,8 @@ const SidebarSectionTypeTemplate = observer(forwardRef<I.SidebarSectionRef, I.Si
 				subIds: J.Menu.dataviewTemplate,
 				className: 'fixed',
 				classNameWrap: 'fromSidebar',
-				onOpen: () => node.addClass('active'),
-				onClose: () => node.removeClass('active'),
+				onOpen: () => U.Dom.addClass(node, 'active'),
+				onClose: () => U.Dom.removeClass(node, 'active'),
 				data: {
 					template: item,
 					isView: false,

--- a/src/ts/component/widget/view/calendar/index.tsx
+++ b/src/ts/component/widget/view/calendar/index.tsx
@@ -76,8 +76,8 @@ const WidgetViewCalendar = observer(forwardRef<WidgetViewCalendarRefProps, I.Wid
 				classNameWrap: 'fromSidebar',
 				horizontal: I.MenuDirection.Center,
 				noFlipX: true,
-				onOpen: () => $(element).addClass('active'),
-				onClose: () => $(element).removeClass('active'),
+				onOpen: () => U.Dom.addClass(U.Dom.select(element), 'active'),
+				onClose: () => U.Dom.removeClass(U.Dom.select(element), 'active'),
 				data: {
 					rootId,
 					blockId: J.Constant.blockId.dataview,

--- a/src/ts/component/widget/view/index.tsx
+++ b/src/ts/component/widget/view/index.tsx
@@ -425,7 +425,7 @@ const WidgetView = observer(forwardRef<WidgetViewRefProps, I.WidgetComponent>((p
 	}, [ searchIds ]);
 
 	useEffect(() => {
-		$(`#widget-${U.Common.esc(parent.id)}`).toggleClass('isEmpty', isEmpty);
+		U.Dom.toggleClass(U.Dom.get(`widget-${U.Common.esc(parent.id)}`), 'isEmpty', isEmpty);
 		checkShowAllButton(subId);
 	});
 

--- a/src/ts/lib/util/dom.ts
+++ b/src/ts/lib/util/dom.ts
@@ -4,6 +4,50 @@ import * as I from 'Interface';
 
 class UtilDom {
 
+	get (id: string): HTMLElement | null {
+		return document.getElementById(id);
+	};
+
+	select (selector: string, root: ParentNode = document): HTMLElement | null {
+		return root.querySelector(selector);
+	};
+
+	selectAll (selector: string, root: ParentNode = document): HTMLElement[] {
+		return Array.from(root.querySelectorAll(selector));
+	};
+
+	addClass (el: HTMLElement, ...names: string[]) {
+		if (el) {
+			el.classList.add(...names);
+		};
+	};
+
+	removeClass (el: HTMLElement, ...names: string[]) {
+		if (el) {
+			el.classList.remove(...names);
+		};
+	};
+
+	hasClass (el: HTMLElement, name: string): boolean {
+		return el ? el.classList.contains(name) : false;
+	};
+
+	toggleClass (el: HTMLElement, name: string, force?: boolean) {
+		if (el) {
+			el.classList.toggle(name, force);
+		};
+	};
+
+	contentWidth (el: HTMLElement): number {
+		const style = getComputedStyle(el);
+		return el.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight);
+	};
+
+	contentHeight (el: HTMLElement): number {
+		const style = getComputedStyle(el);
+		return el.clientHeight - parseFloat(style.paddingTop) - parseFloat(style.paddingBottom);
+	};
+
 	/**
 	 * Returns the current selection range in the window.
 	 * @returns {Range|null} The selection range or null if none.

--- a/src/ts/store/menu.ts
+++ b/src/ts/store/menu.ts
@@ -173,15 +173,16 @@ class MenuStore {
 		const { param } = item;
 		const { noAnimation, subIds, onClose } = param;
 		const t = noAnimation ? 0 : J.Constant.delay.menu;
-		const el = $(`#${U.String.toCamelCase(`menu-${id}`)}`);
+		const el = U.Dom.get(U.String.toCamelCase(`menu-${id}`));
 
 		if (subIds && subIds.length) {
 			this.closeAll(subIds);
 		};
 
-		if (el.length) {
-			el.toggleClass('noAnimation', noAnimation);
-			el.css({ transform: '' }).removeClass('show');
+		if (el) {
+			U.Dom.toggleClass(el, 'noAnimation', noAnimation);
+			el.style.transform = '';
+			U.Dom.removeClass(el, 'show');
 		};
 
 		U.Data.updateTabsDimmer(null, this.menuList.filter(it => it.id != id));


### PR DESCRIPTION
## Summary
- Adds centralized DOM helper methods to `U.Dom` (`get`, `select`, `selectAll`, `addClass`, `removeClass`, `toggleClass`, `hasClass`, `contentWidth`, `contentHeight`) — single indirection point for all DOM queries and class manipulation, with built-in null safety
- Migrates jQuery class manipulation (`.addClass`/`.removeClass`/`.hasClass`/`.toggleClass`) to `U.Dom.*` across 23 files
- Fully removes `import $ from 'jquery'` from 12 files where no other jQuery usage remained

## Test plan
- [ ] Verify bookmark cards toggle `isVertical` class correctly on resize
- [ ] Verify dataview grid foot cells show hover state
- [ ] Verify featured block shows/hides and first-cell highlighting works
- [ ] Verify audio player toggles `isPlaying` class
- [ ] Verify cell editing states (file, text) toggle `isEditing` class
- [ ] Verify form textarea focus/clear states
- [ ] Verify popup overlay class toggles on open/close
- [ ] Verify menu item vertical icon detection and tooltip
- [ ] Verify auth login frame removes `invisible` class
- [ ] Verify settings pages (API, membership, space list) active states
- [ ] Verify sidebar template context menu active state
- [ ] Verify widget empty state and calendar day menu active state
- [ ] Verify menu close animation (noAnimation toggle, show removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)