### PR TITLE
Remove jQuery from dom.ts, migrate scroll/container consumers to native DOM

### DIFF
--- a/docs/jquery-removal-plan.md
+++ b/docs/jquery-removal-plan.md
@@ -1,42 +1,137 @@
 # jQuery Removal Plan
 
-> Created: 2026-03-28 | Status: Planning | Current jQuery: `^3.7.1` (192 KB minified)
+> Created: 2026-03-28 | Updated: 2026-03-29 | Status: **In Progress** | Current jQuery: `^3.7.1` (192 KB minified)
 
 ---
 
-## Current State
+## Migration Progress
 
-jQuery is used across **199 files** in `src/ts/`, totalling roughly **3,000+ call sites**. It was introduced early in the project before React patterns matured, and persists because it provides convenient APIs for tasks React intentionally does not own (measuring DOM, managing window events, imperative class toggling).
+### What's Done
 
-### Usage Breakdown
+| PR | Phase | Description | Files | Call Sites |
+|----|-------|-------------|-------|------------|
+| [#2103](https://github.com/anyproto/anytype-ts/pull/2103) | 0 + 1a | `U.Dom` helpers (`get`, `select`, `selectAll`, `addClass`, `removeClass`, `toggleClass`, `hasClass`, `contentWidth`, `contentHeight`) + class manipulation migration in 23 files | 24 | ~42 |
+| [#2104](https://github.com/anyproto/anytype-ts/pull/2104) | 1b + 2a | Remove jQuery from `dom.ts` entirely. `getScrollContainer`/`getPageContainer`/`getPageFlexContainer` return `HTMLElement \| null`. Migrate all ~80 consumer call sites. Convert `getWindowDimensions`, `triggerResizeEditor`, `addBodyClass`, `injectCss`, `pauseMedia`, `renderLinks`, `toggle`, `scrollToHeader`, `clearSelection` | 53 | ~120 |
 
-| Category | ~Count | Native Replacement Available |
-|----------|--------|------------------------------|
-| Class manipulation (`.addClass`/`.removeClass`/`.toggleClass`/`.hasClass`) | 597 | `classList` API |
-| Element traversal (`.find`/`.closest`/`.parent`/`.children`/`.siblings`) | 39+ | `querySelector`/`closest`/`parentElement` |
-| Dimensions & position (`.width`/`.height`/`.offset`/`.outerWidth`/`.css`) | 41+ | `getBoundingClientRect`/`offsetWidth`/`getComputedStyle` |
-| Inline style manipulation (`.css(prop, value)`) | ~60 | `el.style.prop` / `el.style.setProperty()` |
-| Namespaced events (`$(window).on('keydown.ns')`) | 221 | Custom helper (see below) |
-| DOM show/hide/append/remove | ~100 | Direct DOM API or React state |
-| Scroll position (`.scrollTop`/`.scrollLeft`) | ~50 | `element.scrollTop` |
-| jQuery wrapping of refs (`$(node.current)`) | 266+ | Use ref directly |
-| Animation (`.animate`/`.fadeIn`) | 4 | CSS transitions / Web Animations API |
-| AJAX | 0 | N/A |
+**Total migrated so far: ~75 files, ~160 call sites**
 
-### Top Files by jQuery Density
+### What's Left
 
-| File | Calls | Primary Use |
-|------|-------|-------------|
-| `block/table.tsx` | 74 | Cell sizing, selection, class toggling |
-| `lib/sidebar.ts` | 46 | Resize, animation, class toggling |
-| `block/index.tsx` | 42 | Block state classes, traversal |
-| `app.tsx` | 40 | Global events, resize |
-| `block/embed.tsx` | 38 | Iframe sizing, visibility |
-| `dataview/view/grid.tsx` | 33 | Column sizing, scroll sync |
-| `dataview/view/board.tsx` | 33 | Card layout, drag |
-| `dataview/view/timeline.tsx` | 29 | Timeline positioning |
-| `widget/index.tsx` | 28 | Widget state classes |
-| `menu/index.tsx` | 28 | Menu positioning, events |
+**185 files** still import jQuery. **223 files** total use `$(` (38 via global `window.$`). Roughly **1,123 `$(` call sites** remain.
+
+| Category | Remaining | Notes |
+|----------|-----------|-------|
+| `$(window).on`/`.off`/`.trigger` | **218** across 115 files | Namespaced events — largest single category. Menus are ~80% of these (uniform pattern) |
+| `.addClass`/`.removeClass`/`.hasClass`/`.toggleClass` | **550** across 138 files | Many in heavy files (sidebar 40, table 33, block/index 20). Some already migrated in easy files |
+| `$(ref.current)` wrapping | **370** across 113 files | Wraps React refs just to call `.find()`, `.addClass()`, `.css()`, etc. |
+| `.width()`/`.height()`/`.offset()`/`.outerWidth()` | **190** across 58 files | Dimension queries — use `clientWidth`/`getBoundingClientRect()`/`U.Dom.contentWidth()` |
+| `.find()` traversal | ~100+ | Often chained on `$(ref.current).find(...)` |
+| `.css({...})` inline styles | ~80+ | Replace with `Object.assign(el.style, ...)` |
+| `.animate()` | 4 | Replace with CSS transitions or `element.animate()` |
+| `window.$ = $` global | 1 (`app.tsx`) | Remove last — blocks tree-shaking |
+
+---
+
+## Current State (Post-Migration)
+
+### `lib/util/dom.ts` — Fully jQuery-Free
+
+All methods now use native DOM APIs. jQuery import removed. Key return type changes:
+
+| Method | Before | After |
+|--------|--------|-------|
+| `getScrollContainer(isPopup)` | `JQuery<HTMLElement>` | `HTMLElement \| null` |
+| `getPageContainer(isPopup)` | `JQuery<HTMLElement>` | `HTMLElement \| null` |
+| `getPageFlexContainer(isPopup)` | `JQuery<HTMLElement>` | `HTMLElement \| null` |
+| `getScrollContainerTop(isPopup)` | `number` (via jQuery) | `number` (native) |
+| `getMaxScrollHeight(isPopup)` | `number` (via jQuery) | `number` (native) |
+| `getAppContainerHeight()` | `number` (via jQuery) | `number` (native) |
+| `getWindowDimensions()` | `{ ww, wh }` (via jQuery) | `{ ww, wh }` (native `window.innerWidth/Height`) |
+| `triggerResizeEditor(isPopup)` | `$(window).trigger(...)` | `window.dispatchEvent(new CustomEvent(...))` |
+
+### `U.Dom` Helper API
+
+Available helpers (use these instead of raw `document.*` calls):
+
+```typescript
+U.Dom.get(id)                          // getElementById
+U.Dom.select(selector, root?)         // querySelector
+U.Dom.selectAll(selector, root?)      // querySelectorAll
+U.Dom.addClass(el, ...names)          // classList.add (null-safe)
+U.Dom.removeClass(el, ...names)       // classList.remove (null-safe)
+U.Dom.toggleClass(el, name, force?)   // classList.toggle (null-safe)
+U.Dom.hasClass(el, name)              // classList.contains (null-safe)
+U.Dom.contentWidth(el)                // jQuery .width() equivalent
+U.Dom.contentHeight(el)               // jQuery .height() equivalent
+```
+
+---
+
+## Remaining Phases
+
+### Phase 3: Event Migration (~115 files, 218 event sites)
+
+This is the **largest remaining category**. jQuery namespaced events (`$(window).on('keydown.menuName')`) have no native equivalent — need either an `EventNamespace` helper or inline `addEventListener`/`removeEventListener` with stored handler refs.
+
+**3a. Window/document events** (~100 files)
+- Start with **menus** (~80 files) — they all follow the same `$(window).on('keydown.menuName')` / `$(window).off('keydown.menuName')` pattern
+- Then popups (~15 files), then pages (~20 files)
+
+**3b. Custom event bus** (~25 trigger sites)
+- Replace `$(window).trigger('customEvent')` with `dispatchEvent(new CustomEvent(...))`
+- Events like `updateGraphRoot`, `updateGraphSettings`, `resize.editor`, `archiveObject.search`
+
+**Decision needed**: Create `EventNamespace` helper (per original plan) or use inline `addEventListener`/`removeEventListener` with stored refs (as done in #2104 for scroll events). The menu pattern is uniform enough that either approach works.
+
+### Phase 4: Heavy Files (~20 files, ~800 call sites)
+
+These files have deep jQuery integration across multiple categories (classes, events, dimensions, traversal):
+
+| File | ~Remaining `$(` | Primary Patterns |
+|------|-----------------|------------------|
+| `lib/sidebar.ts` | ~25 | Events, `$(window)`, `$('#sidebarDummyLeft')`, dimension queries |
+| `block/table.tsx` | ~40 | Cell sizing (`.outerWidth()`), selection, events |
+| `block/index.tsx` | ~20 | State classes, traversal (`.find`), events |
+| `app.tsx` | ~30 | Global events, classes, `window.$ = $` |
+| `block/embed.tsx` | ~15 | Events, dimension queries |
+| `dataview/view/grid.tsx` | ~15 | Column sizing, scroll sync, events |
+| `dataview/view/board.tsx` | ~15 | Card layout, drag, events |
+| `dataview/view/timeline.tsx` | ~10 | Positioning, dimension queries |
+| `drag/provider.tsx` | ~15 | Measurement, events, broadcast class clears |
+| `selection/provider.tsx` | ~8 | Selection rect, events, broadcast class clears |
+| `editor/page.tsx` | ~10 | Events, measurement, placeholder text |
+| `block/chat/form.tsx` | ~15 | Text editing, events, class manipulation |
+| `block/cover.tsx` | ~20 | Image positioning, events, dimension queries |
+| `menu/index.tsx` | ~10 | Positioning, events |
+| `widget/index.tsx` | ~10 | State classes, events |
+
+Each file should be its own PR with before/after testing.
+
+### Phase 5: Remaining $(ref.current) Wrapping (~113 files, 370 sites)
+
+Many files wrap React refs in jQuery just to call one method:
+```typescript
+// Before
+$(nodeRef.current).find('.child')
+$(nodeRef.current).addClass('active')
+$(nodeRef.current).css({ width: px })
+
+// After
+nodeRef.current?.querySelector('.child')
+U.Dom.addClass(nodeRef.current, 'active')
+nodeRef.current.style.width = `${px}px`
+```
+
+These are mechanical but spread across many files. Can be done in batches grouped by component area.
+
+### Phase 6: Cleanup (1 PR)
+
+1. Remove `window.$ = $` from `app.tsx`
+2. Remove `import $ from 'jquery'` from all remaining files
+3. Remove `jquery` from `package.json`
+4. Remove `window.$` type declaration
+5. Run `bun run typecheck` and `bun run lint` to verify clean removal
+6. Verify bundle size reduction (~192 KB minified, ~70 KB gzipped)
 
 ---
 
@@ -57,68 +152,11 @@ jQuery is used across **199 files** in `src/ts/`, totalling roughly **3,000+ cal
 
 **Problem**: jQuery namespaced events (`.on('keydown.myComponent')`) are attached to `window`/`document` and cleaned up in `componentWillUnmount` or `useEffect` cleanup. If cleanup is missed or runs in wrong order, handlers leak.
 
-**Examples**:
-```typescript
-// Common pattern across ~100 files
-$(window).on('keydown.sidebarPageVault', handler);
-// Must manually call $(window).off('keydown.sidebarPageVault')
-```
-
 **Impact**: Memory leaks, ghost event handlers, handlers firing for destroyed components.
 
 ### 3. jQuery Selectors Bypassing React's Component Tree
 
 **Problem**: Selectors like `$('#page .block.c' + blockId)` reach across component boundaries, creating invisible coupling. The selector breaks silently if class names or DOM structure change.
-
-**Existing solution**: `S.Common.refSet(id, ref)` / `S.Common.getRef(id)` provides a centralized ref registry. Currently it stores **React component instances** (not raw DOM nodes) — consumers call `.getNode()` to access the underlying DOM element, or call component methods like `.clear()`, `.onDragStart()` directly.
-
-**Current registrations** (5 total):
-- `'sidebarLeft'` → SidebarLeft component (has `.getNode()`, `.getComponentRef()`)
-- `'selectionProvider'` → SelectionProvider (has `.clear()`, `.renderSelection()`)
-- `'dragProvider'` → DragProvider (has `.onDragStart()`)
-- `` `editor${ns}` `` → Editor page component
-- `` `sidebarRight${ns}` `` → SidebarRight component (has `.getNode()`)
-
-**Current consumers** (73+ call sites) already access these refs. There are also ~30 jQuery selectors that reach across components by DOM ID. Most of these are **not** truly global — they can be replaced with `U.Dom` helpers (see [DOM Helpers](#dom-helpers-in-libutildomts)), local refs, or scoped `querySelector` on a parent. Only genuinely global singletons (sidebar, selection, drag providers) belong in the `refSet` registry.
-
-**Cross-component selectors to migrate** (grouped by replacement strategy):
-
-**Use `S.Common.refSet`** — only for global singletons accessed from many unrelated parts of the app:
-
-| Pattern | Files | Notes |
-|---------|-------|-------|
-| `$('#sidebarDummyLeft')` | `sidebar.ts` (5 sites) | Accessed from sidebar service, genuinely global |
-
-**Use `U.Dom` helpers** — for stable, unique elements that are always in the DOM:
-
-| Pattern | Files | Replacement |
-|---------|-------|-------------|
-| `$('#page...')`, `$('#pageFlex...')` | `dom.ts`, `editor/page.tsx` | `U.Dom.get('page')` / `U.Dom.get('pageFlex')` |
-| `$('#appContainer')` | `dom.ts` | `U.Dom.get('appContainer')` |
-| `$('#preview')`, `$('#toast')`, `$('#tooltipContainer')` | `preview.ts`, `preview/index.tsx` | `U.Dom.get(...)` |
-| `$('#dragLayer')` | `drag/provider.tsx` | `U.Dom.get('dragLayer')` |
-
-**Use local refs or scoped `querySelector`** — for elements scoped to a subtree:
-
-| Pattern | Files | Replacement |
-|---------|-------|-------------|
-| `$('#sidebarRight #relationGroup-${id}')` | `sidebar/page/object/relation.tsx` | `nodeRef.current.querySelector(...)` on sidebar right's own ref |
-| `$('#sidebarRight #preview-${id}')` | `sidebar/section/type/template.tsx` | Same — local to sidebar right |
-| `$('#header #button-header-more')` | `header/main/settings.tsx` | Local ref inside header |
-| `$('#button-header-search')`, `$('#button-header-relation')` | `keyboard.ts`, `graph/provider.tsx` | `U.Dom.get(...)` — these have stable IDs |
-| `$('#graphPreview')`, `$('#graphPreviewItem')` | `graph/provider.tsx` (4 sites) | Local refs inside graph provider |
-| `$('.popupPage .content')` | `page/main/graph.tsx` | `U.Dom.select(...)` or local ref |
-| `$(`.placeholder.c${blockId}`)` | `editor/page.tsx` (2 sites) | Local ref on the placeholder element |
-
-**Global state-class selectors** — replace broadcast `.removeClass()` with provider-tracked state:
-
-| Pattern | Files | Replacement |
-|---------|-------|-------------|
-| `$('.dropTarget.isOver').removeClass(...)` | `drag/provider.tsx`, `keyboard.ts` | DragProvider tracks current drop target ref, clears it directly |
-| `$('.isDragging').removeClass(...)` | `drag/provider.tsx` (3 sites) | DragProvider clears via tracked refs |
-| `$('.isSelectionSelected').removeClass(...)` | `selection/provider.tsx` | SelectionProvider clears via tracked refs |
-| `$('.colResize.active').removeClass(...)` | `drag/provider.tsx` | Track active column ref |
-| `$('.block.isDragging').removeClass(...)` | `drag/provider.tsx` | Clear from DragProvider |
 
 **Impact**: Fragile code that breaks when any ancestor restructures its markup. No compile-time safety.
 
@@ -126,18 +164,13 @@ $(window).on('keydown.sidebarPageVault', handler);
 
 **Problem**: jQuery `.width()` / `.height()` / `.offset()` trigger forced layout reflow. When called in loops or rapid succession (e.g., drag handlers, resize observers), this causes layout thrashing.
 
-**Examples**:
-- `table.tsx` calling `.outerWidth()` on every column during resize
-- `timeline.tsx` measuring positions in animation frames
-- `sidebar.ts` reading `.width()` during drag
-
 **Impact**: Janky resize/drag interactions, dropped frames.
 
 ### 5. `window.$ = $` Global Leak
 
-**Problem**: `app.tsx:54` exposes jQuery globally. Any file can use `$` without importing, making usage invisible to tree-shaking and bundler analysis.
+**Problem**: `app.tsx` exposes jQuery globally. Any file can use `$` without importing, making usage invisible to tree-shaking and bundler analysis (38 files currently do this).
 
-**Impact**: Cannot tree-shake jQuery even after removing all imports. Makes it hard to track remaining usage.
+**Impact**: Cannot tree-shake jQuery even after removing all imports.
 
 ---
 
@@ -145,398 +178,60 @@ $(window).on('keydown.sidebarPageVault', handler);
 
 ### DOM Helpers in `lib/util/dom.ts`
 
-**Rule: Never use raw `document.getElementById`, `document.querySelector`, or `document.querySelectorAll` directly in component or library code.** All DOM lookups go through `U.Dom` helpers. This gives us a single place to swap implementations, add instrumentation, or guard against missing elements — without touching every call site.
+**Rule: Never use raw `document.getElementById`, `document.querySelector`, or `document.querySelectorAll` directly in component or library code.** All DOM lookups go through `U.Dom` helpers.
 
-New helpers to add to the existing `UtilDom` class:
-
-```typescript
-// lib/util/dom.ts — new methods on the existing UtilDom class
-
-/** Get element by ID. Single indirection point for all getElementById calls. */
-get (id: string): HTMLElement | null {
-    return document.getElementById(id);
-};
-
-/** querySelector on a root (defaults to document). */
-select (selector: string, root: ParentNode = document): HTMLElement | null {
-    return root.querySelector(selector);
-};
-
-/** querySelectorAll on a root (defaults to document). */
-selectAll (selector: string, root: ParentNode = document): HTMLElement[] {
-    return Array.from(root.querySelectorAll(selector));
-};
-
-/**
- * Content width of an element (matches jQuery `.width()` semantics).
- * jQuery `.width()` returns content width WITHOUT padding or border.
- * Native APIs differ: `clientWidth` = content + padding, `offsetWidth` = content + padding + border.
- * This helper provides a drop-in replacement to avoid off-by-a-few-pixels regressions.
- */
-contentWidth (el: HTMLElement): number {
-    const style = getComputedStyle(el);
-    return el.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight);
-};
-
-/**
- * Content height of an element (matches jQuery `.height()` semantics).
- */
-contentHeight (el: HTMLElement): number {
-    const style = getComputedStyle(el);
-    return el.clientHeight - parseFloat(style.paddingTop) - parseFloat(style.paddingBottom);
-};
-```
-
-**Usage across the migration**:
-```typescript
-// Before (jQuery)
-$('#preview').hide();
-$('#page.isFull').scrollTop();
-$('.block.isDragging');
-
-// After (U.Dom helpers)
-const el = U.Dom.get('preview');
-if (el) el.style.display = 'none';
-
-U.Dom.select('#page.isFull')?.scrollTop;
-
-U.Dom.selectAll('.block.isDragging');
-```
-
-Existing methods like `getScrollContainer`, `getPageContainer`, `getPageFlexContainer`, `getAppContainerHeight` will be refactored to return `HTMLElement | null` instead of `JQuery<HTMLElement>`, using the new `get`/`select` helpers internally.
+**Status: IMPLEMENTED** — See [U.Dom Helper API](#udom-helper-api) above.
 
 ### A. Namespaced Events → `EventNamespace` Helper
 
-jQuery's namespaced events are the hardest to replace because `addEventListener` has no equivalent. Create a small utility:
+**Status: NOT YET IMPLEMENTED** — Currently using inline `addEventListener`/`removeEventListener` with stored handler refs for scroll events. Decision pending on whether to create the `EventNamespace` utility for the ~218 remaining event sites.
+
+Proposed utility:
 
 ```typescript
-// lib/util/eventNamespace.ts (~40 lines)
+// lib/util/eventNamespace.ts
 class EventNamespace {
     private handlers = new Map<string, { event: string; target: EventTarget; handler: EventListener }[]>();
 
     on (target: EventTarget, event: string, ns: string, handler: EventListener, options?: AddEventListenerOptions) {
-        if (!this.handlers.has(ns)) {
-            this.handlers.set(ns, []);
-        };
-
+        if (!this.handlers.has(ns)) this.handlers.set(ns, []);
         this.handlers.get(ns).push({ event, target, handler });
         target.addEventListener(event, handler, options);
     };
 
-    off (target: EventTarget, ns: string) {
-        const entries = this.handlers.get(ns);
-
-        if (!entries) {
-            return;
-        };
-
-        for (const { event, target: t, handler } of entries) {
-            if (t === target) {
-                t.removeEventListener(event, handler);
-            };
-        };
-
-        // Keep only entries for other targets
-        const remaining = entries.filter(e => e.target !== target);
-
-        if (remaining.length) {
-            this.handlers.set(ns, remaining);
-        } else {
-            this.handlers.delete(ns);
-        };
-    };
-
-    offAll (ns: string) {
-        const entries = this.handlers.get(ns);
-
-        if (!entries) {
-            return;
-        };
-
-        for (const { event, target, handler } of entries) {
-            target.removeEventListener(event, handler);
-        };
-
-        this.handlers.delete(ns);
-    };
-}
-
-export const events = new EventNamespace();
-```
-
-**Usage**:
-```typescript
-// Before
-$(window).on('keydown.myComponent', handler);
-$(window).off('keydown.myComponent');
-
-// After
-events.on(window, 'keydown', 'myComponent', handler);
-events.off(window, 'myComponent');
-
-// Remove all events for a namespace (any target)
-events.offAll('myComponent');
-```
-
-Alternatively, provide a React hook:
-
-```typescript
-// lib/hook/useNamespacedEvent.ts
-function useNamespacedEvent(target: EventTarget, event: string, handler: EventListener, deps: any[]) {
-    useEffect(() => {
-        target.addEventListener(event, handler);
-        return () => target.removeEventListener(event, handler);
-    }, deps);
+    off (target: EventTarget, ns: string) { /* remove handlers for target+ns */ };
+    offAll (ns: string) { /* remove all handlers for ns */ };
 }
 ```
 
-### B. Class Manipulation → `classList` or React State
+### B. Class Manipulation → `U.Dom.addClass`/`U.Dom.removeClass`/etc.
 
-```typescript
-// Before
-$(node).addClass('active');
-$(node).removeClass('active');
-$(node).hasClass('active');
-$(node).toggleClass('active', condition);
-
-// After (imperative, for refs)
-node.classList.add('active');
-node.classList.remove('active');
-node.classList.contains('active');
-node.classList.toggle('active', condition);
-
-// After (declarative, preferred for React-owned DOM)
-const cn = ['block', (isActive ? 'active' : '')];
-return <div className={cn.join(' ')} />;
-```
+**Status: IMPLEMENTED** for 23 easy files. ~550 calls remain across 138 files (mostly in heavy files).
 
 ### C. Dimensions & Position → Native APIs + `U.Dom` Helpers
 
-```typescript
-// Before (jQuery)
-$(el).width();              // content width (no padding)
-$(el).outerWidth();         // including border
-$(el).outerWidth(true);     // including margin
-$(el).offset();             // { top, left } relative to document
+**Status: PARTIALLY DONE** — Container methods migrated. ~190 dimension calls remain in individual components.
 
-// After (native)
-el.getBoundingClientRect(); // { width, height, top, left, ... } - one call, no reflow per-property
-el.offsetWidth;             // including border (same as outerWidth)
-el.clientWidth;             // content + padding (NOT same as jQuery .width())
-
-// After (U.Dom helper — exact jQuery .width() equivalent)
-U.Dom.contentWidth(el);     // content width without padding or border
-U.Dom.contentHeight(el);    // content height without padding or border
-```
-
-**Important**: jQuery `.width()` returns content width *without* padding, which differs from every native property. `clientWidth` includes padding, `offsetWidth` includes padding + border, `getBoundingClientRect().width` includes padding + border + transforms. For files doing pixel math (table, grid, timeline), use `U.Dom.contentWidth()` as a drop-in replacement. For files that just need approximate sizing, `getBoundingClientRect()` is fine and more performant.
-
-For the common pattern of measuring multiple elements, batch reads before writes to avoid layout thrashing.
+Use `U.Dom.contentWidth(el)` as exact jQuery `.width()` drop-in for pixel math. Use `getBoundingClientRect()` for approximate sizing.
 
 ### D. Inline Style Manipulation → `el.style`
 
+**Status: NOT YET STARTED** — ~80+ `.css({...})` calls remain.
+
 ```typescript
 // Before
-$(el).css('width', px);
 $(el).css({ left, top, width });
-
-// After (single property)
-el.style.width = `${px}px`;
-
-// After (multiple properties)
+// After
 Object.assign(el.style, { left: `${left}px`, top: `${top}px`, width: `${width}px` });
-// or for bulk:
-el.style.cssText = `left:${left}px;top:${top}px;width:${width}px`;
 ```
 
-### E. Cross-Component DOM Access
+### E. Scroll Position → Direct Property
 
-All DOM lookups go through `U.Dom` helpers — never raw `document.getElementById` or `document.querySelector` in component or library code. Pick the simplest approach for each case:
+**Status: DONE** for container-level scroll. Some component-level `.scrollTop()` calls remain (~11).
 
-**`U.Dom.get`** — for stable, unique elements by ID:
-```typescript
-// Before
-$('#preview').hide();
+### F. Custom Event Triggers → `dispatchEvent`
 
-// After
-const el = U.Dom.get('preview');
-if (el) el.style.display = 'none';
-```
-
-**`U.Dom.select` / `U.Dom.selectAll`** — for CSS selector lookups:
-```typescript
-// Before
-$('.popupPage .content');
-
-// After
-U.Dom.select('.popupPage .content');
-```
-
-**`U.Dom.select` scoped to a parent ref** — for subtree lookups:
-```typescript
-// Before
-$(`#sidebarRight #relationGroup-${id}`);
-
-// After — scoped to the sidebar right's own ref
-U.Dom.select(`#relationGroup-${id}`, nodeRef.current);
-```
-
-**Local refs** — for elements within the same component or its direct children:
-```typescript
-// Before
-$('#graphPreviewItem').css({ left, top });
-
-// After — ref created in the same component
-graphPreviewItemRef.current.style.cssText = `left:${left}px;top:${top}px`;
-```
-
-**`S.Common.refSet`/`getRef`** — reserve for global singletons accessed from many unrelated parts (sidebar, selection/drag providers). Already used this way:
-```typescript
-// Existing pattern — component instance with methods
-S.Common.getRef('selectionProvider')?.clear();
-const node = S.Common.getRef('sidebarLeft')?.getNode();
-```
-
-**Note**: Some current consumers wrap `getRef` results in jQuery: `$(S.Common.getRef('sidebarLeft')?.getNode())`. These should drop the jQuery wrapper and use the DOM node directly.
-
-### F. Scroll Position → Direct Property
-
-```typescript
-// Before
-$(el).scrollTop();
-$(el).scrollTop(100);
-
-// After
-el.scrollTop;
-el.scrollTop = 100;
-// or: el.scrollTo({ top: 100, behavior: 'smooth' });
-```
-
-### G. `$(ref.current)` Wrapping → Use Ref Directly
-
-The pattern `$(nodeRef.current).find(...)` wraps a React ref in jQuery just to call one method. Replace with `U.Dom.select(selector, nodeRef.current)` or `nodeRef.current.querySelector(...)`.
-
-### H. Custom Event Triggers → `dispatchEvent`
-
-```typescript
-// Before
-$(window).trigger('resize.editor');
-$(window).trigger('updateGraphRoot', data);
-
-// After
-window.dispatchEvent(new CustomEvent('resize.editor'));
-window.dispatchEvent(new CustomEvent('updateGraphRoot', { detail: data }));
-```
-
-Note: Both jQuery `.trigger()` and native `dispatchEvent` are synchronous, so timing behavior is preserved. The only difference is that custom data moves from the second argument to `event.detail`.
-
----
-
-## Phased Removal Plan
-
-### Phase 0: Infrastructure (1 PR)
-
-1. Add `U.Dom` helpers (`get`, `select`, `selectAll`, `contentWidth`, `contentHeight`) to the existing `lib/util/dom.ts`
-2. Create `src/ts/lib/util/eventNamespace.ts` with the `EventNamespace` class
-3. Create `src/ts/hook/useEvent.ts` with `useNamespacedEvent` hook
-4. Add ESLint rules to block new jQuery usage:
-   - Restricted import: warn on `import $ from 'jquery'`
-   - Restricted globals: warn on bare `$` and `jQuery` (catches `window.$ = $` usage)
-   - Restricted globals: warn on `document.getElementById`, `document.querySelector`, `document.querySelectorAll` with message pointing to `U.Dom` helpers
-5. Document the migration helpers in this file
-
-**Goal**: No new jQuery or raw DOM query usage enters the codebase after this point.
-
-### Phase 1: Low-Hanging Fruit (~80 files, ~400 call sites)
-
-Target files with **fewer than 5 jQuery calls** each, where replacements are mechanical. Break into one PR per category.
-
-**1a. Class manipulation in components** (~144 files, 597 calls)
-- Replace `.addClass`/`.removeClass`/`.hasClass`/`.toggleClass` with `classList`
-- Where possible, move to React state-driven className instead
-- Priority: files with 1-3 class calls (quick wins)
-
-**1b. Scroll position** (~30 files)
-- Replace `.scrollTop()`/`.scrollLeft()` with native properties
-
-**1c. `$(ref.current)` unwrapping** (~50 files)
-- Replace `$(nodeRef.current).someMethod()` with `nodeRef.current.nativeMethod()`
-
-**1d. Remove 4 animation calls**
-- Replace with CSS transitions or `element.animate()`
-
-### Phase 2: Cross-Component Selectors (~30 files)
-
-Replace jQuery selectors that reach across component boundaries. All replacements go through `U.Dom` helpers — never raw `document.getElementById` or `document.querySelector`.
-
-**2a. `U.Dom` helpers for stable unique elements**:
-- `lib/util/dom.ts` — refactor `getScrollContainer()`, `getPageContainer()`, `getPageFlexContainer()`, `getAppContainerHeight()` to use `this.get()`/`this.select()` and return `HTMLElement | null` instead of `JQuery<HTMLElement>`
-- `lib/preview.ts` — 6 calls for `#preview`, `#toast`, `#tooltipContainer` → `U.Dom.get(...)`
-- `lib/keyboard.ts` — `$('#button-header-search').trigger('click')` → `U.Dom.get(...)?.click()`
-- `drag/provider.tsx` — `$('#dragLayer')` → `U.Dom.get('dragLayer')`
-
-**2b. Local refs for component-scoped elements**:
-- `graph/provider.tsx` — 4 calls for `#graphPreview*` → local refs within graph provider
-- `sidebar/page/object/relation.tsx`, `sidebar/section/type/template.tsx` — `U.Dom.select(...)` scoped to the sidebar's own ref
-- `header/main/settings.tsx` — local ref for the more button
-- `editor/page.tsx` — 2 placeholder selectors → local refs on placeholder elements
-
-**2c. `S.Common.refSet` only for global singletons**:
-- `lib/sidebar.ts` — `$('#sidebarDummyLeft')` (5 sites) → register via `refSet`, accessed from sidebar service
-- Drop jQuery wrapping from existing `$(S.Common.getRef('sidebarLeft')?.getNode())` patterns in `sidebar.ts` and `drag/provider.tsx`
-
-**2d. Global state-class selectors** — replace broadcast `.removeClass()` with provider-tracked state:
-- `$('.dropTarget.isOver').removeClass(...)` → DragProvider tracks current drop target ref, clears it directly
-- `$('.isDragging').removeClass(...)` → DragProvider clears via tracked refs
-- `$('.isSelectionSelected').removeClass(...)` → SelectionProvider clears via tracked refs
-- `$('.colResize.active').removeClass(...)` → Track active column ref
-
-### Phase 3: Event Migration (~120 files, 221 event sites)
-
-**3a. Window/document events** (~100 files)
-- Replace `$(window).on('event.ns', handler)` with `EventNamespace` helper or `useEffect` cleanup
-- Start with menus (~40 files) since they follow a uniform pattern:
-  ```typescript
-  // Every menu does this same pattern
-  $(window).on('keydown.menuName', handler);
-  $(window).off('keydown.menuName');
-  ```
-- Then popups (~15 files), then pages (~20 files)
-
-**3b. Custom event bus** (~25 trigger sites)
-- Replace `$(window).trigger('customEvent')` with `dispatchEvent(new CustomEvent(...))`
-- Events like `updateGraphRoot`, `updateGraphSettings`, `resize.editor`, `archiveObject.search`
-- Custom data moves from jQuery's second argument to `event.detail`
-
-### Phase 4: Heavy Files (~20 files, ~800 call sites)
-
-These files have deep jQuery integration and need careful refactoring:
-
-| File | Calls | Strategy |
-|------|-------|----------|
-| `block/table.tsx` | 74 | Extract measurement into a `useTableLayout` hook; use `U.Dom.contentWidth()` as drop-in for `.width()`; batch reads with `getBoundingClientRect` |
-| `lib/sidebar.ts` | 46 | Migrate to CSS custom properties for width + `classList`; events to `EventNamespace`; `$('#sidebarDummyLeft')` to `S.Common.getRef`; drop jQuery wrapping on existing `getRef` calls |
-| `block/index.tsx` | 42 | Move state classes to React state; traversal to `U.Dom.select()` |
-| `app.tsx` | 40 | Events to `useEffect`; classes to state; register all root refs via `S.Common.refSet` |
-| `block/embed.tsx` | 38 | Iframe measurement to `ResizeObserver`; visibility to `IntersectionObserver` |
-| `dataview/view/grid.tsx` | 33 | Column sizing: use `U.Dom.contentWidth()` for pixel math; consider CSS grid or `ResizeObserver` |
-| `dataview/view/board.tsx` | 33 | Card layout measurement to `getBoundingClientRect` |
-| `drag/provider.tsx` | 22 | Measurement to native APIs; events to `EventNamespace`; broadcast class clears to tracked refs |
-| `selection/provider.tsx` | 21 | Selection rect to native APIs; broadcast class clears to tracked refs |
-| `editor/page.tsx` | 28 | Events and measurement to native APIs; placeholder text via `S.Common.getRef` |
-
-Each file in this phase should be its own PR with before/after testing of the specific interaction (resize, drag, scroll sync, etc.).
-
-### Phase 5: Cleanup (1 PR)
-
-1. Remove `window.$ = $` from `app.tsx`
-2. Remove `import $ from 'jquery'` from all files
-3. Remove `jquery` from `package.json`
-4. Remove `window.$` type declaration
-5. Remove ESLint restricted-import rule for jQuery (no longer needed)
-6. Promote ESLint restricted-globals for `document.getElementById`/`querySelector` from warn to error
-7. Run `bun run typecheck` and `bun run lint` to verify clean removal
-8. Verify bundle size reduction (~192 KB minified, ~70 KB gzipped)
+**Status: PARTIALLY DONE** — `triggerResizeEditor` converted. ~25 other `$(window).trigger()` sites remain.
 
 ---
 
@@ -545,13 +240,13 @@ Each file in this phase should be its own PR with before/after testing of the sp
 When converting a file from jQuery to native:
 
 - [ ] List all jQuery calls in the file
-- [ ] For each call, identify the replacement (`classList`, `U.Dom.get`, `U.Dom.select`, `U.Dom.contentWidth`, etc.)
-- [ ] If the file uses `$('#id')` to reach into another component, replace with `U.Dom.get(...)`, `U.Dom.select(...)` scoped to a parent, or a local ref. Only use `S.Common.refSet` for global singletons
+- [ ] For each call, identify the replacement (`U.Dom.addClass`, `U.Dom.get`, `U.Dom.select`, `U.Dom.contentWidth`, etc.)
+- [ ] If the file uses `$('#id')`, replace with `U.Dom.get(...)` or `U.Dom.select(...)`
 - [ ] If the file uses `.css(prop, value)`, replace with `el.style.prop = value`
-- [ ] If the file uses namespaced events, migrate to `EventNamespace` or `useEffect` cleanup
+- [ ] If the file uses namespaced events, migrate to `addEventListener`/`removeEventListener` with stored handler refs
 - [ ] If the file uses `$(ref.current)`, replace with direct ref access
-- [ ] If class toggling drives visual state, prefer moving to React state + className
-- [ ] If the file uses `.width()` / `.height()` for pixel math, use `U.Dom.contentWidth()` / `U.Dom.contentHeight()` — not `clientWidth` (which includes padding)
+- [ ] If class toggling drives visual state, use `U.Dom.addClass`/`U.Dom.removeClass`/`U.Dom.toggleClass`
+- [ ] If the file uses `.width()` / `.height()` for pixel math, use `U.Dom.contentWidth()` / `U.Dom.contentHeight()`
 - [ ] Never use raw `document.getElementById` / `document.querySelector` — always go through `U.Dom`
 - [ ] Run `bun run typecheck` and `bun run lint`
 - [ ] Manually test the interaction (resize, drag, menu, etc.)
@@ -568,17 +263,16 @@ When converting a file from jQuery to native:
 | Timing differences between jQuery and native events | jQuery `.trigger()` is synchronous; `dispatchEvent` is too, but custom data moves to `event.detail` — verify listeners read from the right place |
 | `.width()` vs native width — subtle but critical | jQuery `.width()` = content width (no padding); `clientWidth` = content + padding; `offsetWidth` = content + padding + border; `getBoundingClientRect().width` = content + padding + border + transforms. Use `U.Dom.contentWidth()` as exact drop-in for `.width()` in pixel-math code (table, grid, timeline). Use `getBoundingClientRect()` for approximate sizing |
 | Layout thrashing from naive migration | Batch DOM reads before writes; use `requestAnimationFrame` where needed |
-| Scattered raw DOM queries after migration | ESLint restricted-globals rule catches `document.getElementById`/`querySelector` — all lookups go through `U.Dom` helpers so we have a single point to change |
-| `window.$` bypasses import-based ESLint rule | Phase 0 adds restricted-globals rule for `$` and `jQuery` in addition to restricted-imports, catching both import and global usage |
-| Team unfamiliarity with native APIs | This document serves as reference; code review during migration |
+| Scattered raw DOM queries after migration | All lookups go through `U.Dom` helpers so we have a single point to change |
+| `window.$` bypasses import-based linting | 38 files still use global `$` — remove `window.$ = $` in Phase 6 |
 
 ---
 
 ## Success Metrics
 
-- **Phase 0**: ESLint rules block new jQuery imports, raw `$` globals, and raw `document.getElementById`/`querySelector`
-- **Phase 1**: jQuery call count drops from ~3,000 to ~1,800
-- **Phase 2**: Cross-component jQuery selectors drop to 0; all lookups through `U.Dom`
-- **Phase 3**: Event-related jQuery drops to 0; `EventNamespace` or hooks used everywhere
-- **Phase 4**: Top 20 files fully converted
-- **Phase 5**: `jquery` removed from `package.json`; bundle size drops ~70 KB gzipped
+| Metric | Start | Current | Target |
+|--------|-------|---------|--------|
+| Files importing jQuery | 199 | **185** | 0 |
+| Total `$(` call sites | ~3,000 | **~1,123** | 0 |
+| `dom.ts` jQuery-free | No | **Yes** | Yes |
+| Bundle size (jQuery) | 192 KB | 192 KB | 0 KB |

--- a/docs/jquery-removal-plan.md
+++ b/docs/jquery-removal-plan.md
@@ -1,256 +1,229 @@
 # jQuery Removal Plan
 
-> Created: 2026-03-28 | Updated: 2026-03-29 | Status: **In Progress** | Current jQuery: `^3.7.1` (192 KB minified)
+> Created: 2026-03-28 | Updated: 2026-03-29 | Status: **In Progress** | jQuery: `^3.7.1` (192 KB minified)
 
 ---
 
-## Migration Progress
+## At a Glance
 
-### What's Done
-
-| PR | Phase | Description | Files | Call Sites |
-|----|-------|-------------|-------|------------|
-| [#2103](https://github.com/anyproto/anytype-ts/pull/2103) | 0 + 1a | `U.Dom` helpers (`get`, `select`, `selectAll`, `addClass`, `removeClass`, `toggleClass`, `hasClass`, `contentWidth`, `contentHeight`) + class manipulation migration in 23 files | 24 | ~42 |
-| [#2104](https://github.com/anyproto/anytype-ts/pull/2104) | 1b + 2a | Remove jQuery from `dom.ts` entirely. `getScrollContainer`/`getPageContainer`/`getPageFlexContainer` return `HTMLElement \| null`. Migrate all ~80 consumer call sites. Convert `getWindowDimensions`, `triggerResizeEditor`, `addBodyClass`, `injectCss`, `pauseMedia`, `renderLinks`, `toggle`, `scrollToHeader`, `clearSelection` | 53 | ~120 |
-
-**Total migrated so far: ~75 files, ~160 call sites**
-
-### What's Left
-
-**185 files** still import jQuery. **223 files** total use `$(` (38 via global `window.$`). Roughly **1,123 `$(` call sites** remain.
-
-| Category | Remaining | Notes |
-|----------|-----------|-------|
-| `$(window).on`/`.off`/`.trigger` | **218** across 115 files | Namespaced events — largest single category. Menus are ~80% of these (uniform pattern) |
-| `.addClass`/`.removeClass`/`.hasClass`/`.toggleClass` | **550** across 138 files | Many in heavy files (sidebar 40, table 33, block/index 20). Some already migrated in easy files |
-| `$(ref.current)` wrapping | **370** across 113 files | Wraps React refs just to call `.find()`, `.addClass()`, `.css()`, etc. |
-| `.width()`/`.height()`/`.offset()`/`.outerWidth()` | **190** across 58 files | Dimension queries — use `clientWidth`/`getBoundingClientRect()`/`U.Dom.contentWidth()` |
-| `.find()` traversal | ~100+ | Often chained on `$(ref.current).find(...)` |
-| `.css({...})` inline styles | ~80+ | Replace with `Object.assign(el.style, ...)` |
-| `.animate()` | 4 | Replace with CSS transitions or `element.animate()` |
-| `window.$ = $` global | 1 (`app.tsx`) | Remove last — blocks tree-shaking |
+| Metric | Start | Now | Target |
+|--------|-------|-----|--------|
+| Files with jQuery | 199 | **185** | 0 |
+| `$(` call sites | ~3,000 | **~1,123** | 0 |
+| `dom.ts` jQuery-free | No | **Yes** | Yes |
+| Bundle saving | 0 KB | 0 KB | ~70 KB gzip |
 
 ---
 
-## Current State (Post-Migration)
+## Phase Checklist
 
-### `lib/util/dom.ts` — Fully jQuery-Free
+### Phase 0: Infrastructure
+- [x] Add `U.Dom.get()`, `U.Dom.select()`, `U.Dom.selectAll()` to `lib/util/dom.ts` — PR #2103
+- [x] Add `U.Dom.addClass()`, `U.Dom.removeClass()`, `U.Dom.toggleClass()`, `U.Dom.hasClass()` — PR #2103
+- [x] Add `U.Dom.contentWidth()`, `U.Dom.contentHeight()` — PR #2103
+- [ ] Create `EventNamespace` helper (`lib/util/eventNamespace.ts`)
+- [ ] Add ESLint restricted-import rule for `import $ from 'jquery'`
+- [ ] Add ESLint restricted-globals rule for bare `$`, `jQuery`, `document.getElementById`, `document.querySelector`
 
-All methods now use native DOM APIs. jQuery import removed. Key return type changes:
+### Phase 1: Mechanical Replacements
+- [x] **1a. Class manipulation** — 23 easy files migrated to `U.Dom.addClass`/etc., jQuery import removed from 12 — PR #2103
+- [x] **1b. Scroll position** — container-level `.scrollTop()` migrated in 53 files — PR #2104
+- [ ] **1c. `$(ref.current)` unwrapping** — ~370 sites across 113 files still wrap React refs in `$()` just to call `.find()`, `.addClass()`, `.css()`
+- [ ] **1d. Animation** — 4 `.animate()` calls remain → CSS transitions or `element.animate()`
 
-| Method | Before | After |
-|--------|--------|-------|
-| `getScrollContainer(isPopup)` | `JQuery<HTMLElement>` | `HTMLElement \| null` |
-| `getPageContainer(isPopup)` | `JQuery<HTMLElement>` | `HTMLElement \| null` |
-| `getPageFlexContainer(isPopup)` | `JQuery<HTMLElement>` | `HTMLElement \| null` |
-| `getScrollContainerTop(isPopup)` | `number` (via jQuery) | `number` (native) |
-| `getMaxScrollHeight(isPopup)` | `number` (via jQuery) | `number` (native) |
-| `getAppContainerHeight()` | `number` (via jQuery) | `number` (native) |
-| `getWindowDimensions()` | `{ ww, wh }` (via jQuery) | `{ ww, wh }` (native `window.innerWidth/Height`) |
+### Phase 2: dom.ts and Container Migration
+- [x] Remove jQuery import from `dom.ts` — PR #2104
+- [x] `getScrollContainer()` returns `HTMLElement | null` — PR #2104
+- [x] `getPageContainer()` returns `HTMLElement | null` — PR #2104
+- [x] `getPageFlexContainer()` returns `HTMLElement | null` — PR #2104
+- [x] Migrate all ~80 consumer call sites for new return types — PR #2104
+- [x] Convert `getWindowDimensions()` to `window.innerWidth`/`innerHeight` — PR #2104
+- [x] Convert `triggerResizeEditor()` to `dispatchEvent` — PR #2104
+- [x] Convert `clearSelection()`, `addBodyClass()`, `injectCss()`, `pauseMedia()` — PR #2104
+- [x] Convert `renderLinks()`, `toggle()`, `scrollToHeader()` — PR #2104
+
+### Phase 3: Event Migration — NOT STARTED
+- [ ] **3a. Menus** (~80 files) — `$(window).on('keydown.menuName')` / `$(window).off('keydown.menuName')` — uniform pattern
+- [ ] **3b. Popups** (~15 files) — same `$(window).on`/`.off` pattern
+- [ ] **3c. Pages & components** (~20 files) — `$(window).on`/`.off` for resize, keyboard, etc.
+- [ ] **3d. Custom event bus** (~25 trigger sites) — `$(window).trigger('customEvent')` → `dispatchEvent(new CustomEvent(...))`
+
+### Phase 4: Heavy Files — NOT STARTED
+- [ ] `lib/sidebar.ts` (~25 remaining) — events, `$('#sidebarDummyLeft')`, dimension queries
+- [ ] `block/table.tsx` (~40 remaining) — cell sizing, selection, events
+- [ ] `block/index.tsx` (~20 remaining) — state classes, traversal, events
+- [ ] `app.tsx` (~30 remaining) — global events, classes, `window.$ = $`
+- [ ] `block/embed.tsx` (~15 remaining) — events, dimension queries
+- [ ] `dataview/view/grid.tsx` (~15 remaining) — column sizing, scroll sync, events
+- [ ] `dataview/view/board.tsx` (~15 remaining) — card layout, drag, events
+- [ ] `dataview/view/timeline.tsx` (~10 remaining) — positioning, dimension queries
+- [ ] `drag/provider.tsx` (~15 remaining) — measurement, events, broadcast class clears
+- [ ] `selection/provider.tsx` (~8 remaining) — selection rect, broadcast class clears
+- [ ] `editor/page.tsx` (~10 remaining) — events, measurement
+- [ ] `block/chat/form.tsx` (~15 remaining) — text editing, events, classes
+- [ ] `block/cover.tsx` (~20 remaining) — image positioning, events
+- [ ] `menu/index.tsx` (~10 remaining) — positioning, events
+- [ ] `widget/index.tsx` (~10 remaining) — state classes, events
+
+### Phase 5: Remaining Ref Wrapping — NOT STARTED
+- [ ] Batch-convert ~370 `$(ref.current)` sites across ~113 files to direct ref access
+
+### Phase 6: Final Cleanup — NOT STARTED
+- [ ] Remove `window.$ = $` from `app.tsx`
+- [ ] Remove all remaining `import $ from 'jquery'`
+- [ ] Remove `jquery` from `package.json`
+- [ ] Remove `window.$` type declaration
+- [ ] Verify bundle size reduction (~70 KB gzipped)
+
+---
+
+## Remaining jQuery by Category
+
+| Category | Count | Files | Replacement |
+|----------|-------|-------|-------------|
+| `$(window).on`/`.off`/`.trigger` | **218** | 115 | `addEventListener`/`removeEventListener` or `EventNamespace` helper |
+| `.addClass`/`.removeClass`/`.toggleClass`/`.hasClass` | **550** | 138 | `U.Dom.addClass()`/`U.Dom.removeClass()`/etc. |
+| `$(ref.current)` wrapping | **370** | 113 | Use ref directly: `nodeRef.current?.querySelector()` |
+| `.width()`/`.height()`/`.offset()`/`.outerWidth()` | **190** | 58 | `clientWidth`/`getBoundingClientRect()`/`U.Dom.contentWidth()` |
+| `.find()` traversal | ~100+ | — | `querySelector`/`U.Dom.select(selector, parent)` |
+| `.css({...})` inline styles | ~80+ | — | `Object.assign(el.style, {...})` |
+| `.scrollTop()`/`.scrollLeft()` | ~11 | — | `el.scrollTop`/`el.scrollLeft` property |
+| `.animate()` | 4 | — | CSS transitions or `element.animate()` |
+| `window.$ = $` global | 1 | `app.tsx` | Remove last |
+
+---
+
+## U.Dom Helper API (Implemented)
+
+Use these instead of raw `document.*` calls or jQuery:
+
+```typescript
+// DOM queries
+U.Dom.get(id)                          // getElementById wrapper
+U.Dom.select(selector, root?)         // querySelector wrapper
+U.Dom.selectAll(selector, root?)      // querySelectorAll wrapper
+
+// Class manipulation (null-safe — no need for ?. chains)
+U.Dom.addClass(el, ...names)
+U.Dom.removeClass(el, ...names)
+U.Dom.toggleClass(el, name, force?)
+U.Dom.hasClass(el, name)
+
+// Measurement (exact jQuery .width()/.height() semantics)
+U.Dom.contentWidth(el)                 // content width without padding/border
+U.Dom.contentHeight(el)                // content height without padding/border
+```
+
+### dom.ts Methods — All Native Now
+
+| Method | Was (jQuery) | Now (native) |
+|--------|-------------|--------------|
+| `getScrollContainer(isPopup)` | `$('#page.isPopup')` → JQuery | `this.select(...)` → `HTMLElement \| null` |
+| `getPageContainer(isPopup)` | `$('#page.isPopup')` → JQuery | `this.select(...)` → `HTMLElement \| null` |
+| `getPageFlexContainer(isPopup)` | `$('#pageFlex.isPopup')` → JQuery | `this.select(...)` → `HTMLElement \| null` |
+| `getScrollContainerTop(isPopup)` | `.scrollTop()` jQuery | `.scrollTop` native property |
+| `getMaxScrollHeight(isPopup)` | `container.get(0).scrollHeight` | `el.scrollHeight - el.clientHeight` |
+| `getAppContainerHeight()` | `$('#appContainer').height()` | `U.Dom.contentHeight(el)` |
+| `getWindowDimensions()` | `$(window).width()/height()` | `window.innerWidth`/`innerHeight` |
 | `triggerResizeEditor(isPopup)` | `$(window).trigger(...)` | `window.dispatchEvent(new CustomEvent(...))` |
-
-### `U.Dom` Helper API
-
-Available helpers (use these instead of raw `document.*` calls):
-
-```typescript
-U.Dom.get(id)                          // getElementById
-U.Dom.select(selector, root?)         // querySelector
-U.Dom.selectAll(selector, root?)      // querySelectorAll
-U.Dom.addClass(el, ...names)          // classList.add (null-safe)
-U.Dom.removeClass(el, ...names)       // classList.remove (null-safe)
-U.Dom.toggleClass(el, name, force?)   // classList.toggle (null-safe)
-U.Dom.hasClass(el, name)              // classList.contains (null-safe)
-U.Dom.contentWidth(el)                // jQuery .width() equivalent
-U.Dom.contentHeight(el)               // jQuery .height() equivalent
-```
+| `clearSelection()` | `$(activeElement).trigger('blur')` | `activeElement.blur()` |
+| `addBodyClass(prefix, v)` | `$('html').attr('class', ...)` | `document.documentElement.className = ...` |
+| `injectCss(id, css)` | `$('head').append(...)` | `document.head.appendChild(style)` |
+| `pauseMedia()` | `$('audio, video').each(...)` | `selectAll('audio, video').forEach(...)` |
+| `renderLinks(obj)` | jQuery `.find('a')`, `.click()` | `querySelectorAll('a')`, `addEventListener` |
+| `toggle(obj, delay, isOpen)` | jQuery `.css()`, `.addClass()` | `el.style`, `U.Dom.addClass()` |
+| `scrollToHeader(rootId, item, isPopup)` | jQuery `.parents()`, `.offset()` | `el.closest()`, `getBoundingClientRect()` |
 
 ---
 
-## Remaining Phases
+## Replacement Patterns Reference
 
-### Phase 3: Event Migration (~115 files, 218 event sites)
-
-This is the **largest remaining category**. jQuery namespaced events (`$(window).on('keydown.menuName')`) have no native equivalent — need either an `EventNamespace` helper or inline `addEventListener`/`removeEventListener` with stored handler refs.
-
-**3a. Window/document events** (~100 files)
-- Start with **menus** (~80 files) — they all follow the same `$(window).on('keydown.menuName')` / `$(window).off('keydown.menuName')` pattern
-- Then popups (~15 files), then pages (~20 files)
-
-**3b. Custom event bus** (~25 trigger sites)
-- Replace `$(window).trigger('customEvent')` with `dispatchEvent(new CustomEvent(...))`
-- Events like `updateGraphRoot`, `updateGraphSettings`, `resize.editor`, `archiveObject.search`
-
-**Decision needed**: Create `EventNamespace` helper (per original plan) or use inline `addEventListener`/`removeEventListener` with stored refs (as done in #2104 for scroll events). The menu pattern is uniform enough that either approach works.
-
-### Phase 4: Heavy Files (~20 files, ~800 call sites)
-
-These files have deep jQuery integration across multiple categories (classes, events, dimensions, traversal):
-
-| File | ~Remaining `$(` | Primary Patterns |
-|------|-----------------|------------------|
-| `lib/sidebar.ts` | ~25 | Events, `$(window)`, `$('#sidebarDummyLeft')`, dimension queries |
-| `block/table.tsx` | ~40 | Cell sizing (`.outerWidth()`), selection, events |
-| `block/index.tsx` | ~20 | State classes, traversal (`.find`), events |
-| `app.tsx` | ~30 | Global events, classes, `window.$ = $` |
-| `block/embed.tsx` | ~15 | Events, dimension queries |
-| `dataview/view/grid.tsx` | ~15 | Column sizing, scroll sync, events |
-| `dataview/view/board.tsx` | ~15 | Card layout, drag, events |
-| `dataview/view/timeline.tsx` | ~10 | Positioning, dimension queries |
-| `drag/provider.tsx` | ~15 | Measurement, events, broadcast class clears |
-| `selection/provider.tsx` | ~8 | Selection rect, events, broadcast class clears |
-| `editor/page.tsx` | ~10 | Events, measurement, placeholder text |
-| `block/chat/form.tsx` | ~15 | Text editing, events, class manipulation |
-| `block/cover.tsx` | ~20 | Image positioning, events, dimension queries |
-| `menu/index.tsx` | ~10 | Positioning, events |
-| `widget/index.tsx` | ~10 | State classes, events |
-
-Each file should be its own PR with before/after testing.
-
-### Phase 5: Remaining $(ref.current) Wrapping (~113 files, 370 sites)
-
-Many files wrap React refs in jQuery just to call one method:
-```typescript
-// Before
-$(nodeRef.current).find('.child')
-$(nodeRef.current).addClass('active')
-$(nodeRef.current).css({ width: px })
-
-// After
-nodeRef.current?.querySelector('.child')
-U.Dom.addClass(nodeRef.current, 'active')
-nodeRef.current.style.width = `${px}px`
-```
-
-These are mechanical but spread across many files. Can be done in batches grouped by component area.
-
-### Phase 6: Cleanup (1 PR)
-
-1. Remove `window.$ = $` from `app.tsx`
-2. Remove `import $ from 'jquery'` from all remaining files
-3. Remove `jquery` from `package.json`
-4. Remove `window.$` type declaration
-5. Run `bun run typecheck` and `bun run lint` to verify clean removal
-6. Verify bundle size reduction (~192 KB minified, ~70 KB gzipped)
-
----
-
-## Antipatterns & Problems
-
-### 1. React/jQuery Impedance Mismatch
-
-**Problem**: jQuery mutates the DOM imperatively while React expects to own it. When both touch the same nodes, React can silently lose track of state, or jQuery changes get overwritten on re-render.
-
-**Examples**:
-- `$(node).addClass('active')` inside a React component → the class disappears on next render
-- `$(node).css('width', px)` inside `useEffect` → overwritten when MobX triggers re-render
-- `$(node).html(content)` → React's virtual DOM diverges from real DOM
-
-**Impact**: Subtle bugs where UI flickers, state drifts, or clicks stop working after re-render.
-
-### 2. Namespaced Events Without Lifecycle Guarantees
-
-**Problem**: jQuery namespaced events (`.on('keydown.myComponent')`) are attached to `window`/`document` and cleaned up in `componentWillUnmount` or `useEffect` cleanup. If cleanup is missed or runs in wrong order, handlers leak.
-
-**Impact**: Memory leaks, ghost event handlers, handlers firing for destroyed components.
-
-### 3. jQuery Selectors Bypassing React's Component Tree
-
-**Problem**: Selectors like `$('#page .block.c' + blockId)` reach across component boundaries, creating invisible coupling. The selector breaks silently if class names or DOM structure change.
-
-**Impact**: Fragile code that breaks when any ancestor restructures its markup. No compile-time safety.
-
-### 4. Measurement Loops
-
-**Problem**: jQuery `.width()` / `.height()` / `.offset()` trigger forced layout reflow. When called in loops or rapid succession (e.g., drag handlers, resize observers), this causes layout thrashing.
-
-**Impact**: Janky resize/drag interactions, dropped frames.
-
-### 5. `window.$ = $` Global Leak
-
-**Problem**: `app.tsx` exposes jQuery globally. Any file can use `$` without importing, making usage invisible to tree-shaking and bundler analysis (38 files currently do this).
-
-**Impact**: Cannot tree-shake jQuery even after removing all imports.
-
----
-
-## Replacement Strategies
-
-### DOM Helpers in `lib/util/dom.ts`
-
-**Rule: Never use raw `document.getElementById`, `document.querySelector`, or `document.querySelectorAll` directly in component or library code.** All DOM lookups go through `U.Dom` helpers.
-
-**Status: IMPLEMENTED** — See [U.Dom Helper API](#udom-helper-api) above.
-
-### A. Namespaced Events → `EventNamespace` Helper
-
-**Status: NOT YET IMPLEMENTED** — Currently using inline `addEventListener`/`removeEventListener` with stored handler refs for scroll events. Decision pending on whether to create the `EventNamespace` utility for the ~218 remaining event sites.
-
-Proposed utility:
-
-```typescript
-// lib/util/eventNamespace.ts
-class EventNamespace {
-    private handlers = new Map<string, { event: string; target: EventTarget; handler: EventListener }[]>();
-
-    on (target: EventTarget, event: string, ns: string, handler: EventListener, options?: AddEventListenerOptions) {
-        if (!this.handlers.has(ns)) this.handlers.set(ns, []);
-        this.handlers.get(ns).push({ event, target, handler });
-        target.addEventListener(event, handler, options);
-    };
-
-    off (target: EventTarget, ns: string) { /* remove handlers for target+ns */ };
-    offAll (ns: string) { /* remove all handlers for ns */ };
-}
-```
-
-### B. Class Manipulation → `U.Dom.addClass`/`U.Dom.removeClass`/etc.
-
-**Status: IMPLEMENTED** for 23 easy files. ~550 calls remain across 138 files (mostly in heavy files).
-
-### C. Dimensions & Position → Native APIs + `U.Dom` Helpers
-
-**Status: PARTIALLY DONE** — Container methods migrated. ~190 dimension calls remain in individual components.
-
-Use `U.Dom.contentWidth(el)` as exact jQuery `.width()` drop-in for pixel math. Use `getBoundingClientRect()` for approximate sizing.
-
-### D. Inline Style Manipulation → `el.style`
-
-**Status: NOT YET STARTED** — ~80+ `.css({...})` calls remain.
+### Namespaced Events (NOT YET IMPLEMENTED)
 
 ```typescript
 // Before
-$(el).css({ left, top, width });
-// After
-Object.assign(el.style, { left: `${left}px`, top: `${top}px`, width: `${width}px` });
+$(window).on('keydown.myComponent', handler);
+$(window).off('keydown.myComponent');
+
+// After (option A — inline, used for scroll events in #2104)
+let handler = (e) => { ... };
+window.addEventListener('keydown', handler);
+window.removeEventListener('keydown', handler);
+
+// After (option B — EventNamespace helper, proposed)
+events.on(window, 'keydown', 'myComponent', handler);
+events.off(window, 'myComponent');
 ```
 
-### E. Scroll Position → Direct Property
+### Class Manipulation
 
-**Status: DONE** for container-level scroll. Some component-level `.scrollTop()` calls remain (~11).
+```typescript
+// Before                                  // After
+$(node).addClass('active');                U.Dom.addClass(node, 'active');
+$(node).removeClass('active');             U.Dom.removeClass(node, 'active');
+$(node).hasClass('active');                U.Dom.hasClass(node, 'active');
+$(node).toggleClass('active', cond);       U.Dom.toggleClass(node, 'active', cond);
+```
 
-### F. Custom Event Triggers → `dispatchEvent`
+### Dimensions & Position
 
-**Status: PARTIALLY DONE** — `triggerResizeEditor` converted. ~25 other `$(window).trigger()` sites remain.
+```typescript
+// Before                                  // After
+$(el).width();                             U.Dom.contentWidth(el);    // exact match
+$(el).outerWidth();                        el.offsetWidth;
+$(el).offset();                            el.getBoundingClientRect();
+```
+
+### Inline Styles
+
+```typescript
+// Before                                  // After
+$(el).css('width', px);                    el.style.width = `${px}px`;
+$(el).css({ left, top, width });           Object.assign(el.style, { left: `${left}px`, ... });
+```
+
+### Scroll Position
+
+```typescript
+// Before                                  // After
+$(el).scrollTop();                         el.scrollTop;
+$(el).scrollTop(100);                      el.scrollTop = 100;
+```
+
+### Ref Unwrapping
+
+```typescript
+// Before                                  // After
+$(nodeRef.current).find('.child');         nodeRef.current?.querySelector('.child');
+$(nodeRef.current).addClass('x');          U.Dom.addClass(nodeRef.current, 'x');
+$(nodeRef.current).css({ width: px });     nodeRef.current.style.width = `${px}px`;
+```
+
+### Custom Events
+
+```typescript
+// Before                                  // After
+$(window).trigger('resize.editor');        window.dispatchEvent(new CustomEvent('resize.editor'));
+$(window).trigger('myEvent', data);        window.dispatchEvent(new CustomEvent('myEvent', { detail: data }));
+```
 
 ---
 
 ## Migration Checklist Per File
 
-When converting a file from jQuery to native:
-
-- [ ] List all jQuery calls in the file
-- [ ] For each call, identify the replacement (`U.Dom.addClass`, `U.Dom.get`, `U.Dom.select`, `U.Dom.contentWidth`, etc.)
-- [ ] If the file uses `$('#id')`, replace with `U.Dom.get(...)` or `U.Dom.select(...)`
-- [ ] If the file uses `.css(prop, value)`, replace with `el.style.prop = value`
-- [ ] If the file uses namespaced events, migrate to `addEventListener`/`removeEventListener` with stored handler refs
-- [ ] If the file uses `$(ref.current)`, replace with direct ref access
-- [ ] If class toggling drives visual state, use `U.Dom.addClass`/`U.Dom.removeClass`/`U.Dom.toggleClass`
-- [ ] If the file uses `.width()` / `.height()` for pixel math, use `U.Dom.contentWidth()` / `U.Dom.contentHeight()`
-- [ ] Never use raw `document.getElementById` / `document.querySelector` — always go through `U.Dom`
+- [ ] List all `$(` calls in the file
+- [ ] Replace `$('#id')` → `U.Dom.get(...)` or `U.Dom.select(...)`
+- [ ] Replace `.addClass`/`.removeClass`/`.toggleClass`/`.hasClass` → `U.Dom.addClass`/etc.
+- [ ] Replace `.css(prop, value)` → `el.style.prop = value`
+- [ ] Replace `.width()`/`.height()` → `U.Dom.contentWidth()`/`clientWidth`/`getBoundingClientRect()`
+- [ ] Replace `$(window).on/off` → `addEventListener`/`removeEventListener` with stored handler ref
+- [ ] Replace `$(ref.current)` → use ref directly
+- [ ] Replace `.find(selector)` → `U.Dom.select(selector, parent)` or `parent.querySelector()`
+- [ ] Replace `.scrollTop()` → `el.scrollTop` property
+- [ ] Never use raw `document.getElementById`/`querySelector` — use `U.Dom.*`
 - [ ] Run `bun run typecheck` and `bun run lint`
 - [ ] Manually test the interaction (resize, drag, menu, etc.)
-- [ ] Remove `import $ from 'jquery'` if no calls remain
+- [ ] Remove `import $ from 'jquery'` if no `$(` calls remain
 - [ ] Verify no runtime errors in dev console
 
 ---
@@ -259,20 +232,8 @@ When converting a file from jQuery to native:
 
 | Risk | Mitigation |
 |------|------------|
-| Behavioral regression in drag/resize | Test each heavy file individually; keep jQuery fallback until verified |
-| Timing differences between jQuery and native events | jQuery `.trigger()` is synchronous; `dispatchEvent` is too, but custom data moves to `event.detail` — verify listeners read from the right place |
-| `.width()` vs native width — subtle but critical | jQuery `.width()` = content width (no padding); `clientWidth` = content + padding; `offsetWidth` = content + padding + border; `getBoundingClientRect().width` = content + padding + border + transforms. Use `U.Dom.contentWidth()` as exact drop-in for `.width()` in pixel-math code (table, grid, timeline). Use `getBoundingClientRect()` for approximate sizing |
-| Layout thrashing from naive migration | Batch DOM reads before writes; use `requestAnimationFrame` where needed |
-| Scattered raw DOM queries after migration | All lookups go through `U.Dom` helpers so we have a single point to change |
-| `window.$` bypasses import-based linting | 38 files still use global `$` — remove `window.$ = $` in Phase 6 |
-
----
-
-## Success Metrics
-
-| Metric | Start | Current | Target |
-|--------|-------|---------|--------|
-| Files importing jQuery | 199 | **185** | 0 |
-| Total `$(` call sites | ~3,000 | **~1,123** | 0 |
-| `dom.ts` jQuery-free | No | **Yes** | Yes |
-| Bundle size (jQuery) | 192 KB | 192 KB | 0 KB |
+| Drag/resize regression | Test each heavy file individually; keep jQuery until verified |
+| `.width()` vs native width | jQuery `.width()` = content only; `clientWidth` includes padding. Use `U.Dom.contentWidth()` for pixel math |
+| Layout thrashing | Batch DOM reads before writes; use `requestAnimationFrame` |
+| `window.$` bypasses linting | 38 files use global `$` — remove `window.$ = $` in Phase 6 |
+| jQuery `.trigger()` data convention | Custom data moves from 2nd arg to `event.detail` — verify listeners |

--- a/docs/jquery-removal-plan.md
+++ b/docs/jquery-removal-plan.md
@@ -1,6 +1,6 @@
 # jQuery Removal Plan
 
-> Created: 2026-03-28 | Updated: 2026-03-29 | Status: **In Progress** | jQuery: `^3.7.1` (192 KB minified)
+> Created: 2026-03-28 | Updated: 2026-03-30 | Status: **In Progress** | jQuery: `^3.7.1` (192 KB minified)
 
 ---
 
@@ -8,102 +8,139 @@
 
 | Metric | Start | Now | Target |
 |--------|-------|-----|--------|
-| Files with jQuery | 199 | **185** | 0 |
-| `$(` call sites | ~3,000 | **~1,123** | 0 |
+| Files with jQuery | 199 | **211** (+38 made explicit) | 0 |
+| `$(` call sites | ~3,000 | **~1,089** | 0 |
 | `dom.ts` jQuery-free | No | **Yes** | Yes |
+| `preview.ts` jQuery-free | No | **Yes** | Yes |
+| `window.$ = $` global | Yes | **Removed** | Removed |
 | Bundle saving | 0 KB | 0 KB | ~70 KB gzip |
+
+> File count went up because 38 files that relied on the hidden `window.$` global now have explicit `import $ from 'jquery'` — this makes remaining usage fully trackable via grep.
 
 ---
 
-## Phase Checklist
+## What's Done
 
-### Phase 0: Infrastructure
-- [x] Add `U.Dom.get()`, `U.Dom.select()`, `U.Dom.selectAll()` to `lib/util/dom.ts` — PR #2103
-- [x] Add `U.Dom.addClass()`, `U.Dom.removeClass()`, `U.Dom.toggleClass()`, `U.Dom.hasClass()` — PR #2103
-- [x] Add `U.Dom.contentWidth()`, `U.Dom.contentHeight()` — PR #2103
-- [ ] Create `EventNamespace` helper (`lib/util/eventNamespace.ts`)
-- [ ] Add ESLint restricted-import rule for `import $ from 'jquery'`
-- [ ] Add ESLint restricted-globals rule for bare `$`, `jQuery`, `document.getElementById`, `document.querySelector`
+### Files Fully jQuery-Free (import removed)
 
-### Phase 1: Mechanical Replacements
-- [x] **1a. Class manipulation** — 23 easy files migrated to `U.Dom.addClass`/etc., jQuery import removed from 12 — PR #2103
-- [x] **1b. Scroll position** — container-level `.scrollTop()` migrated in 53 files — PR #2104
-- [ ] **1c. `$(ref.current)` unwrapping** — ~370 sites across 113 files still wrap React refs in `$()` just to call `.find()`, `.addClass()`, `.css()`
-- [ ] **1d. Animation** — 4 `.animate()` calls remain → CSS transitions or `element.animate()`
+| File | What was converted | PR |
+|------|-------------------|----|
+| `lib/util/dom.ts` | All container methods, scroll helpers, `addBodyClass`, `injectCss`, `pauseMedia`, `renderLinks`, `toggle`, `scrollToHeader`, `clearSelection`, `getWindowDimensions`, `triggerResizeEditor` | #2104 |
+| `lib/preview.ts` | `tooltipShow`, `tooltipHide`, `previewShow`, `previewHide`, `toastShow`, `toastHide` | #2104 |
+| `component/block/bookmark.tsx` | Class manipulation | #2103 |
+| `component/block/media/audio.tsx` | Class manipulation | #2103 |
+| `component/block/featured.tsx` | Class manipulation + tooltip element | #2103, #2104 |
+| `component/block/dataview/filters/rule.tsx` | Tooltip element | #2104 |
+| `component/block/dataview/view/grid/foot/cell.tsx` | Tooltip element | #2104 |
+| `component/block/chat/message/reaction.tsx` | Tooltip element | #2104 |
+| `component/cell/file.tsx` | Class manipulation | #2103 |
+| `component/cell/text.tsx` | Class manipulation | #2103 |
+| `component/form/textarea.tsx` | Class manipulation | #2103 |
+| `component/list/popup.tsx` | Class manipulation | #2103 |
+| `component/menu/item/vertical.tsx` | Tooltip element | #2104 |
+| `component/menu/publish.tsx` | Tooltip element | #2104 |
+| `component/page/auth/login.tsx` | Class manipulation | #2103 |
+| `component/page/main/settings/api.tsx` | Class manipulation | #2103 |
+| `component/page/main/settings/membership/intro.tsx` | Class manipulation | #2103 |
+| `component/page/main/settings/membership/loader.tsx` | Class manipulation | #2103 |
+| `component/page/main/settings/space/list.tsx` | Class manipulation | #2103 |
+| `component/page/main/settings/index.tsx` | Tooltip element | #2104 |
+| `component/popup/introduceChats.tsx` | Class manipulation | #2103 |
+| `component/popup/membership/activation.tsx` | Class manipulation | #2103 |
+| `component/popup/space/joinByLink.tsx` | Class manipulation | #2103 |
+| `component/popup/settings/onboarding.tsx` | Tooltip element | #2104 |
+| `component/util/icon.tsx` | Tooltip element | #2104 |
+| `component/util/progressBar.tsx` | Tooltip element | #2104 |
+| `component/util/sync.tsx` | Tooltip element | #2104 |
 
-### Phase 2: dom.ts and Container Migration
-- [x] Remove jQuery import from `dom.ts` — PR #2104
-- [x] `getScrollContainer()` returns `HTMLElement | null` — PR #2104
-- [x] `getPageContainer()` returns `HTMLElement | null` — PR #2104
-- [x] `getPageFlexContainer()` returns `HTMLElement | null` — PR #2104
-- [x] Migrate all ~80 consumer call sites for new return types — PR #2104
-- [x] Convert `getWindowDimensions()` to `window.innerWidth`/`innerHeight` — PR #2104
-- [x] Convert `triggerResizeEditor()` to `dispatchEvent` — PR #2104
-- [x] Convert `clearSelection()`, `addBodyClass()`, `injectCss()`, `pauseMedia()` — PR #2104
-- [x] Convert `renderLinks()`, `toggle()`, `scrollToHeader()` — PR #2104
+### Infrastructure Implemented
 
-### Phase 3: Event Migration — NOT STARTED
-- [ ] **3a. Menus** (~80 files) — `$(window).on('keydown.menuName')` / `$(window).off('keydown.menuName')` — uniform pattern
-- [ ] **3b. Popups** (~15 files) — same `$(window).on`/`.off` pattern
-- [ ] **3c. Pages & components** (~20 files) — `$(window).on`/`.off` for resize, keyboard, etc.
-- [ ] **3d. Custom event bus** (~25 trigger sites) — `$(window).trigger('customEvent')` → `dispatchEvent(new CustomEvent(...))`
+- [x] `U.Dom.get()`, `U.Dom.select()`, `U.Dom.selectAll()` — DOM query helpers
+- [x] `U.Dom.addClass()`, `U.Dom.removeClass()`, `U.Dom.toggleClass()`, `U.Dom.hasClass()` — null-safe class manipulation
+- [x] `U.Dom.contentWidth()`, `U.Dom.contentHeight()` — jQuery `.width()`/`.height()` drop-in
+- [x] `window.$ = $` removed from `app.tsx` and `extension/entry.tsx`
+- [x] 38 files using global `$` now have explicit `import $ from 'jquery'`
 
-### Phase 4: Heavy Files — NOT STARTED
-- [ ] `lib/sidebar.ts` (~25 remaining) — events, `$('#sidebarDummyLeft')`, dimension queries
-- [ ] `block/table.tsx` (~40 remaining) — cell sizing, selection, events
-- [ ] `block/index.tsx` (~20 remaining) — state classes, traversal, events
-- [ ] `app.tsx` (~30 remaining) — global events, classes, `window.$ = $`
-- [ ] `block/embed.tsx` (~15 remaining) — events, dimension queries
-- [ ] `dataview/view/grid.tsx` (~15 remaining) — column sizing, scroll sync, events
-- [ ] `dataview/view/board.tsx` (~15 remaining) — card layout, drag, events
-- [ ] `dataview/view/timeline.tsx` (~10 remaining) — positioning, dimension queries
-- [ ] `drag/provider.tsx` (~15 remaining) — measurement, events, broadcast class clears
-- [ ] `selection/provider.tsx` (~8 remaining) — selection rect, broadcast class clears
-- [ ] `editor/page.tsx` (~10 remaining) — events, measurement
-- [ ] `block/chat/form.tsx` (~15 remaining) — text editing, events, classes
-- [ ] `block/cover.tsx` (~20 remaining) — image positioning, events
-- [ ] `menu/index.tsx` (~10 remaining) — positioning, events
-- [ ] `widget/index.tsx` (~10 remaining) — state classes, events
+### Container Methods Migrated (return `HTMLElement | null`)
 
-### Phase 5: Remaining Ref Wrapping — NOT STARTED
-- [ ] Batch-convert ~370 `$(ref.current)` sites across ~113 files to direct ref access
+All ~80 consumer call sites updated across 53 files:
 
-### Phase 6: Final Cleanup — NOT STARTED
-- [ ] Remove `window.$ = $` from `app.tsx`
+- [x] `getScrollContainer(isPopup)` — `.scrollTop()`, `.on()/.off()`, `.height()`, `.offset()`, `.find()`, `.get(0)`
+- [x] `getPageContainer(isPopup)` — `.width()`, `.css()`, `.on()/.off()`
+- [x] `getPageFlexContainer(isPopup)` — `.width()`, `.height()`, `.css()`, `.on()/.off()`
+- [x] `getScrollContainerTop(isPopup)` — internal
+- [x] `getMaxScrollHeight(isPopup)` — internal
+- [x] `getAppContainerHeight()` — internal
+- [x] `getWindowDimensions()` — uses `window.innerWidth`/`innerHeight`
+- [x] `triggerResizeEditor(isPopup)` — uses `dispatchEvent(new CustomEvent(...))`
+
+### Tooltip/Preview Element Param Migrated
+
+`TooltipParam.element` and `Preview.element` now accept `HTMLElement` instead of jQuery. ~25 callers updated.
+
+---
+
+## What's Left
+
+### Remaining jQuery by Category
+
+| Category | Count | Files | Status |
+|----------|-------|-------|--------|
+| `$(window).on`/`.off`/`.trigger` | **218** | 115 | Not started — menus are ~80% (uniform pattern) |
+| `.addClass`/`.removeClass`/`.hasClass`/`.toggleClass` | **550** | 138 | 23 easy files done; heavy files remain |
+| `$(ref.current)` wrapping | **359** | 109 | ~11 converted via tooltip migration; bulk remains |
+| `.width()`/`.height()`/`.offset()`/`.outerWidth()` | **182** | 57 | Container-level done; component-level remains |
+| `.css({...})` inline styles | **188** | 77 | Not started |
+| `.find()` traversal | ~100+ | — | Some converted via container migration |
+| `.scrollTop()`/`.scrollLeft()` | ~11 | — | Container-level done; a few component-level remain |
+| `.animate()` | 4 | — | Not started |
+
+### Phase Checklist — Remaining Work
+
+**Phase 3: Event Migration** — NOT STARTED
+- [ ] Menus (~80 files) — `$(window).on('keydown.menuName')` / `$(window).off('keydown.menuName')`
+- [ ] Popups (~15 files) — same pattern
+- [ ] Pages & components (~20 files) — resize, keyboard, scroll events
+- [ ] Custom event bus (~25 trigger sites) — `$(window).trigger()` → `dispatchEvent`
+- [ ] Decide: `EventNamespace` helper vs inline `addEventListener`/`removeEventListener`
+
+**Phase 4: Heavy Files** — NOT STARTED
+- [ ] `lib/sidebar.ts` (~25 calls) — events, `$('#sidebarDummyLeft')`, dimensions
+- [ ] `block/table.tsx` (~40 calls) — cell sizing, selection, events
+- [ ] `block/index.tsx` (~20 calls) — state classes, traversal, events
+- [ ] `app.tsx` (~30 calls) — global events, classes
+- [ ] `block/embed.tsx` (~15 calls) — events, dimensions
+- [ ] `dataview/view/grid.tsx` (~15 calls) — column sizing, events
+- [ ] `dataview/view/board.tsx` (~15 calls) — card layout, drag, events
+- [ ] `dataview/view/timeline.tsx` (~10 calls) — positioning, dimensions
+- [ ] `drag/provider.tsx` (~15 calls) — measurement, events, broadcast class clears
+- [ ] `selection/provider.tsx` (~8 calls) — selection rect, broadcast class clears
+- [ ] `editor/page.tsx` (~10 calls) — events, measurement
+- [ ] `block/chat/form.tsx` (~15 calls) — text editing, events, classes
+- [ ] `block/cover.tsx` (~20 calls) — image positioning, events, dimensions
+- [ ] `menu/index.tsx` (~10 calls) — positioning, events
+- [ ] `widget/index.tsx` (~10 calls) — state classes, events
+
+**Phase 5: Remaining $(ref.current) Wrapping** — NOT STARTED
+- [ ] ~359 sites across ~109 files — mechanical ref unwrapping
+
+**Phase 6: Final Cleanup** — NOT STARTED
 - [ ] Remove all remaining `import $ from 'jquery'`
 - [ ] Remove `jquery` from `package.json`
 - [ ] Remove `window.$` type declaration
-- [ ] Verify bundle size reduction (~70 KB gzipped)
+- [ ] Verify bundle size reduction
 
 ---
 
-## Remaining jQuery by Category
-
-| Category | Count | Files | Replacement |
-|----------|-------|-------|-------------|
-| `$(window).on`/`.off`/`.trigger` | **218** | 115 | `addEventListener`/`removeEventListener` or `EventNamespace` helper |
-| `.addClass`/`.removeClass`/`.toggleClass`/`.hasClass` | **550** | 138 | `U.Dom.addClass()`/`U.Dom.removeClass()`/etc. |
-| `$(ref.current)` wrapping | **370** | 113 | Use ref directly: `nodeRef.current?.querySelector()` |
-| `.width()`/`.height()`/`.offset()`/`.outerWidth()` | **190** | 58 | `clientWidth`/`getBoundingClientRect()`/`U.Dom.contentWidth()` |
-| `.find()` traversal | ~100+ | — | `querySelector`/`U.Dom.select(selector, parent)` |
-| `.css({...})` inline styles | ~80+ | — | `Object.assign(el.style, {...})` |
-| `.scrollTop()`/`.scrollLeft()` | ~11 | — | `el.scrollTop`/`el.scrollLeft` property |
-| `.animate()` | 4 | — | CSS transitions or `element.animate()` |
-| `window.$ = $` global | 1 | `app.tsx` | Remove last |
-
----
-
-## U.Dom Helper API (Implemented)
-
-Use these instead of raw `document.*` calls or jQuery:
+## U.Dom Helper API
 
 ```typescript
-// DOM queries
-U.Dom.get(id)                          // getElementById wrapper
-U.Dom.select(selector, root?)         // querySelector wrapper
-U.Dom.selectAll(selector, root?)      // querySelectorAll wrapper
+// DOM queries (use instead of raw document.*)
+U.Dom.get(id)                          // getElementById
+U.Dom.select(selector, root?)         // querySelector
+U.Dom.selectAll(selector, root?)      // querySelectorAll
 
-// Class manipulation (null-safe — no need for ?. chains)
+// Class manipulation (null-safe)
 U.Dom.addClass(el, ...names)
 U.Dom.removeClass(el, ...names)
 U.Dom.toggleClass(el, name, force?)
@@ -114,117 +151,66 @@ U.Dom.contentWidth(el)                 // content width without padding/border
 U.Dom.contentHeight(el)                // content height without padding/border
 ```
 
-### dom.ts Methods — All Native Now
-
-| Method | Was (jQuery) | Now (native) |
-|--------|-------------|--------------|
-| `getScrollContainer(isPopup)` | `$('#page.isPopup')` → JQuery | `this.select(...)` → `HTMLElement \| null` |
-| `getPageContainer(isPopup)` | `$('#page.isPopup')` → JQuery | `this.select(...)` → `HTMLElement \| null` |
-| `getPageFlexContainer(isPopup)` | `$('#pageFlex.isPopup')` → JQuery | `this.select(...)` → `HTMLElement \| null` |
-| `getScrollContainerTop(isPopup)` | `.scrollTop()` jQuery | `.scrollTop` native property |
-| `getMaxScrollHeight(isPopup)` | `container.get(0).scrollHeight` | `el.scrollHeight - el.clientHeight` |
-| `getAppContainerHeight()` | `$('#appContainer').height()` | `U.Dom.contentHeight(el)` |
-| `getWindowDimensions()` | `$(window).width()/height()` | `window.innerWidth`/`innerHeight` |
-| `triggerResizeEditor(isPopup)` | `$(window).trigger(...)` | `window.dispatchEvent(new CustomEvent(...))` |
-| `clearSelection()` | `$(activeElement).trigger('blur')` | `activeElement.blur()` |
-| `addBodyClass(prefix, v)` | `$('html').attr('class', ...)` | `document.documentElement.className = ...` |
-| `injectCss(id, css)` | `$('head').append(...)` | `document.head.appendChild(style)` |
-| `pauseMedia()` | `$('audio, video').each(...)` | `selectAll('audio, video').forEach(...)` |
-| `renderLinks(obj)` | jQuery `.find('a')`, `.click()` | `querySelectorAll('a')`, `addEventListener` |
-| `toggle(obj, delay, isOpen)` | jQuery `.css()`, `.addClass()` | `el.style`, `U.Dom.addClass()` |
-| `scrollToHeader(rootId, item, isPopup)` | jQuery `.parents()`, `.offset()` | `el.closest()`, `getBoundingClientRect()` |
-
 ---
 
-## Replacement Patterns Reference
-
-### Namespaced Events (NOT YET IMPLEMENTED)
+## Replacement Patterns
 
 ```typescript
-// Before
-$(window).on('keydown.myComponent', handler);
-$(window).off('keydown.myComponent');
+// Class manipulation
+$(node).addClass('x')                  → U.Dom.addClass(node, 'x')
+$(node).removeClass('x')               → U.Dom.removeClass(node, 'x')
+$(node).toggleClass('x', cond)         → U.Dom.toggleClass(node, 'x', cond)
+$(node).hasClass('x')                  → U.Dom.hasClass(node, 'x')
 
-// After (option A — inline, used for scroll events in #2104)
-let handler = (e) => { ... };
-window.addEventListener('keydown', handler);
-window.removeEventListener('keydown', handler);
+// DOM queries
+$('#id')                               → U.Dom.get('id')
+$('.selector')                         → U.Dom.select('.selector')
+$(parent).find('.child')               → U.Dom.select('.child', parent)
 
-// After (option B — EventNamespace helper, proposed)
-events.on(window, 'keydown', 'myComponent', handler);
-events.off(window, 'myComponent');
-```
+// Dimensions
+$(el).width()                          → U.Dom.contentWidth(el)
+$(el).outerWidth()                     → el.offsetWidth
+$(el).offset()                         → el.getBoundingClientRect()
 
-### Class Manipulation
+// Inline styles
+$(el).css('width', px)                 → el.style.width = `${px}px`
+$(el).css({ left, top })               → Object.assign(el.style, { left: `${left}px`, ... })
 
-```typescript
-// Before                                  // After
-$(node).addClass('active');                U.Dom.addClass(node, 'active');
-$(node).removeClass('active');             U.Dom.removeClass(node, 'active');
-$(node).hasClass('active');                U.Dom.hasClass(node, 'active');
-$(node).toggleClass('active', cond);       U.Dom.toggleClass(node, 'active', cond);
-```
+// Scroll
+$(el).scrollTop()                      → el.scrollTop
+$(el).scrollTop(100)                   → el.scrollTop = 100
 
-### Dimensions & Position
+// Events
+$(window).on('keydown.ns', handler)    → window.addEventListener('keydown', handler)
+$(window).off('keydown.ns')            → window.removeEventListener('keydown', handler)
+$(window).trigger('myEvent')           → window.dispatchEvent(new CustomEvent('myEvent'))
 
-```typescript
-// Before                                  // After
-$(el).width();                             U.Dom.contentWidth(el);    // exact match
-$(el).outerWidth();                        el.offsetWidth;
-$(el).offset();                            el.getBoundingClientRect();
-```
+// Ref unwrapping
+$(nodeRef.current).find('.x')          → nodeRef.current?.querySelector('.x')
+$(nodeRef.current).addClass('x')       → U.Dom.addClass(nodeRef.current, 'x')
 
-### Inline Styles
-
-```typescript
-// Before                                  // After
-$(el).css('width', px);                    el.style.width = `${px}px`;
-$(el).css({ left, top, width });           Object.assign(el.style, { left: `${left}px`, ... });
-```
-
-### Scroll Position
-
-```typescript
-// Before                                  // After
-$(el).scrollTop();                         el.scrollTop;
-$(el).scrollTop(100);                      el.scrollTop = 100;
-```
-
-### Ref Unwrapping
-
-```typescript
-// Before                                  // After
-$(nodeRef.current).find('.child');         nodeRef.current?.querySelector('.child');
-$(nodeRef.current).addClass('x');          U.Dom.addClass(nodeRef.current, 'x');
-$(nodeRef.current).css({ width: px });     nodeRef.current.style.width = `${px}px`;
-```
-
-### Custom Events
-
-```typescript
-// Before                                  // After
-$(window).trigger('resize.editor');        window.dispatchEvent(new CustomEvent('resize.editor'));
-$(window).trigger('myEvent', data);        window.dispatchEvent(new CustomEvent('myEvent', { detail: data }));
+// Tooltip/preview element
+element: $(e.currentTarget)            → element: e.currentTarget as HTMLElement
+element: $(nodeRef.current)            → element: nodeRef.current
 ```
 
 ---
 
 ## Migration Checklist Per File
 
-- [ ] List all `$(` calls in the file
-- [ ] Replace `$('#id')` → `U.Dom.get(...)` or `U.Dom.select(...)`
-- [ ] Replace `.addClass`/`.removeClass`/`.toggleClass`/`.hasClass` → `U.Dom.addClass`/etc.
+- [ ] List all `$(` calls
+- [ ] Replace `$('#id')` → `U.Dom.get(...)` / `U.Dom.select(...)`
+- [ ] Replace `.addClass`/`.removeClass`/`.toggleClass`/`.hasClass` → `U.Dom.*`
 - [ ] Replace `.css(prop, value)` → `el.style.prop = value`
 - [ ] Replace `.width()`/`.height()` → `U.Dom.contentWidth()`/`clientWidth`/`getBoundingClientRect()`
-- [ ] Replace `$(window).on/off` → `addEventListener`/`removeEventListener` with stored handler ref
+- [ ] Replace `$(window).on/off` → `addEventListener`/`removeEventListener` with stored handler
 - [ ] Replace `$(ref.current)` → use ref directly
-- [ ] Replace `.find(selector)` → `U.Dom.select(selector, parent)` or `parent.querySelector()`
+- [ ] Replace `.find(selector)` → `U.Dom.select(selector, parent)`
 - [ ] Replace `.scrollTop()` → `el.scrollTop` property
 - [ ] Never use raw `document.getElementById`/`querySelector` — use `U.Dom.*`
 - [ ] Run `bun run typecheck` and `bun run lint`
-- [ ] Manually test the interaction (resize, drag, menu, etc.)
+- [ ] Manually test the interaction
 - [ ] Remove `import $ from 'jquery'` if no `$(` calls remain
-- [ ] Verify no runtime errors in dev console
 
 ---
 
@@ -232,8 +218,7 @@ $(window).trigger('myEvent', data);        window.dispatchEvent(new CustomEvent(
 
 | Risk | Mitigation |
 |------|------------|
-| Drag/resize regression | Test each heavy file individually; keep jQuery until verified |
-| `.width()` vs native width | jQuery `.width()` = content only; `clientWidth` includes padding. Use `U.Dom.contentWidth()` for pixel math |
+| Drag/resize regression | Test each heavy file individually |
+| `.width()` vs native width | Use `U.Dom.contentWidth()` for pixel math (exact jQuery match) |
 | Layout thrashing | Batch DOM reads before writes; use `requestAnimationFrame` |
-| `window.$` bypasses linting | 38 files use global `$` — remove `window.$ = $` in Phase 6 |
-| jQuery `.trigger()` data convention | Custom data moves from 2nd arg to `event.detail` — verify listeners |
+| jQuery `.trigger()` data convention | Custom data moves to `event.detail` — verify listeners |

--- a/extension/entry.tsx
+++ b/extension/entry.tsx
@@ -18,7 +18,6 @@ declare global {
 	}
 };
 
-window.$ = $;
 window.isExtension = true;
 window.Electron = {
 	currentWindow: () => ({}),

--- a/src/ts/app.tsx
+++ b/src/ts/app.tsx
@@ -51,8 +51,6 @@ declare global {
 	}
 };
 
-window.$ = $;
-
 if (!isPackaged) {
 	window.Anytype = {
 		Lib: {

--- a/src/ts/component/block/bookmark.tsx
+++ b/src/ts/component/block/bookmark.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useEffect, useRef, MouseEvent } from 'react';
-import $ from 'jquery';
 import raf from 'raf';
 import { observer } from 'mobx-react';
 import { InputWithFile, ObjectName, ObjectDescription, Loader, Error, Icon } from 'Component';
@@ -95,8 +94,10 @@ const BlockBookmark = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, 
 	
 	const resize = () => {
 		window.setTimeout(() => {
-			const inner = $(innerRef.current);
-			inner.toggleClass('isVertical', inner.width() <= getWrapperWidth() / 2);
+			const inner = innerRef.current;
+			if (inner) {
+				U.Dom.toggleClass(inner, 'isVertical', inner.offsetWidth <= getWrapperWidth() / 2);
+			};
 		}, 0);
 	};
 

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -81,12 +81,19 @@ const BlockChat = observer(forwardRef<RefProps, I.BlockComponent>((props, ref) =
 	const messages = S.Chat.getList(subId);
 	const analyticsChatId = getAnalyticsChatId();
 
+	const scrollHandlerRef = useRef<((e: Event) => void) | null>(null);
+
 	const unbind = () => {
 		const events = [ 'messageAdd', 'messageUpdate', 'reactionUpdate', 'focus' ];
 		const ns = block.id + namespace;
 
 		$(window).off(events.map(it => `${it}.${ns}`).join(' '));
-		U.Dom.getScrollContainer(isPopup).off(`scroll.${ns}`);
+
+		const container = U.Dom.getScrollContainer(isPopup);
+		if (container && scrollHandlerRef.current) {
+			container.removeEventListener('scroll', scrollHandlerRef.current);
+			scrollHandlerRef.current = null;
+		};
 	};
 
 	const rebind = () => {
@@ -100,7 +107,11 @@ const BlockChat = observer(forwardRef<RefProps, I.BlockComponent>((props, ref) =
 		win.on(`reactionUpdate.${ns}`, () => scrollToBottomCheck());
 		win.on(`focus.${ns}`, () => readScrolledMessages());
 
-		U.Dom.getScrollContainer(isPopup).on(`scroll.${ns}`, e => onScroll(e));
+		const container = U.Dom.getScrollContainer(isPopup);
+		if (container) {
+			scrollHandlerRef.current = (e: Event) => onScroll(e);
+			container.addEventListener('scroll', scrollHandlerRef.current);
+		};
 	};
 
 	const loadDepsAndReplies = (list: I.ChatMessage[], callBack?: () => void) => {
@@ -587,7 +598,7 @@ const BlockChat = observer(forwardRef<RefProps, I.BlockComponent>((props, ref) =
 		const dates = node.find('.sectionDate');
 		const offset = J.Size.header + 8;
 		const container = U.Dom.getScrollContainer(isPopup);
-		const top = container.offset().top;
+		const top = container?.getBoundingClientRect().top ?? 0;
 
 		raf.cancel(frameRef.current);
 		frameRef.current = raf(() => {
@@ -620,7 +631,7 @@ const BlockChat = observer(forwardRef<RefProps, I.BlockComponent>((props, ref) =
 	const onScroll = (e: any) => {
 		const subId = getSubId();
 		const container = U.Dom.getScrollContainer(isPopup);
-		const st = Math.ceil(container.scrollTop());
+		const st = Math.ceil(container?.scrollTop ?? 0);
 		const max = U.Dom.getMaxScrollHeight(isPopup);
 		const list = getMessagesInViewport();
 		const state = S.Chat.getState(subId);
@@ -745,7 +756,7 @@ const BlockChat = observer(forwardRef<RefProps, I.BlockComponent>((props, ref) =
 		const messages = getMessages();
 		const container = U.Dom.getScrollContainer(isPopup);
 		const formHeight = Number($(formRef.current?.getNode()).outerHeight()) || 0;
-		const ch = container.outerHeight();
+		const ch = container?.offsetHeight ?? 0;
 		const max = ch - formHeight;
 		const ret = [];
 
@@ -852,8 +863,12 @@ const BlockChat = observer(forwardRef<RefProps, I.BlockComponent>((props, ref) =
 
 		raf(() => {
 			const container = U.Dom.getScrollContainer(isPopup);
+			if (!container) {
+				return;
+			};
+
 			const top = getMessageScrollPosition(id);
-			const y = Math.max(0, top - container.height() / 2 - J.Size.header);
+			const y = Math.max(0, top - (container.clientHeight / 2) - J.Size.header);
 
 			setIsBottom(false);
 			setAutoLoadDisabled(true);
@@ -869,9 +884,10 @@ const BlockChat = observer(forwardRef<RefProps, I.BlockComponent>((props, ref) =
 			};
 
 			if (animate) {
-				container.stop(true, true).animate({ scrollTop: y }, 300, cb);
+				container.scrollTo({ top: y, behavior: 'smooth' });
+				window.setTimeout(cb, 300);
 			} else {
-				container.scrollTop(y);
+				container.scrollTop = y;
 				cb();
 			};
 		});
@@ -901,11 +917,14 @@ const BlockChat = observer(forwardRef<RefProps, I.BlockComponent>((props, ref) =
 
 			setAutoLoadDisabled(true);
 
-			if (animate) {
-				container.stop(true, true).animate({ scrollTop: y }, 300, cb);
-			} else {
-				container.scrollTop(y);
-				cb();
+			if (container) {
+				if (animate) {
+					container.scrollTo({ top: y, behavior: 'smooth' });
+					window.setTimeout(cb, 300);
+				} else {
+					container.scrollTop = y;
+					cb();
+				};
 			};
 		});
 	};
@@ -930,7 +949,7 @@ const BlockChat = observer(forwardRef<RefProps, I.BlockComponent>((props, ref) =
 			};
 
 			const container = U.Dom.getScrollContainer(isPopup);
-			const threshold = container.outerHeight() / 2;
+			const threshold = (container?.offsetHeight ?? 0) / 2;
 
 			if (getMessageScrollOffset(id) < threshold) {
 				onScrollToBottomClick();
@@ -1110,11 +1129,18 @@ const BlockChat = observer(forwardRef<RefProps, I.BlockComponent>((props, ref) =
 		renderDates();
 
 		const container = U.Dom.getScrollContainer(isPopup);
-		const ns = block.id + namespace;
 
-		container.off(`scroll.${ns}`);
+		if (container && scrollHandlerRef.current) {
+			container.removeEventListener('scroll', scrollHandlerRef.current);
+		};
+
 		window.clearTimeout(timeoutResize.current);
-		timeoutResize.current = window.setTimeout(() => container.on(`scroll.${ns}`, e => onScroll(e)), 50);
+		timeoutResize.current = window.setTimeout(() => {
+			if (container) {
+				scrollHandlerRef.current = (e: Event) => onScroll(e);
+				container.addEventListener('scroll', scrollHandlerRef.current);
+			};
+		}, 50);
 	};
 
 	const setLoaded = (v: boolean) => {

--- a/src/ts/component/block/chat/attachment/index.tsx
+++ b/src/ts/component/block/chat/attachment/index.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, useRef, useImperativeHandle } from 'react';
 import { observer } from 'mobx-react';
 import { IconObject, Icon, ObjectName, ObjectDescription, ObjectType, MediaVideo, MediaAudio } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 interface Props {
 	object: any;

--- a/src/ts/component/block/chat/form.tsx
+++ b/src/ts/component/block/chat/form.tsx
@@ -686,7 +686,7 @@ const ChatForm = observer(forwardRef<RefProps, Props>((props, ref) => {
 		e.stopPropagation();
 
 		window.clearTimeout(timeoutDrag.current);
-		$(nodeRef.current).addClass('isDraggingOver').css({ height: U.Dom.getScrollContainer(isPopup).height() });
+		$(nodeRef.current).addClass('isDraggingOver').css({ height: U.Dom.getScrollContainer(isPopup)?.clientHeight ?? 0 });
 	};
 	
 	const onDragLeave = (e: any) => {

--- a/src/ts/component/block/chat/message/index.tsx
+++ b/src/ts/component/block/chat/message/index.tsx
@@ -32,7 +32,7 @@ const ChatMessage = observer(forwardRef<ChatMessageRefProps, I.ChatMessageCompon
 
 	useEffect(() => {
 		const resizeObserver = new ResizeObserver((entries) => {
-			const width = entries[0]?.target.offsetWidth ?? 0;
+			const width = (entries[0]?.target as HTMLElement)?.offsetWidth ?? 0;
 
 			raf(() => {
 				if (!nodeRef.current) {

--- a/src/ts/component/block/chat/message/reaction.tsx
+++ b/src/ts/component/block/chat/message/reaction.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, memo } from 'react';
 import { observer } from 'mobx-react';
 import { IconObject } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 interface Props extends I.ChatMessageReaction, I.ChatMessageComponent {
 	onSelect: (icon: string) => void;

--- a/src/ts/component/block/chat/message/reaction.tsx
+++ b/src/ts/component/block/chat/message/reaction.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, memo } from 'react';
 import { observer } from 'mobx-react';
 import { IconObject } from 'Component';
 import * as I from 'Interface';
-import $ from 'jquery';
+
 
 interface Props extends I.ChatMessageReaction, I.ChatMessageComponent {
 	onSelect: (icon: string) => void;
@@ -31,7 +31,7 @@ const ChatMessageReaction = observer(forwardRef<{}, Props>((props, ref) => {
 		<div 
 			className={cn.join(' ')}
 			onClick={() => onSelect(icon)}
-			onMouseEnter={e => Preview.tooltipShow({ text: tooltip, element: $(e.currentTarget) })}
+			onMouseEnter={e => Preview.tooltipShow({ text: tooltip, element: e.currentTarget as HTMLElement })}
 			onMouseLeave={() => Preview.tooltipHide(false)}
 		>
 			<div className="value">

--- a/src/ts/component/block/dataview.tsx
+++ b/src/ts/component/block/dataview.tsx
@@ -1670,10 +1670,10 @@ const BlockDataview = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 		const container = U.Dom.getScrollContainer(isPopup);
 		const hoverArea = blockNode.find('.hoverArea');
 
-		if (hoverArea.length && container.length) {
+		if (hoverArea.length && container) {
 			const rect = hoverArea.get(0).getBoundingClientRect();
 			const top = rect.bottom;
-			const containerBottom = container.get(0).getBoundingClientRect().bottom;
+			const containerBottom = container.getBoundingClientRect().bottom;
 			const height = containerBottom - top;
 
 			blockNode.find('.dragOverlay').css({ height });

--- a/src/ts/component/block/dataview/controls.tsx
+++ b/src/ts/component/block/dataview/controls.tsx
@@ -364,6 +364,8 @@ const Controls = observer(forwardRef<ControlsRefProps, Props>((props, ref) => {
 		keyboard.disableSelection(false);
 	};
 
+	const filterMouseDownHandler = useRef<((e: any) => void) | null>(null);
+
 	const onFilterShow = () => {
 		if (!filterRef.current) {
 			return;
@@ -379,14 +381,20 @@ const Controls = observer(forwardRef<ControlsRefProps, Props>((props, ref) => {
 			filterRef.current?.focus();
 		};
 
-		container.off('mousedown.filter').on('mousedown.filter', (e: any) => { 
+		if (filterMouseDownHandler.current && container) {
+			container.removeEventListener('mousedown', filterMouseDownHandler.current);
+		};
+
+		filterMouseDownHandler.current = (e: any) => {
 			const value = filterRef.current.getValue();
 
 			if (!value && !$(e.target).parents(`.filter`).length) {
 				onFilterHide();
-				container.off('mousedown.filter');
+				container?.removeEventListener('mousedown', filterMouseDownHandler.current);
 			};
-		});
+		};
+
+		container?.addEventListener('mousedown', filterMouseDownHandler.current);
 
 		win.off('keydown.filter').on('keydown.filter', (e: any) => {
 			e.stopPropagation();
@@ -521,7 +529,9 @@ const Controls = observer(forwardRef<ControlsRefProps, Props>((props, ref) => {
 			const container = U.Dom.getPageFlexContainer(isPopup);
 			const win = $(window);
 
-			container.off('mousedown.filter');
+			if (filterMouseDownHandler.current && container) {
+				container.removeEventListener('mousedown', filterMouseDownHandler.current);
+			};
 			win.off('keydown.filter');
 		};
 

--- a/src/ts/component/block/dataview/filters/rule.tsx
+++ b/src/ts/component/block/dataview/filters/rule.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useRef, useEffect } from 'react';
-import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { Icon, Select, Input, Label, Tag } from 'Component';
 import ItemObject from 'Component/cell/item/object';
@@ -256,7 +255,7 @@ const DataviewFilterRule = observer(forwardRef<{}, Props>((props, ref) => {
 									<span
 										key={item.id}
 										id={tooltipId}
-										onMouseEnter={() => Preview.tooltipShow({ text: item.name, element: $(`#${tooltipId}`) })}
+										onMouseEnter={() => Preview.tooltipShow({ text: item.name, element: U.Dom.get(tooltipId) })}
 										onMouseLeave={() => Preview.tooltipHide(false)}
 									>
 										{el}
@@ -270,7 +269,7 @@ const DataviewFilterRule = observer(forwardRef<{}, Props>((props, ref) => {
 							<div
 								id={restId}
 								className="rest"
-								onMouseEnter={() => Preview.tooltipShow({ text: rest.map(it => it.name).join(', '), element: $(`#${restId}`) })}
+								onMouseEnter={() => Preview.tooltipShow({ text: rest.map(it => it.name).join(', '), element: U.Dom.get(restId) })}
 								onMouseLeave={() => Preview.tooltipHide(false)}
 							>
 								+{rest.length}
@@ -307,7 +306,7 @@ const DataviewFilterRule = observer(forwardRef<{}, Props>((props, ref) => {
 							<div
 								id={restId}
 								className="rest"
-								onMouseEnter={() => Preview.tooltipShow({ text: rest.map(it => it.name).join(', '), element: $(`#${restId}`) })}
+								onMouseEnter={() => Preview.tooltipShow({ text: rest.map(it => it.name).join(', '), element: U.Dom.get(restId) })}
 								onMouseLeave={() => Preview.tooltipHide(false)}
 							>
 								+{rest.length}

--- a/src/ts/component/block/dataview/head.tsx
+++ b/src/ts/component/block/dataview/head.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, useEffect, useRef, useState } from 'react';
 import { observer } from 'mobx-react';
 import { Icon, Editable } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const BlockDataviewHead = observer(forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 

--- a/src/ts/component/block/dataview/view/board.tsx
+++ b/src/ts/component/block/dataview/view/board.tsx
@@ -55,13 +55,16 @@ const ViewBoard = observer(forwardRef<I.ViewRef, I.ViewComponent>((props, ref) =
 		};
 	});
 
+	const scrollViewHandlerRef = useRef<(() => void) | null>(null);
+
 	const rebind = () => {
 		const scroll = $(scrollRef.current);
 
 		unbind();
 
 		scroll.on('scroll', () => onScrollHorizontal());
-		U.Dom.getPageContainer(isPopup).on('scroll.board', onScrollView);
+		scrollViewHandlerRef.current = onScrollView;
+		U.Dom.getPageContainer(isPopup)?.addEventListener('scroll', scrollViewHandlerRef.current);
 
 		if (!isInline) {
 			stickyScrollRef.current?.bind(scroll, isSyncingScroll.current);
@@ -73,7 +76,10 @@ const ViewBoard = observer(forwardRef<I.ViewRef, I.ViewComponent>((props, ref) =
 
 		scroll.off('scroll');
 		stickyScrollRef.current?.unbind();
-		U.Dom.getPageContainer(isPopup).off('scroll.board');
+		if (scrollViewHandlerRef.current) {
+			U.Dom.getPageContainer(isPopup)?.removeEventListener('scroll', scrollViewHandlerRef.current);
+			scrollViewHandlerRef.current = null;
+		};
 	};
 
 	const onScrollHorizontal = () => {
@@ -556,7 +562,7 @@ const ViewBoard = observer(forwardRef<I.ViewRef, I.ViewComponent>((props, ref) =
 		const scroll = $(scrollRef.current);
 		const view = node.find('.viewContent');
 		const container = U.Dom.getPageContainer(isPopup);
-		const cw = container.width();
+		const cw = container?.clientWidth ?? 0;
 		const size = J.Size.dataview.board;
 		const groups = getGroups(false);
 		const width = groups.length * (size.card + size.margin) - size.margin;

--- a/src/ts/component/block/dataview/view/board/card.tsx
+++ b/src/ts/component/block/dataview/view/board/card.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from 'motion/react';
 import { observer } from 'mobx-react';
 import { Cell, SelectionTarget, ObjectCover, Icon } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 interface Props extends I.ViewComponent {
 	id: string;

--- a/src/ts/component/block/dataview/view/calendar.tsx
+++ b/src/ts/component/block/dataview/view/calendar.tsx
@@ -3,6 +3,7 @@ import { observer } from 'mobx-react';
 import { Select, Icon } from 'Component';
 import Item from './calendar/item';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const PADDING = 16;
 

--- a/src/ts/component/block/dataview/view/calendar.tsx
+++ b/src/ts/component/block/dataview/view/calendar.tsx
@@ -106,7 +106,7 @@ const ViewCalendar = observer(forwardRef<I.ViewRef, I.ViewComponent>((props, ref
 		const node = $(nodeRef.current);
 		const wrap = node.find('.wrap');
 		const container = U.Dom.getPageContainer(isPopup);
-		const mw = container.width() - PADDING * 2;
+		const mw = (container?.clientWidth ?? 0) - PADDING * 2;
 		const day = node.find('.day').first();
 		const menu = S.Menu.get('calendarDay');
 

--- a/src/ts/component/block/dataview/view/calendar/item.tsx
+++ b/src/ts/component/block/dataview/view/calendar/item.tsx
@@ -99,11 +99,13 @@ const CalendarItem = observer(forwardRef<Ref, Props>((props, ref) => {
 	};
 
 	const onMouseEnter = (e: any, item: any) => {
-		const node = $(nodeRef.current);
-		const element = node.find(`#record-${U.Common.esc(item.id)}`);
+		const node = nodeRef.current;
+		const element = node?.querySelector(`#record-${U.Common.esc(item.id)}`) as HTMLElement;
 		const name = U.String.shorten(item.name, 50);
 
-		Preview.tooltipShow({ text: name, element });
+		if (element) {
+			Preview.tooltipShow({ text: name, element });
+		};
 	};
 
 	const onMouseLeave = () => {

--- a/src/ts/component/block/dataview/view/calendar/item.tsx
+++ b/src/ts/component/block/dataview/view/calendar/item.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, useRef, useEffect, useImperativeHandle } from 'react
 import { observer } from 'mobx-react';
 import { IconObject, ObjectName, Icon, DropTarget } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 interface Props extends I.ViewComponent {
 	d: number;

--- a/src/ts/component/block/dataview/view/gallery.tsx
+++ b/src/ts/component/block/dataview/view/gallery.tsx
@@ -276,7 +276,7 @@ const ViewGallery = observer(forwardRef<I.ViewRef, I.ViewComponent>((props, ref)
 
 		content = (
 			<WindowScroller
-				scrollElement={U.Dom.getScrollContainer(isPopup).get(0)}
+				scrollElement={U.Dom.getScrollContainer(isPopup)}
 				onScroll={onScroll}
 				scrollTop={topRef.current}
 			>

--- a/src/ts/component/block/dataview/view/graph.tsx
+++ b/src/ts/component/block/dataview/view/graph.tsx
@@ -47,8 +47,8 @@ const ViewGraph = observer(forwardRef<I.ViewRef, I.ViewComponent>((props, ref) =
 			node.css({ width: 0, height: 0, marginLeft: 0 });
 
 			const container = U.Dom.getPageContainer(isPopup);
-			const cw = container.width();
-			const ch = container.height();
+			const cw = container?.clientWidth ?? 0;
+			const ch = container?.clientHeight ?? 0;
 			const mw = cw - PADDING * 2;
 			const margin = (cw - mw) / 2;
 			const { top } = node.offset();

--- a/src/ts/component/block/dataview/view/grid.tsx
+++ b/src/ts/component/block/dataview/view/grid.tsx
@@ -63,6 +63,8 @@ const ViewGrid = observer(forwardRef<I.ViewRef, I.ViewComponent>((props, ref) =>
 		return null;
 	};
 
+	const scrollVerticalHandlerRef = useRef<(() => void) | null>(null);
+
 	const rebind = () => {
 		const scroll = $(scrollRef.current);
 		const container = U.Dom.getScrollContainer(isPopup);
@@ -70,7 +72,8 @@ const ViewGrid = observer(forwardRef<I.ViewRef, I.ViewComponent>((props, ref) =>
 		unbind();
 
 		scroll.on('scroll', () => onScrollHorizontal());
-		container.off(`scroll.${block.id}`).on(`scroll.${block.id}`, () => raf(() => onScrollVertical()));
+		scrollVerticalHandlerRef.current = () => raf(() => onScrollVertical());
+		container?.addEventListener('scroll', scrollVerticalHandlerRef.current);
 
 		if (!isInline) {
 			stickyScrollbarRef.current?.bind(scroll, isSyncingScroll.current);
@@ -82,7 +85,10 @@ const ViewGrid = observer(forwardRef<I.ViewRef, I.ViewComponent>((props, ref) =>
 		const container = U.Dom.getScrollContainer(isPopup);
 
 		scroll.off('scroll');
-		container.off(`scroll.${block.id}`);
+		if (scrollVerticalHandlerRef.current) {
+			container?.removeEventListener('scroll', scrollVerticalHandlerRef.current);
+			scrollVerticalHandlerRef.current = null;
+		};
 		stickyScrollbarRef.current?.unbind();
 	};
 
@@ -348,13 +354,13 @@ const ViewGrid = observer(forwardRef<I.ViewRef, I.ViewComponent>((props, ref) =>
 		const wrap = $(scrollWrapRef.current);
 		const container = U.Dom.getPageContainer(isPopup);
 		const width = getVisibleRelations().reduce((res: number, current: any) => res + current.width, J.Size.blockMenu);
-		const cw = container.width();
-		const ch = container.height();
+		const cw = container?.clientWidth ?? 0;
+		const ch = container?.clientHeight ?? 0;
 
 		if (isInline) {
 			if (parent) {
 				if (parent.isPage() || parent.isLayoutDiv()) {
-					const wrapper = container.find('#editorWrapper');
+					const wrapper = $(container).find('#editorWrapper');
 					const ww = wrapper.width();
 					const vw = Math.max(ww, width) + (width > ww ? PADDING : 0);
 					const margin = Math.max(0, (cw - ww) / 2);
@@ -462,7 +468,7 @@ const ViewGrid = observer(forwardRef<I.ViewRef, I.ViewComponent>((props, ref) =>
 				threshold={10}
 			>
 				{({ onRowsRendered }) => (
-					<WindowScroller scrollElement={U.Dom.getScrollContainer(isPopup).get(0)}>
+					<WindowScroller scrollElement={U.Dom.getScrollContainer(isPopup)}>
 						{({ height, isScrolling, registerChild, scrollTop }) => (
 							<AutoSizer disableHeight={true}>
 								{({ width }) => (

--- a/src/ts/component/block/dataview/view/grid/foot/cell.tsx
+++ b/src/ts/component/block/dataview/view/grid/foot/cell.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, useRef, useState, useImperativeHandle, useEffect } from 'react';
 import { observer } from 'mobx-react';
 import * as I from 'Interface';
-import $ from 'jquery';
+
 
 interface Props extends I.ViewComponent, I.ViewRelation {
 	rootId?: string;
@@ -155,7 +155,7 @@ const FootCell = observer(forwardRef<Ref, Props>((props, ref) => {
 
 		const t = Preview.tooltipCaption(name, result);
 		if (t) {
-			Preview.tooltipShow({ text: t, element: $(nodeRef.current), typeY: I.MenuDirection.Top });
+			Preview.tooltipShow({ text: t, element: nodeRef.current, typeY: I.MenuDirection.Top });
 		};
 	};
 

--- a/src/ts/component/block/dataview/view/grid/foot/cell.tsx
+++ b/src/ts/component/block/dataview/view/grid/foot/cell.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, useRef, useState, useImperativeHandle, useEffect } from 'react';
 import { observer } from 'mobx-react';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 interface Props extends I.ViewComponent, I.ViewRelation {
 	rootId?: string;

--- a/src/ts/component/block/dataview/view/grid/foot/cell.tsx
+++ b/src/ts/component/block/dataview/view/grid/foot/cell.tsx
@@ -144,9 +144,9 @@ const FootCell = observer(forwardRef<Ref, Props>((props, ref) => {
 			return;
 		};
 
-		const node = $(nodeRef.current);
+		const node = nodeRef.current;
 
-		node.addClass('hover');
+		U.Dom.addClass(node, 'hover');
 
 		if ((result === null) || S.Menu.isOpen()) {
 			return;
@@ -154,12 +154,12 @@ const FootCell = observer(forwardRef<Ref, Props>((props, ref) => {
 
 		const t = Preview.tooltipCaption(name, result);
 		if (t) {
-			Preview.tooltipShow({ text: t, element: node, typeY: I.MenuDirection.Top });
+			Preview.tooltipShow({ text: t, element: $(nodeRef.current), typeY: I.MenuDirection.Top });
 		};
 	};
 
 	const onMouseLeave = () => {
-		$(nodeRef.current).removeClass('hover');
+		U.Dom.removeClass(nodeRef.current, 'hover');
 		Preview.tooltipHide();
 	};
 

--- a/src/ts/component/block/dataview/view/grid/head/cell.tsx
+++ b/src/ts/component/block/dataview/view/grid/head/cell.tsx
@@ -4,6 +4,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Icon, ObjectName } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 interface Props extends I.ViewComponent, I.ViewRelation {
 	rootId: string;

--- a/src/ts/component/block/dataview/view/list.tsx
+++ b/src/ts/component/block/dataview/view/list.tsx
@@ -80,7 +80,7 @@ const ViewList = observer(forwardRef<I.ViewRef, I.ViewComponent>((props, ref) =>
 				threshold={10}
 			>
 				{({ onRowsRendered }) => (
-					<WindowScroller scrollElement={U.Dom.getScrollContainer(isPopup).get(0)}>
+					<WindowScroller scrollElement={U.Dom.getScrollContainer(isPopup)}>
 						{({ height, isScrolling, scrollTop }) => (
 							<AutoSizer disableHeight={true}>
 								{({ width }) => (

--- a/src/ts/component/block/dataview/view/timeline.tsx
+++ b/src/ts/component/block/dataview/view/timeline.tsx
@@ -43,13 +43,21 @@ const ViewTimeline = observer(forwardRef<{}, I.ViewComponent>((props, ref) => {
 		return getRecords().map(id => S.Detail.get(subId, id));
 	};
 
+	const scrollHandlerRef = useRef<((e: Event) => void) | null>(null);
+
 	const rebind = () => {
 		unbind();
-		U.Dom.getScrollContainer(isPopup).on('scroll.timeline', e => onScrollVertical(e));
+		const container = U.Dom.getScrollContainer(isPopup);
+		scrollHandlerRef.current = (e: Event) => onScrollVertical(e);
+		container?.addEventListener('scroll', scrollHandlerRef.current);
 	};
 
 	const unbind = () => {
-		U.Dom.getScrollContainer(isPopup).off('scroll.timeline');
+		const container = U.Dom.getScrollContainer(isPopup);
+		if (scrollHandlerRef.current) {
+			container?.removeEventListener('scroll', scrollHandlerRef.current);
+			scrollHandlerRef.current = null;
+		};
 	};
 
 	const getData = () => {
@@ -390,13 +398,13 @@ const ViewTimeline = observer(forwardRef<{}, I.ViewComponent>((props, ref) => {
 		const tooltips = $(tooltipRef.current);
 		const scrollContainer = U.Dom.getScrollContainer(isPopup);
 		const pageContainer = U.Dom.getPageContainer(isPopup);
-		const top = body.offset().top - J.Size.header - 14 - scrollContainer.scrollTop();
+		const top = body.offset().top - J.Size.header - 14 - (scrollContainer?.scrollTop ?? 0);
 		const left = node.offset().left;
 
 		if (!isInline) {
 			node.css({ width: 0, marginLeft: 0 });
 
-			const cw = pageContainer.width();
+			const cw = pageContainer?.clientWidth ?? 0;
 			const mw = cw - PADDING * 2;
 			const margin = (cw - mw) / 2;
 
@@ -668,7 +676,7 @@ const ViewTimeline = observer(forwardRef<{}, I.ViewComponent>((props, ref) => {
 								threshold={10}
 							>
 								{({ onRowsRendered }) => (
-									<WindowScroller scrollElement={U.Dom.getScrollContainer(isPopup).get(0)}>
+									<WindowScroller scrollElement={U.Dom.getScrollContainer(isPopup)}>
 										{({ height, isScrolling, registerChild, scrollTop }) => (
 											<AutoSizer>
 												{({ width }) => (

--- a/src/ts/component/block/embed.tsx
+++ b/src/ts/component/block/embed.tsx
@@ -120,6 +120,8 @@ const BlockEmbed = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref
 		rebind();
 	};
 
+	const scrollHandlerRef = useRef<(() => void) | null>(null);
+
 	const rebind = () => {
 		const win = $(window);
 		const node = $(nodeRef.current);
@@ -142,7 +144,7 @@ const BlockEmbed = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref
 				S.Menu.close('blockLatex');
 
 				placeholderCheck();
-				save(true, () => { 
+				save(true, () => {
 					setIsEditing(false);
 					S.Menu.close('previewLatex');
 				});
@@ -161,7 +163,8 @@ const BlockEmbed = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref
 
 		if (!U.Embed.allowAutoRender(processor)) {
 			const container = U.Dom.getScrollContainer(isPopup);
-			container.on(`scroll.${block.id}`, () => onScroll());
+			scrollHandlerRef.current = () => onScroll();
+			container?.addEventListener('scroll', scrollHandlerRef.current);
 		};
 
 		node.on('edit', e => onEdit(e));
@@ -172,7 +175,11 @@ const BlockEmbed = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref
 		const events = [ 'mousedown', 'mouseup', 'online', 'offline', 'resize' ];
 
 		$(window).off(events.map(it => `${it}.${block.id}`).join(' '));
-		container.off(`scroll.${block.id}`);
+
+		if (scrollHandlerRef.current) {
+			container?.removeEventListener('scroll', scrollHandlerRef.current);
+			scrollHandlerRef.current = null;
+		};
 	};
 
 	const onScroll = () => {
@@ -184,14 +191,15 @@ const BlockEmbed = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref
 		timeoutScrollRef.current = window.setTimeout(() => {
 			const container = U.Dom.getScrollContainer(isPopup);
 			const node = $(nodeRef.current);
-			if (!node.length) {
+			if (!node.length || !container) {
 				return;
 			};
 
-			const ch = container.height();
-			const st = container.scrollTop();
+			const ch = container.clientHeight;
+			const st = container.scrollTop;
 			const rect = U.Dom.getElementRect(node.get(0));
-			const top = rect.top - container.offset().top;
+			const containerRect = container.getBoundingClientRect();
+			const top = rect.top - containerRect.top;
 
 			if (top <= st + ch) {
 				setIsShowing(true);
@@ -953,7 +961,7 @@ const BlockEmbed = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref
 		const container = U.Dom.getScrollContainer(isPopup);
 
 		if (isFullScreen) {
-			scrollTopRef.current = container.scrollTop();
+			scrollTopRef.current = container?.scrollTop ?? 0;
 		};
 
 		const onEscape = (e: KeyboardEvent) => {
@@ -971,8 +979,8 @@ const BlockEmbed = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref
 		return () => {
 			window.removeEventListener('keydown', onEscape, true);
 
-			if (isFullScreen) {
-				container.scrollTop(scrollTopRef.current);
+			if (isFullScreen && container) {
+				container.scrollTop = scrollTopRef.current;
 			};
 		};
 	}, [ isFullScreen ]);

--- a/src/ts/component/block/featured.tsx
+++ b/src/ts/component/block/featured.tsx
@@ -46,14 +46,17 @@ const BlockFeatured = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 
 	const init = () => {
 		const items = getItems().filter(it => it.relationKey != 'description');
-		const node = $(nodeRef.current);
-		const obj = $(`#block-${U.Common.esc(block.id)}`);
+		const node = nodeRef.current;
+		const obj = U.Dom.get(`block-${U.Common.esc(block.id)}`);
 
-		obj.toggleClass('isHidden', !items.length);
+		U.Dom.toggleClass(obj, 'isHidden', !items.length);
 
 		if (node) {
-			node.find('.cell.first').removeClass('first');
-			node.find('.cell').first().addClass('first');
+			node.querySelectorAll('.cell.first').forEach(el => U.Dom.removeClass(el as HTMLElement, 'first'));
+			const firstCell = node.querySelector('.cell');
+			if (firstCell) {
+				U.Dom.addClass(firstCell as HTMLElement, 'first');
+			};
 		};
 	};
 

--- a/src/ts/component/block/featured.tsx
+++ b/src/ts/component/block/featured.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useRef, useEffect, MouseEvent } from 'react';
-import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { observable } from 'mobx';
 import { ObjectType, Cell, Block } from 'Component';
@@ -255,10 +254,12 @@ const BlockFeatured = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 	};
 
 	const onMouseEnter = (e: any, relationKey: string, text?: string) => {
-		const cell = $(`#${U.Common.esc(Relation.cellId(PREFIX, relationKey, rootId))}`);
+		const cell = U.Dom.get(U.Common.esc(Relation.cellId(PREFIX, relationKey, rootId)));
 		const relation = S.Record.getRelationByKey(relationKey);
 		const show = (text: string) => {
-			Preview.tooltipShow({ text, element: cell });
+			if (cell) {
+				Preview.tooltipShow({ text, element: cell });
+			};
 		};
 
 		if (text) {

--- a/src/ts/component/block/index.tsx
+++ b/src/ts/component/block/index.tsx
@@ -497,14 +497,14 @@ const Block = observer(forwardRef<Ref, Props>((props, ref) => {
 					return;
 				};
 
-				const item = $(e.currentTarget);
-				const url = String(item.attr('href') || '');
+				const item = e.currentTarget as HTMLElement;
+				const url = String(item.getAttribute('href') || '');
 
 				if (!url) {
 					return;
 				};
 
-				const range = String(item.attr('data-range') || '').split('-');
+				const range = String(item.getAttribute('data-range') || '').split('-');
 				const { target, spaceId, isInside } = U.Common.getLinkParamFromUrl(url);
 
 				const cb = (object) => {

--- a/src/ts/component/block/link.tsx
+++ b/src/ts/component/block/link.tsx
@@ -72,7 +72,7 @@ const BlockLink = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref)
 		};
 
 		Preview.previewShow({ 
-			element: $(nodeRef.current).find('.cardName .name'), 
+			element: nodeRef.current?.querySelector('.cardName .name') as HTMLElement,
 			object,
 			target: targetBlockId, 
 			noUnlink: true,

--- a/src/ts/component/block/media/audio.tsx
+++ b/src/ts/component/block/media/audio.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useEffect, forwardRef, useImperativeHandle } from 'react';
-import $ from 'jquery';
 import raf from 'raf';
 import { observer } from 'mobx-react';
 import { InputWithFile, Error, MediaAudio, Icon } from 'Component';
@@ -26,11 +25,11 @@ const BlockAudio = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref
 	};
 
 	const onPlay = () => {
-		$(nodeRef.current).addClass('isPlaying');
+		U.Dom.addClass(nodeRef.current, 'isPlaying');
 	};
 
 	const onPause = () => {
-		$(nodeRef.current).removeClass('isPlaying');
+		U.Dom.removeClass(nodeRef.current, 'isPlaying');
 	};
 
 	const onKeyDownHandler = (e: any) => {

--- a/src/ts/component/block/table.tsx
+++ b/src/ts/component/block/table.tsx
@@ -1358,7 +1358,7 @@ const BlockTable = observer(forwardRef<I.BlockRef, I.BlockComponent>((props, ref
 			if (parent.isPage() || parent.isLayoutDiv()) {
 				const container = U.Dom.getPageContainer(isPopup);
 
-				maxWidth = container.width() - PADDING;
+				maxWidth = (container?.clientWidth ?? 0) - PADDING;
 				wrapperWidth = getWrapperWidth() + J.Size.blockMenu;
 
 				wrap.toggleClass('withScroll', width > maxWidth);

--- a/src/ts/component/block/table/cell.tsx
+++ b/src/ts/component/block/table/cell.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef } from 'react';
 import { observer } from 'mobx-react';
 import { Icon, Block } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 interface Props extends I.BlockComponentTable {
 	rowIdx: number;

--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -1411,11 +1411,12 @@ const BlockText = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 
 				window.setTimeout(() => {
 					const pageContainer = U.Dom.getPageFlexContainer(isPopup);
+					const onMouseDown = () => {
+						pageContainer?.removeEventListener('mousedown', onMouseDown);
+						S.Menu.close('blockContext');
+					};
 
-					pageContainer.off('mousedown.context').on('mousedown.context', () => { 
-						pageContainer.off('mousedown.context');
-						S.Menu.close('blockContext'); 
-					});
+					pageContainer?.addEventListener('mousedown', onMouseDown);
 				}, S.Menu.getTimeout());
 			});
 		});

--- a/src/ts/component/cell/file.tsx
+++ b/src/ts/component/cell/file.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useState, useImperativeHandle, useEffect } from 'react';
-import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { IconObject, ObjectName } from 'Component';
 import * as I from 'Interface';
@@ -47,7 +46,7 @@ const CellFile = observer(forwardRef<I.CellRef, I.Cell>((props, ref) => {
 	};
 
 	useEffect(() => {
-		$(`#${U.Common.esc(id)}`).toggleClass('isEditing', isEditing);
+		U.Dom.toggleClass(U.Dom.get(U.Common.esc(id)), 'isEditing', isEditing);
 	}, [ isEditing ]);
 
 	useImperativeHandle(ref, () => ({

--- a/src/ts/component/cell/index.tsx
+++ b/src/ts/component/cell/index.tsx
@@ -460,7 +460,7 @@ const Cell = observer(forwardRef<I.CellRef, Props>((props, ref) => {
 	};
 
 	const onMouseEnterHandler = (e: any) => {
-		const cell = $(`#${U.Common.esc(Relation.cellId(idPrefix, relation.relationKey, record.id))}`);
+		const cell = U.Dom.get(U.Common.esc(Relation.cellId(idPrefix, relation.relationKey, record.id)));
 		const { text = '', caption = '' } = tooltipParam;
 		const t = Preview.tooltipCaption(text, caption);
 
@@ -468,7 +468,7 @@ const Cell = observer(forwardRef<I.CellRef, Props>((props, ref) => {
 			onMouseEnter(e);
 		};
 
-		if (t) {
+		if (t && cell) {
 			Preview.tooltipShow({ ...tooltipParam, text: t, element: cell });
 		};
 	};

--- a/src/ts/component/cell/text.tsx
+++ b/src/ts/component/cell/text.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useRef, useState, useEffect, useImperativeHandle } from 'react';
-import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { Input, IconObject, ChatCounter, Icon } from 'Component';
 import * as I from 'Interface';
@@ -343,8 +342,8 @@ const CellText = observer(forwardRef<I.CellRef, I.Cell>((props, ref: any) => {
 	}, []);
 
 	useEffect(() => {
-		const cell = $(`#${U.Common.esc(id)}`);
-		const card = viewType == I.ViewType.Grid ? null : $(`#record-${U.Common.esc(record.id)}`);
+		const cell = U.Dom.get(U.Common.esc(id));
+		const card = viewType == I.ViewType.Grid ? null : U.Dom.get(`record-${U.Common.esc(record.id)}`);
 
 		if (isEditing) {
 			let val = value.current;
@@ -392,16 +391,20 @@ const CellText = observer(forwardRef<I.CellRef, I.Cell>((props, ref: any) => {
 		} else {
 			setValue(Relation.formatValue(relation, record[relation.relationKey], true));
 
-			cell.find('.cellContent').css({ left: '', right: '' });
+			const cellContent = cell?.querySelector('.cellContent') as HTMLElement;
+			if (cellContent) {
+				cellContent.style.left = '';
+				cellContent.style.right = '';
+			};
 		};
 
-		cell.toggleClass('isEditing', isEditing);
-		if (card && card.length) {
-			card.toggleClass('isEditing', isEditing);
+		U.Dom.toggleClass(cell, 'isEditing', isEditing);
+		if (card) {
+			U.Dom.toggleClass(card, 'isEditing', isEditing);
 		};
 
 		if (S.Common.cellId) {
-			$(`#${U.Common.esc(S.Common.cellId)}`).addClass('isEditing');
+			U.Dom.addClass(U.Dom.get(U.Common.esc(S.Common.cellId)), 'isEditing');
 		};
 	});
 

--- a/src/ts/component/comment/section.tsx
+++ b/src/ts/component/comment/section.tsx
@@ -69,10 +69,9 @@ const CommentSection = observer((props: I.CommentSectionProps) => {
 		};
 
 		const container = U.Dom.getScrollContainer(isPopup);
-		const ns = 'commentSection';
 
-		container.on(`scroll.${ns}`, () => {
-			const st = Math.ceil(container.scrollTop());
+		const scrollHandler = () => {
+			const st = Math.ceil(container?.scrollTop ?? 0);
 			const max = U.Dom.getMaxScrollHeight(isPopup);
 
 			isBottom.current = (max - st) <= SCROLL_THRESHOLD;
@@ -80,10 +79,12 @@ const CommentSection = observer((props: I.CommentSectionProps) => {
 			setHidden(true);
 			window.clearTimeout(scrollTimerRef.current);
 			scrollTimerRef.current = window.setTimeout(() => setHidden(false), 150);
-		});
+		};
+
+		container?.addEventListener('scroll', scrollHandler);
 
 		return () => {
-			container.off(`scroll.${ns}`);
+			container?.removeEventListener('scroll', scrollHandler);
 			window.clearTimeout(scrollTimerRef.current);
 
 			if (discussionId) {
@@ -190,16 +191,15 @@ const CommentSection = observer((props: I.CommentSectionProps) => {
 			};
 
 			const container = U.Dom.getScrollContainer(isPopup);
-			if (!container.length) {
+			if (!container) {
 				return;
 			};
 
-			const containerEl = container.get(0);
 			const elRect = el.getBoundingClientRect();
-			const containerRect = containerEl.getBoundingClientRect();
-			const scrollTop = containerEl.scrollTop + (elRect.top - containerRect.top) - (containerRect.height / 3);
+			const containerRect = container.getBoundingClientRect();
+			const scrollTop = container.scrollTop + (elRect.top - containerRect.top) - (containerRect.height / 3);
 
-			containerEl.scrollTop = Math.max(0, scrollTop);
+			container.scrollTop = Math.max(0, scrollTop);
 
 			el.classList.add('isHighlighted');
 			window.setTimeout(() => el.classList.remove('isHighlighted'), HIGHLIGHT_DURATION);
@@ -429,11 +429,9 @@ const CommentSection = observer((props: I.CommentSectionProps) => {
 
 		window.setTimeout(() => {
 			const container = U.Dom.getScrollContainer(isPopup);
-			if (container.length) {
+			if (container) {
 				isBottom.current = true;
-
-				const el = container.get(0);
-				el.scrollTop = el.scrollHeight;
+				container.scrollTop = container.scrollHeight;
 			};
 		}, 0);
 	}, [ isPopup, resize ]);
@@ -605,9 +603,8 @@ const CommentSection = observer((props: I.CommentSectionProps) => {
 
 		window.setTimeout(() => {
 			const container = U.Dom.getScrollContainer(isPopup);
-			if (container.length) {
-				const el = container.get(0);
-				el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+			if (container) {
+				container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
 			};
 
 			window.setTimeout(() => formRef.current?.focus(), 300);

--- a/src/ts/component/drag/box.tsx
+++ b/src/ts/component/drag/box.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useRef, ReactNode, Children, cloneElement } from 'react';
+import $ from 'jquery';
 
 interface Props {
 	children?: ReactNode;

--- a/src/ts/component/drag/layer.tsx
+++ b/src/ts/component/drag/layer.tsx
@@ -23,11 +23,12 @@ const DragLayer = observer(forwardRef((_, ref: any) => {
 		const rect = U.Dom.getElementRect(componentNode);
 		const node = $(nodeRef.current);
 		const inner = node.find('#inner').html('');
-		const container = U.Dom.getPageFlexContainer(keyboard.isPopup());
+		const containerEl = U.Dom.getPageFlexContainer(keyboard.isPopup());
+		const container = containerEl ? $(containerEl) : $();
 		const wrap = $('<div></div>');
 
 		let width = rect.width;
-		
+
 		switch (type) {
 			case I.DropType.Block: {
 				wrap.addClass('blocks');
@@ -64,7 +65,8 @@ const DragLayer = observer(forwardRef((_, ref: any) => {
 			};
 
 			case I.DropType.Relation: {
-				const container = U.Dom.getPageFlexContainer(keyboard.isPopup());
+				const relContainerEl = U.Dom.getPageFlexContainer(keyboard.isPopup());
+				const container = relContainerEl ? $(relContainerEl) : $();
 				const add = $('<div class="sidebarPage pageObjectRelation"></div>');
 
 				wrap.addClass('sidebar').append(add);

--- a/src/ts/component/drag/provider.tsx
+++ b/src/ts/component/drag/provider.tsx
@@ -281,7 +281,8 @@ const DragProvider = observer(forwardRef<I.DragProviderRefProps, Props>((props, 
 		const selection = S.Common.getRef('selectionProvider');
 		const win = $(window);
 		const node = $(nodeRef.current);
-		const container = U.Dom.getScrollContainer(isPopup);
+		const containerEl = U.Dom.getScrollContainer(isPopup);
+		const container = containerEl ? $(containerEl) : $();
 		const sidebar = $(S.Common.getRef('sidebarLeft')?.getNode());
 		const layer = $('#dragLayer');
 		const body = $('body');
@@ -306,7 +307,7 @@ const DragProvider = observer(forwardRef<I.DragProviderRefProps, Props>((props, 
 
 		node.addClass('isDragging');
 		body.addClass('isDragging');
-		
+
 		keyboard.setDragging(true);
 		keyboard.disableSelection(true);
 		Preview.hideAll();
@@ -495,7 +496,8 @@ const DragProvider = observer(forwardRef<I.DragProviderRefProps, Props>((props, 
 
 		const isPopup = keyboard.isPopup();
 		const node = $(nodeRef.current);
-		const container = U.Dom.getScrollContainer(isPopup);
+		const endContainerEl = U.Dom.getScrollContainer(isPopup);
+		const endContainer = endContainerEl ? $(endContainerEl) : $();
 		const sidebar = $(S.Common.getRef('sidebarLeft')?.getNode());
 		const body = $('body');
 
@@ -510,7 +512,7 @@ const DragProvider = observer(forwardRef<I.DragProviderRefProps, Props>((props, 
 		node.removeClass('isDragging');
 		body.removeClass('isDragging');
 
-		container.off('scroll.drag');
+		endContainer.off('scroll.drag');
 		sidebar.off('scroll.drag');
 
 		$('.isDragging').removeClass('isDragging');

--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -41,6 +41,7 @@ const EditorPage = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 	const container = useRef<any>(null);
 	const scrollTopRef = useRef(0);
 	const isEnterProcessing = useRef(false);
+	const scrollHandlerRef = useRef<(() => void) | null>(null);
 
 	useEffect(() => {
 		open();
@@ -76,7 +77,10 @@ const EditorPage = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 		rebind();
 		resizePage(() => {
 			if (scrollTopRef.current) {
-				U.Dom.getScrollContainer(isPopup).scrollTop(scrollTopRef.current);
+				const sc = U.Dom.getScrollContainer(isPopup);
+				if (sc) {
+					sc.scrollTop = scrollTopRef.current;
+				};
 				scrollTopRef.current = 0;
 			};
 		});
@@ -223,12 +227,17 @@ const EditorPage = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 	
 	const unbind = () => {
 		const ns = `editor${U.Dom.getEventNamespace(isPopup)}`;
-		const container = U.Dom.getScrollContainer(isPopup);
 		const events = [ 'keydown', 'mousemove', 'paste', 'resize', 'focus' ];
 		const selection = S.Common.getRef('selectionProvider');
 
 		$(window).off(events.map(it => `${it}.${ns}`).join(' '));
-		container.off(`scroll.${ns}`);
+
+		const sc = U.Dom.getScrollContainer(isPopup);
+		if (sc && scrollHandlerRef.current) {
+			sc.removeEventListener('scroll', scrollHandlerRef.current);
+			scrollHandlerRef.current = null;
+		};
+
 		Renderer.remove(`commandEditor`);
 		selection?.setContextMenuHandler(null);
 	};
@@ -237,7 +246,7 @@ const EditorPage = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 		const selection = S.Common.getRef('selectionProvider');
 		const win = $(window);
 		const ns = `editor${U.Dom.getEventNamespace(isPopup)}`;
-		const container = U.Dom.getScrollContainer(isPopup);
+		const sc = U.Dom.getScrollContainer(isPopup);
 		const readonly = isReadonly();
 
 		unbind();
@@ -265,12 +274,19 @@ const EditorPage = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 			};
 
 			if (top) {
-				window.setTimeout(() => container.scrollTop(top), 10);
+				const c = U.Dom.getScrollContainer(isPopup);
+				if (c) {
+					window.setTimeout(() => c.scrollTop = top, 10);
+				};
 			};
 		});
 
 		win.on(`resize.${ns} sidebarResize.${ns}`, () => resizePage());
-		container.on(`scroll.${ns}`, () => onScroll());
+
+		if (sc) {
+			scrollHandlerRef.current = () => onScroll();
+			sc.addEventListener('scroll', scrollHandlerRef.current);
+		};
 
 		Renderer.on(`commandEditor`, (e: any, cmd: string, arg: any) => onCommand(cmd, arg));
 
@@ -1220,16 +1236,18 @@ const EditorPage = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 		e.preventDefault();
 
 		const container = U.Dom.getScrollContainer(isPopup);
-		const containerHeight = container.height();
-		const scrollTop = container.scrollTop();
+		const containerHeight = container?.clientHeight ?? 0;
+		const scrollTop = container?.scrollTop ?? 0;
 		const dir = pressed.match(/up/i) ? -1 : 1;
 		const scrollAmount = containerHeight * 0.9;
 		const newScrollTop = Math.max(0, scrollTop + (dir * scrollAmount));
 
-		container.scrollTop(newScrollTop);
+		if (container) {
+			container.scrollTop = newScrollTop;
+		};
 
 		window.setTimeout(() => {
-			const containerOffset = container.offset()?.top || 0;
+			const containerOffset = container?.getBoundingClientRect().top ?? 0;
 			const targetY = dir < 0 ? (containerOffset + 100) : (containerOffset + containerHeight - 100);
 			const blocks = S.Block.getBlocks(rootId, it => it.isFocusable());
 
@@ -1935,7 +1953,7 @@ const EditorPage = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 	const onScroll = () => {
 		const { rootId, isPopup } = props;
 		const container = U.Dom.getScrollContainer(isPopup);
-		const top = container.scrollTop();
+		const top = container?.scrollTop ?? 0;
 
 		Storage.setScroll('editor', rootId, top, isPopup);
 		tocRef.current?.onScroll();
@@ -2602,15 +2620,15 @@ const EditorPage = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 
 			setLayoutWidth(U.Data.getLayoutWidth(rootId));
 
-			if (blocks.length && last.length && scrollContainer.length) {
+			if (blocks.length && last.length && scrollContainer) {
 				last.css({ height: '' });
 
 				const commentSection = node.find('.commentSection');
 				const csh = commentSection.length ? commentSection.outerHeight() : 0;
 
 				if (!csh) {
-					const ct = scrollContainer.offset().top;
-					const ch = scrollContainer.height();
+					const ct = scrollContainer.getBoundingClientRect().top;
+					const ch = scrollContainer.clientHeight;
 					const bt = blocks.offset().top;
 					const bh = blocks.outerHeight();
 
@@ -2666,7 +2684,7 @@ const EditorPage = observer(forwardRef<I.BlockRef, Props>((props, ref) => {
 		weight = Number(weight) || 0;
 
 		const container = U.Dom.getPageContainer(isPopup);
-		const mw = container.width() - 96;
+		const mw = (container?.clientWidth ?? 0) - 96;
 		const width = Math.min(mw, J.Size.editor + (mw - J.Size.editor) * weight);
 
 		return Math.max(300, width);

--- a/src/ts/component/form/button.tsx
+++ b/src/ts/component/form/button.tsx
@@ -76,7 +76,7 @@ const Button = forwardRef<ButtonRef, ButtonProps>(({
 		const t = Preview.tooltipCaption(text, caption);
 
 		if (t) {
-			Preview.tooltipShow({ ...tooltipParam, text: t, element: $(nodeRef.current) });
+			Preview.tooltipShow({ ...tooltipParam, text: t, element: nodeRef.current });
 		};
 
 		if (onMouseEnter) { 

--- a/src/ts/component/form/editable.tsx
+++ b/src/ts/component/form/editable.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, useRef, useImperativeHandle, useEffect } from 'react
 import { getRange, setRange } from 'selection-ranges';
 import raf from 'raf';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 interface Props {
 	id?: string;

--- a/src/ts/component/form/select.tsx
+++ b/src/ts/component/form/select.tsx
@@ -198,7 +198,7 @@ const Select = forwardRef<SelectRefProps, Props>(({
 		const t = Preview.tooltipCaption(text, caption);
 
 		if (t) {
-			Preview.tooltipShow({ ...tooltipParam, text: t, element: $(nodeRef.current) });
+			Preview.tooltipShow({ ...tooltipParam, text: t, element: nodeRef.current });
 		};
 		
 		if (onMouseEnter) {

--- a/src/ts/component/form/textarea.tsx
+++ b/src/ts/component/form/textarea.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useRef, useState, useEffect, useImperativeHandle } from 'react';
-import $ from 'jquery';
+
 
 interface Props {
 	id?: string;
@@ -95,7 +95,7 @@ const Textarea = forwardRef<TextareaRefProps, Props>(({
 			onFocus(e, value);
 		};
 		keyboard.setFocus(true);
-		$(nodeRef.current).addClass('isFocused');
+		U.Dom.addClass(nodeRef.current, 'isFocused');
 	};
 
 	const onBlurHandler = (e: any) => {
@@ -103,7 +103,7 @@ const Textarea = forwardRef<TextareaRefProps, Props>(({
 			onBlur(e, value);
 		};
 		keyboard.setFocus(false);
-		$(nodeRef.current).removeClass('isFocused');
+		U.Dom.removeClass(nodeRef.current, 'isFocused');
 	};
 
 	const onCopyHandler = (e: any) => {
@@ -127,15 +127,15 @@ const Textarea = forwardRef<TextareaRefProps, Props>(({
 	};
 	
 	const setError = (v: boolean) => {
-		$(nodeRef.current).toggleClass('withError', v);
+		U.Dom.toggleClass(nodeRef.current, 'withError', v);
 	};
 
 	const addClass = (v: string) => {
-		$(nodeRef.current).addClass(v);
+		U.Dom.addClass(nodeRef.current, v);
 	};
 	
 	const removeClass = (v: string) => {
-		$(nodeRef.current).removeClass(v);
+		U.Dom.removeClass(nodeRef.current, v);
 	};
 	
 	useEffect(() => setValue(initialValue));

--- a/src/ts/component/header/index.tsx
+++ b/src/ts/component/header/index.tsx
@@ -173,7 +173,7 @@ const Header = observer(forwardRef<{}, Props>((props, ref) => {
 	const onTooltipShow = (e: any, text: string, caption?: string) => {
 		const t = Preview.tooltipCaption(text, caption);
 		if (t) {
-			Preview.tooltipShow({ text: t, element: $(e.currentTarget), typeY: I.MenuDirection.Bottom });
+			Preview.tooltipShow({ text: t, element: e.currentTarget as HTMLElement, typeY: I.MenuDirection.Bottom });
 		};
 	};
 

--- a/src/ts/component/header/index.tsx
+++ b/src/ts/component/header/index.tsx
@@ -188,7 +188,7 @@ const Header = observer(forwardRef<{}, Props>((props, ref) => {
 	};
 
 	const menuOpen = (id: string, elementId: string, param: Partial<I.MenuParam>) => {
-		const element = U.Dom.getScrollContainer(isPopup).find(`.header ${elementId}`);
+		const element = $(U.Dom.getScrollContainer(isPopup)).find(`.header ${elementId}`);
 		const menuParam: any = Object.assign({
 			element,
 			offsetY: 4,

--- a/src/ts/component/header/main/chat.tsx
+++ b/src/ts/component/header/main/chat.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, useState, useImperativeHandle } from 'react';
+import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { Icon, IconObject, ObjectName, HeaderBanner } from 'Component';
 import * as I from 'Interface';
@@ -58,7 +59,7 @@ const HeaderMainChat = observer(forwardRef<{}, I.HeaderComponent>((props, ref) =
 
 		if (spaceview.isChat || spaceview.isOneToOne) {
 			U.Menu.spaceContext(spaceview, {
-				element: U.Dom.getScrollContainer(isPopup).find(`.header ${element}`),
+				element: $(U.Dom.getScrollContainer(isPopup)).find(`.header ${element}`),
 				className: 'fixed',
 				classNameWrap: 'fromHeader',
 				horizontal: I.MenuDirection.Right,

--- a/src/ts/component/header/main/graph.tsx
+++ b/src/ts/component/header/main/graph.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, useRef, useEffect } from 'react';
 import { Icon } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const HeaderMainGraph = forwardRef<{}, I.HeaderComponent>((props, ref) => {
 

--- a/src/ts/component/list/object.tsx
+++ b/src/ts/component/list/object.tsx
@@ -397,7 +397,7 @@ const ListObject = observer(forwardRef<ListObjectRefProps, Props>(({
 		);
 	} else
 	if (useInfiniteScroll) {
-		const scrollContainer = U.Dom.getScrollContainer(isPopup).get(0);
+		const scrollContainer = U.Dom.getScrollContainer(isPopup);
 
 		body = (
 			<InfiniteLoader

--- a/src/ts/component/list/objectManager.tsx
+++ b/src/ts/component/list/objectManager.tsx
@@ -113,14 +113,15 @@ const ObjectManager = observer(forwardRef<ObjectManagerRefProps, Props>(({
 	const [ dummy, setDummy ] = useState(0);
 	const recordIds = S.Record.getRecordIds(subId, '');
 	const records = S.Record.getRecords(subId);
-	const scrollContainer = scrollElement || U.Dom.getScrollContainer(isPopup).get(0);
+	const scrollContainer = scrollElement || U.Dom.getScrollContainer(isPopup);
 
 	const onFilterShow = () => {
 		if (!filterRef.current) {
 			return;
 		};
 
-		const container = U.Dom.getPageFlexContainer(isPopup);
+		const containerEl = U.Dom.getPageFlexContainer(isPopup);
+		const container = containerEl ? $(containerEl) : $();
 		const win = $(window);
 
 		$(filterWrapperRef.current).addClass('active');
@@ -479,7 +480,10 @@ const ObjectManager = observer(forwardRef<ObjectManagerRefProps, Props>(({
 
 		return () => {
 			window.clearTimeout(timeout.current);
-			U.Dom.getPageFlexContainer(isPopup).off('mousedown.filter');
+			const cleanupEl = U.Dom.getPageFlexContainer(isPopup);
+			if (cleanupEl) {
+				$(cleanupEl).off('mousedown.filter');
+			};
 			$(window).off('keydown.filter');
 			checkboxRef.current.clear();
 		};

--- a/src/ts/component/list/popup.tsx
+++ b/src/ts/component/list/popup.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useEffect } from 'react';
-import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { Popup } from 'Component';
 import * as I from 'Interface';
@@ -8,7 +7,7 @@ const ListPopup: FC<I.PageComponent> = observer(() => {
 	const { list } = S.Popup;
 
 	useEffect(() => {
-		$('body').toggleClass('overPopup', S.Popup.list.length > 0);
+		U.Dom.toggleClass(document.body, 'overPopup', S.Popup.list.length > 0);
 	}, [ list.length ]);
 
 	return (

--- a/src/ts/component/menu/block/layout.tsx
+++ b/src/ts/component/menu/block/layout.tsx
@@ -145,12 +145,13 @@ const MenuBlockLayout = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 
 	const onResize = (e: any) => {
-		const container = U.Dom.getPageFlexContainer(isPopup);
+		const containerEl = U.Dom.getPageFlexContainer(isPopup);
+		const container = containerEl ? $(containerEl) : $();
 		const wrapper = $('#editorWrapper');
 
 		wrapper.addClass('isResizing');
 
-		container.off('mousedown.editorSize').on('mousedown.editorSize', (e: any) => { 
+		container.off('mousedown.editorSize').on('mousedown.editorSize', (e: any) => {
 			if (!$(e.target).parents(`#editorSize`).length) {
 				wrapper.removeClass('isResizing');
 				container.off('mousedown.editorSize');

--- a/src/ts/component/menu/calendar/day.tsx
+++ b/src/ts/component/menu/calendar/day.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, useEffect, useRef, useImperativeHandle } from 'react
 import { observer } from 'mobx-react';
 import { Icon, IconObject, ObjectName } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const MenuCalendarDay = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	

--- a/src/ts/component/menu/chat/text.tsx
+++ b/src/ts/component/menu/chat/text.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef } from 'react';
 import { observer } from 'mobx-react';
 import { Icon } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const MenuChatText = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 

--- a/src/ts/component/menu/dataview/create/bookmark.tsx
+++ b/src/ts/component/menu/dataview/create/bookmark.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, useRef, useState, useEffect } from 'react';
 import { Input, Button, Loader, Icon, Error, Switch, Label } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const MenuDataviewCreateBookmark = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 

--- a/src/ts/component/menu/dataview/template/list.tsx
+++ b/src/ts/component/menu/dataview/template/list.tsx
@@ -163,8 +163,8 @@ const MenuTemplateList = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => 
 		const list = obj.find('.items');
 		const length = items.length;
 		const isPopup = keyboard.isPopup();
-		const container = U.Dom.getPageContainer(isPopup);
-		const ww = container.width();
+		const containerEl = U.Dom.getPageContainer(isPopup);
+		const ww = containerEl?.clientWidth || 0;
 
 		let columns = Math.max(1, Math.floor(ww / TEMPLATE_WIDTH));
 		if (columns > length) {

--- a/src/ts/component/menu/help.tsx
+++ b/src/ts/component/menu/help.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react
 import { MenuItemVertical, Button, ShareTooltip } from 'Component';
 import * as I from 'Interface';
 import Highlight from 'Lib/highlight';
+import $ from 'jquery';
 
 const MenuHelp = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 

--- a/src/ts/component/menu/index.tsx
+++ b/src/ts/component/menu/index.tsx
@@ -324,7 +324,8 @@ const Menu = observer(forwardRef<RefProps, I.Menu>((props, ref) => {
 
 	const rebind = () => {
 		const id = getId();
-		const container = U.Dom.getScrollContainer(keyboard.isPopup());
+		const containerEl = U.Dom.getScrollContainer(keyboard.isPopup());
+		const container = containerEl ? $(containerEl) : $();
 
 		unbind();
 		$(window).on(`resize.${id} sidebarResize.${id}`, () => position());
@@ -333,10 +334,11 @@ const Menu = observer(forwardRef<RefProps, I.Menu>((props, ref) => {
 			framePosition.current = raf(() => position());
 		});
 	};
-	
+
 	const unbind = () => {
 		const id = getId();
-		const container = U.Dom.getScrollContainer(keyboard.isPopup());
+		const containerEl = U.Dom.getScrollContainer(keyboard.isPopup());
+		const container = containerEl ? $(containerEl) : $();
 
 		$(window).off(`resize.${id} sidebarResize.${id}`);
 		container.off(`scroll.${id}`);
@@ -1001,7 +1003,7 @@ const Menu = observer(forwardRef<RefProps, I.Menu>((props, ref) => {
 	};
 
 	const getMaxHeight = (isPopup: boolean): number => {
-		return U.Dom.getScrollContainer(isPopup).height() - getBorderTop() - getBorderBottom();
+		return (U.Dom.getScrollContainer(isPopup)?.clientHeight || 0) - getBorderTop() - getBorderBottom();
 	};
 
 	const menuId = getId();

--- a/src/ts/component/menu/item/vertical.tsx
+++ b/src/ts/component/menu/item/vertical.tsx
@@ -187,10 +187,10 @@ const MenuItemVertical = forwardRef<{}, I.MenuItem>((props, ref) => {
 	};
 
 	const resize = () => {
-		const node = $(nodeRef.current);
-		
-		if (!node.hasClass('withIcon')) {
-			node.toggleClass('withIconObject', !!node.find('.iconObject').length);
+		const node = nodeRef.current;
+
+		if (node && !U.Dom.hasClass(node, 'withIcon')) {
+			U.Dom.toggleClass(node, 'withIconObject', !!node.querySelectorAll('.iconObject').length);
 		};
 	};
 

--- a/src/ts/component/menu/item/vertical.tsx
+++ b/src/ts/component/menu/item/vertical.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useRef, useEffect } from 'react';
-import $ from 'jquery';
 import { Icon, IconObject, Switch, Select, ObjectName } from 'Component';
 import * as I from 'Interface';
 
@@ -199,7 +198,7 @@ const MenuItemVertical = forwardRef<{}, I.MenuItem>((props, ref) => {
 		const t = Preview.tooltipCaption(text, caption);
 
 		if (t) {
-			Preview.tooltipShow({ ...tooltipParam, text: t, element: $(nodeRef.current) });
+			Preview.tooltipShow({ ...tooltipParam, text: t, element: nodeRef.current });
 		};
 		
 		onMouseEnter?.(e);

--- a/src/ts/component/menu/onboarding.tsx
+++ b/src/ts/component/menu/onboarding.tsx
@@ -146,8 +146,8 @@ const MenuOnboarding = observer(forwardRef<I.MenuRef, I.Menu>((props: I.Menu, re
 			return;
 		};
 
-		const container = U.Dom.getScrollContainer(isPopup);
-		const top = container.scrollTop();
+		const containerEl = U.Dom.getScrollContainer(isPopup);
+		const top = containerEl?.scrollTop || 0;
 		const element = $(param.element);
 
 		if (!element.length) {
@@ -158,13 +158,16 @@ const MenuOnboarding = observer(forwardRef<I.MenuRef, I.Menu>((props: I.Menu, re
 		const hh = J.Size.header;
 
 		let containerOffset = { top: 0, left: 0 };
-		if (container.length) {
-			containerOffset = container.offset();
+		if (containerEl) {
+			const containerRect = containerEl.getBoundingClientRect();
+			containerOffset = { top: containerRect.top, left: containerRect.left };
 		};
 
 		if (rect.y < 0) {
 			rect.y -= rect.height + hh + containerOffset.top;
-			container.scrollTop(top + rect.y);
+			if (containerEl) {
+				containerEl.scrollTop = top + rect.y;
+			};
 		};
 	};
 

--- a/src/ts/component/menu/publish.tsx
+++ b/src/ts/component/menu/publish.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef, useRef, useState, useEffect, MouseEvent } from 'react';
 import { observer } from 'mobx-react';
 import { Title, Input, Label, Switch, Button, Icon, Error, Loader } from 'Component';
-import $ from 'jquery';
 import * as I from 'Interface';
 
 const MenuPublish = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => {
@@ -140,7 +139,7 @@ const MenuPublish = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		Preview.tooltipShow({
 			text: translate('menuPublishInfoTooltip'),
 			className: 'big',
-			element: $(e.currentTarget),
+			element: e.currentTarget as HTMLElement,
 			typeY: I.MenuDirection.Bottom,
 			typeX: I.MenuDirection.Left,
 			delay: 0,

--- a/src/ts/component/menu/search/chat.tsx
+++ b/src/ts/component/menu/search/chat.tsx
@@ -180,8 +180,9 @@ const MenuSearchChat = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		const menu = $(`#${getId()}`);
 		const obj = menu.find('.content');
 		const { wh } = U.Dom.getWindowDimensions();
-		const header = U.Dom.getScrollContainer(data.isPopup).find('#header .side.center');
-		const width = Math.min(header.width(), J.Size.editor);
+		const containerEl = U.Dom.getScrollContainer(data.isPopup);
+		const headerEl = containerEl?.querySelector('#header .side.center') as HTMLElement;
+		const width = Math.min(headerEl?.clientWidth || 0, J.Size.editor);
 
 		let height = 0;
 		if (!isDropdownOpen) {

--- a/src/ts/component/menu/search/text.tsx
+++ b/src/ts/component/menu/search/text.tsx
@@ -43,7 +43,7 @@ const MenuSearchText = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 
 	const getMatchElements = (): NodeListOf<Element> | null => {
 		const container = getContainer();
-		return container.length ? container.get(0).querySelectorAll(getSearchTag()) : null;
+		return container ? container.querySelectorAll(getSearchTag()) : null;
 	};
 
 	const expandToggle = (el: JQuery<Element>) => {
@@ -157,15 +157,20 @@ const MenuSearchText = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 
 	const scrollToMatch = (matchEl: JQuery<Element>) => {
-		const container = getContainer();
-		const scrollTop = container.scrollTop();
+		const containerEl = getContainer();
+		if (!containerEl) {
+			return;
+		};
+
+		const scrollTop = containerEl.scrollTop;
 		const matchTop = matchEl.offset()?.top || 0;
-		const containerTop = container.offset()?.top || 0;
-		const containerHeight = container.height() || 0;
+		const containerRect = containerEl.getBoundingClientRect();
+		const containerTop = containerRect.top || 0;
+		const containerHeight = containerEl.clientHeight || 0;
 		const offset = J.Size.lastBlock + J.Size.header;
 		const targetY = matchTop - containerTop + scrollTop;
 
-		container.scrollTop(targetY - containerHeight + offset);
+		containerEl.scrollTop = targetY - containerHeight + offset;
 	};
 
 	const updateMatchCounter = () => {
@@ -184,9 +189,11 @@ const MenuSearchText = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			return;
 		};
 
-		const container = getContainer();
+		const containerEl = getContainer();
 		const tag = getSearchTag();
-		container.find(`${tag}.active`).removeClass('active');
+		if (containerEl) {
+			containerEl.querySelectorAll(`${tag}.active`).forEach(el => el.classList.remove('active'));
+		};
 
 		const currentEl = $(elements[n.current]);
 		if (!currentEl.length) {
@@ -223,7 +230,7 @@ const MenuSearchText = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			return;
 		};
 
-		const container = getContainer();
+		const containerEl = getContainer();
 		const node = $(nodeRef.current);
 		const switcher = node.find('#switcher').removeClass('active');
 
@@ -232,13 +239,13 @@ const MenuSearchText = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		lastSearchRef.current = value;
 		storageSet({ search: value });
 
-		if (!value) {
+		if (!value || !containerEl) {
 			return;
 		};
 
 		analytics.event('SearchWords', { length: value.length, route });
 
-		findAndReplaceDOMText(container.get(0), {
+		findAndReplaceDOMText(containerEl, {
 			preset: 'prose',
 			find: new RegExp(U.String.regexEscape(value), 'gi'),
 			wrap: getSearchTag(),

--- a/src/ts/component/menu/smile.tsx
+++ b/src/ts/component/menu/smile.tsx
@@ -486,8 +486,8 @@ const MenuSmile = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		const tt = getTooltip(item);
 
 		element.addClass('active');
-		if (tt) {
-			Preview.tooltipShow({ text: tt, element });
+		if (tt && element.length) {
+			Preview.tooltipShow({ text: tt, element: element.get(0) as HTMLElement });
 		};
 	};
 

--- a/src/ts/component/menu/syncStatus/info.tsx
+++ b/src/ts/component/menu/syncStatus/info.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, useEffect, useRef, useImperativeHandle } from 'react';
 import { MenuItemVertical, Title, Label } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const MenuSyncStatusInfo = forwardRef<{}, I.Menu>((props, ref) => {
 

--- a/src/ts/component/menu/tableOfContents.tsx
+++ b/src/ts/component/menu/tableOfContents.tsx
@@ -3,6 +3,7 @@ import { observer } from 'mobx-react';
 import { AutoSizer, CellMeasurer, InfiniteLoader, List, CellMeasurerCache } from 'react-virtualized';
 import { Label, MenuItemVertical } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const HEIGHT = 28;
 const LIMIT = 20;

--- a/src/ts/component/page/auth/login.tsx
+++ b/src/ts/component/page/auth/login.tsx
@@ -1,6 +1,5 @@
 import React, { forwardRef, useState, useRef, useEffect, KeyboardEvent } from 'react';
 import { observer } from 'mobx-react';
-import $ from 'jquery';
 import { Frame, Error, Button, Header, Phrase, Title, Label } from 'Component';
 import * as I from 'Interface';
 import Storage from 'Lib/storage';
@@ -152,7 +151,7 @@ const PageAuthLogin = observer(forwardRef<I.PageRef, I.PageComponent>((props, re
 	};
 
 	useEffect(() => {
-		$(frameRef.current.getNode()).removeClass('invisible');
+		U.Dom.removeClass(frameRef.current.getNode(), 'invisible');
 		focus();
 	}, []);
 

--- a/src/ts/component/page/auth/onboard.tsx
+++ b/src/ts/component/page/auth/onboard.tsx
@@ -3,6 +3,7 @@ import { observer } from 'mobx-react';
 import { Frame, Title, Label, Button, Icon, Input, Error, Header, Phrase, Footer } from 'Component';
 import * as I from 'Interface';
 import Animation from 'Lib/animation';
+import $ from 'jquery';
 
 enum Stage {
 	Phrase 		= 0,

--- a/src/ts/component/page/auth/pinCheck.tsx
+++ b/src/ts/component/page/auth/pinCheck.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, useRef, useState, useEffect } from 'react';
 import { Frame, Title, Error, Pin, Header } from 'Component';
 import { observer } from 'mobx-react';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const PageAuthPinCheck = observer(forwardRef<I.PageRef, I.PageComponent>(() => {
 

--- a/src/ts/component/page/elements/tableOfContents.tsx
+++ b/src/ts/component/page/elements/tableOfContents.tsx
@@ -64,7 +64,7 @@ const TableOfContents = observer(forwardRef<TableOfContentsRefProps, I.BlockComp
 		raf.cancel(frameScroll.current);
 		frameScroll.current = raf(() => {
 			const container = U.Dom.getScrollContainer(isPopup);
-			const top = container.scrollTop();
+			const top = container?.scrollTop || 0;
 			const co = containerOffset.current.top;
 			const currentList = listRef.current;
 
@@ -129,10 +129,15 @@ const TableOfContents = observer(forwardRef<TableOfContentsRefProps, I.BlockComp
 				return;
 			};
 
-			const container = U.Dom.getScrollContainer(isPopup);
-			const width = container.width();
+			const containerEl = U.Dom.getScrollContainer(isPopup);
+			if (!containerEl) {
+				return;
+			};
 
-			containerOffset.current = container.offset();
+			const width = containerEl.clientWidth;
+			const containerRect = containerEl.getBoundingClientRect();
+
+			containerOffset.current = { top: containerRect.top, left: containerRect.left };
 
 			node.css({ left: containerOffset.current.left + width - node.outerWidth() - 6 });
 			onScroll();

--- a/src/ts/component/page/main/archive.tsx
+++ b/src/ts/component/page/main/archive.tsx
@@ -127,7 +127,8 @@ const PageMainArchive = observer(forwardRef<I.PageRef, I.PageComponent>((props, 
 		filterRef.current.setActive(true);
 		filterRef.current.focus();
 
-		const container = U.Dom.getPageFlexContainer(isPopup);
+		const containerEl = U.Dom.getPageFlexContainer(isPopup);
+		const container = containerEl ? $(containerEl) : $();
 		const win = $(window);
 
 		container.off('mousedown.filter').on('mousedown.filter', (e: any) => {
@@ -195,7 +196,10 @@ const PageMainArchive = observer(forwardRef<I.PageRef, I.PageComponent>((props, 
 
 		return () => {
 			window.clearTimeout(filterTimeout.current);
-			U.Dom.getPageFlexContainer(isPopup).off('mousedown.filter');
+			const cleanupEl = U.Dom.getPageFlexContainer(isPopup);
+			if (cleanupEl) {
+				$(cleanupEl).off('mousedown.filter');
+			};
 			$(window).off('keydown.filter');
 		};
 	}, []);

--- a/src/ts/component/page/main/graph.tsx
+++ b/src/ts/component/page/main/graph.tsx
@@ -63,17 +63,20 @@ const PageMainGraph = observer(forwardRef<I.PageRef, I.PageComponent>((props, re
 	const resize = () => {
 		const container = U.Dom.getScrollContainer(isPopup);
 		const obj = U.Dom.getPageContainer(isPopup);
-		const node = $(nodeRef.current);
-		const wrapper = obj.find('.wrapper');
-		const header = node.find('#header');
-		const height = container.height() - header.height();
+		const node = nodeRef.current;
+		const wrapper = obj?.querySelector('.wrapper') as HTMLElement;
+		const header = node?.querySelector('#header') as HTMLElement;
+		const height = (container?.clientHeight || 0) - (header?.clientHeight || 0);
 
-		wrapper.css({ height });
-		
+		if (wrapper) {
+			wrapper.style.height = `${height}px`;
+		};
+
 		if (isPopup) {
-			const element = $('#popupPage .content');
-			if (element.length) {
-				element.css({ minHeight: 'unset', height: '100%' });
+			const element = document.querySelector('#popupPage .content') as HTMLElement;
+			if (element) {
+				element.style.minHeight = 'unset';
+				element.style.height = '100%';
 			};
 		};
 

--- a/src/ts/component/page/main/history.tsx
+++ b/src/ts/component/page/main/history.tsx
@@ -314,31 +314,42 @@ const PageMainHistory = observer(forwardRef<I.PageRef, I.PageComponent>((props, 
 	};
 
 	const resize = () => {
-		const node = $(nodeRef.current);
-		const sideLeft = $(leftRef.current?.getNode());
-		const sideRight = $(rightRef.current?.getNode());
-		const editorWrapper = node.find('#editorWrapper');
-		const cover = node.find('.block.blockCover');
+		const node = nodeRef.current;
+		const sideLeft = leftRef.current?.getNode() as HTMLElement;
+		const sideRight = rightRef.current?.getNode() as HTMLElement;
+		const editorWrapper = node?.querySelector('#editorWrapper') as HTMLElement;
+		const cover = node?.querySelector('.block.blockCover') as HTMLElement;
 		const container = U.Dom.getPageContainer(isPopup);
 		const sc = U.Dom.getScrollContainer(isPopup);
-		const header = container.find('#header');
-		const height = sc.height();
-		const hh = header.height();
-		const cssl: any = { height };
+		const header = container?.querySelector('#header') as HTMLElement;
+		const height = sc?.clientHeight || 0;
+		const hh = header?.clientHeight || 0;
 
-		sideRight.css({ height });
+		if (sideRight) {
+			sideRight.style.height = `${height}px`;
+		};
 
-		if (cover.length) {
-			cover.css({ top: hh });
+		if (cover) {
+			cover.style.top = `${hh}px`;
 		};
 
 		if (isPopup) {
-			$('.pageMainHistory.isPopup').css({ height });
-			cssl.paddingTop = hh;
+			const popupEl = document.querySelector('.pageMainHistory.isPopup') as HTMLElement;
+			if (popupEl) {
+				popupEl.style.height = `${height}px`;
+			};
+			if (sideLeft) {
+				sideLeft.style.height = `${height}px`;
+				sideLeft.style.paddingTop = `${hh}px`;
+			};
+		} else
+		if (sideLeft) {
+			sideLeft.style.height = `${height}px`;
 		};
 
-		sideLeft.css(cssl);
-		editorWrapper.css({ width: !isSetOrCollection() ? getWrapperWidth() : '' });
+		if (editorWrapper) {
+			editorWrapper.style.width = !isSetOrCollection() ? `${getWrapperWidth()}px` : '';
+		};
 	};
 
 	const getWrapperWidth = (): number => {
@@ -348,8 +359,8 @@ const PageMainHistory = observer(forwardRef<I.PageRef, I.PageComponent>((props, 
 	const getWidth = (weight: number) => {
 		weight = Number(weight) || 0;
 
-		const sideLeft = $(leftRef.current?.getNode());
-		const cw = sideLeft.width();
+		const sideLeft = leftRef.current?.getNode() as HTMLElement;
+		const cw = sideLeft?.clientWidth || 0;
 
 		let width = 0;
 

--- a/src/ts/component/page/main/history/left.tsx
+++ b/src/ts/component/page/main/history/left.tsx
@@ -59,13 +59,16 @@ const HistoryLeft = observer(forwardRef<Ref, Props>((props, ref) => {
 	};
 
 	const onScroll = () => {
-		topRef.current = $(nodeRef.current).scrollTop();
-		U.Dom.getScrollContainer(isPopup).trigger('scroll');
+		topRef.current = nodeRef.current?.scrollTop ?? 0;
+		U.Dom.getScrollContainer(isPopup)?.dispatchEvent(new Event('scroll'));
 	};
 
 	useEffect(() => {
 		S.Block.updateNumbers(rootId);
-		$(nodeRef.current).scrollTop(topRef.current);
+
+		if (nodeRef.current) {
+			nodeRef.current.scrollTop = topRef.current;
+		};
 	});
 
 	useImperativeHandle(ref, () => ({

--- a/src/ts/component/page/main/import.tsx
+++ b/src/ts/component/page/main/import.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useState, useEffect, useRef } from 'react';
-import $ from 'jquery';
 import { Loader, Title, Error, Frame, Button } from 'Component';
 import * as I from 'Interface';
 
@@ -10,11 +9,12 @@ const PageMainImport = forwardRef<I.PageRef, I.PageComponent>((props, ref) => {
 	const [ error, setError ] = useState('');
 
 	const resize = () => {
-		const win = $(window);
 		const obj = U.Dom.getPageFlexContainer(isPopup);
-		const wh = isPopup ? obj.height() : win.height();
+		const wh = isPopup ? (obj?.clientHeight || 0) : window.innerHeight;
 
-		$(nodeRef.current).css({ height: wh });
+		if (nodeRef.current) {
+			nodeRef.current.style.height = `${wh}px`;
+		};
 	};
 
 	useEffect(() => {

--- a/src/ts/component/page/main/invite.tsx
+++ b/src/ts/component/page/main/invite.tsx
@@ -91,13 +91,13 @@ const PageMainInvite = forwardRef<I.PageRef, I.PageComponent>((props, ref) => {
 	};
 
 	const resize = () => {
-		const win = $(window);
 		const obj = U.Dom.getPageFlexContainer(isPopup);
-		const node = $(nodeRef.current);
-		const oh = obj.height();
-		const wh = isPopup ? oh : win.height();
+		const oh = obj?.clientHeight || 0;
+		const wh = isPopup ? oh : window.innerHeight;
 
-		node.css({ height: wh });
+		if (nodeRef.current) {
+			nodeRef.current.style.height = `${wh}px`;
+		};
 		frameRef.current?.resize();
 	};
 

--- a/src/ts/component/page/main/media.tsx
+++ b/src/ts/component/page/main/media.tsx
@@ -126,7 +126,7 @@ const PageMainMedia = observer(forwardRef<I.PageRef, I.PageComponent>((props, re
 		const empty = node.find('#empty');
 		const inner = node.find('.side.left #inner');
 		const container = U.Dom.getScrollContainer(isPopup);
-		const wh = container.height() - 182;
+		const wh = (container?.clientHeight ?? 0) - 182;
 
 		if (blocks.hasClass('vertical')) {
 			inner.css({ minHeight: wh });

--- a/src/ts/component/page/main/membership.tsx
+++ b/src/ts/component/page/main/membership.tsx
@@ -26,11 +26,12 @@ const PageMainMembership = observer(forwardRef<I.PageRef, I.PageComponent>((prop
 	};
 
 	const resize = () => {
-		const win = $(window);
-		const node = $(nodeRef.current);
 		const obj = U.Dom.getPageFlexContainer(isPopup);
+		const h = isPopup ? (obj?.clientHeight || 0) : window.innerHeight;
 
-		node.css({ height: (isPopup ? obj.height() : win.height()) });
+		if (nodeRef.current) {
+			nodeRef.current.style.height = `${h}px`;
+		};
 	};
 
 	useEffect(() => {

--- a/src/ts/component/page/main/navigation.tsx
+++ b/src/ts/component/page/main/navigation.tsx
@@ -58,7 +58,7 @@ const PageMainNavigation = observer(forwardRef<I.PageRef, I.PageComponent>((prop
 			const sides = node.find('.sides');
 			const empty = node.find('#empty');
 			const hh = header.height();
-			const oh = container.height() - hh;
+			const oh = (container?.clientHeight ?? 0) - hh;
 
 			sides.css({ height: oh });
 			items.css({ height: oh });

--- a/src/ts/component/page/main/oneToOne.tsx
+++ b/src/ts/component/page/main/oneToOne.tsx
@@ -15,13 +15,13 @@ const PageMainOneToOne = forwardRef<I.PageRef, I.PageComponent>((props, ref) => 
 	};
 
 	const resize = () => {
-		const win = $(window);
 		const obj = U.Dom.getPageFlexContainer(isPopup);
-		const node = $(nodeRef.current);
-		const oh = obj.height();
-		const wh = isPopup ? oh : win.height();
+		const oh = obj?.clientHeight || 0;
+		const wh = isPopup ? oh : window.innerHeight;
 
-		node.css({ height: wh });
+		if (nodeRef.current) {
+			nodeRef.current.style.height = `${wh}px`;
+		};
 		frameRef.current?.resize();
 	};
 

--- a/src/ts/component/page/main/set.tsx
+++ b/src/ts/component/page/main/set.tsx
@@ -26,10 +26,16 @@ const PageMainSet = observer(forwardRef<I.PageRef, I.PageComponent>((props, ref)
 
 	const unbind = () => {
 		const ns = U.Dom.getEventNamespace(isPopup);
-		const events = [ 'keydown', 'scroll' ];
+		const container = U.Dom.getScrollContainer(isPopup);
 
-		$(window).off(events.map(it => `${it}.set${ns}`).join(' '));
+		$(window).off(`keydown.set${ns}`);
+
+		if (scrollHandler.current && container) {
+			container.removeEventListener('scroll', scrollHandler.current);
+		};
 	};
+
+	const scrollHandler = useRef<(() => void) | null>(null);
 
 	const rebind = () => {
 		const win = $(window);
@@ -39,7 +45,9 @@ const PageMainSet = observer(forwardRef<I.PageRef, I.PageComponent>((props, ref)
 		unbind();
 
 		win.on(`keydown.set${ns}`, e => onKeyDown(e));
-		container.on(`scroll.set${ns}`, () => onScroll());
+
+		scrollHandler.current = () => onScroll();
+		container?.addEventListener('scroll', scrollHandler.current);
 	};
 
 	const checkDeleted = (): boolean => {
@@ -93,14 +101,13 @@ const PageMainSet = observer(forwardRef<I.PageRef, I.PageComponent>((props, ref)
 					cnt++;
 
 					const container = U.Dom.getScrollContainer(isPopup);
-					const el = container.get(0);
 
-					if (!el) {
+					if (!container) {
 						return;
 					};
 
-					if ((el.scrollHeight > target) || (cnt >= 30)) {
-						container.scrollTop(target);
+					if ((container.scrollHeight > target) || (cnt >= 30)) {
+						container.scrollTop = target;
 					} else {
 						window.setTimeout(restore, 50);
 					};
@@ -131,7 +138,7 @@ const PageMainSet = observer(forwardRef<I.PageRef, I.PageComponent>((props, ref)
 		};
 
 		const container = U.Dom.getScrollContainer(isPopup);
-		const top = container.scrollTop();
+		const top = container?.scrollTop ?? 0;
 
 		Storage.setScroll('set', rootId, top, isPopup);
 		S.Common.getRef('selectionProvider')?.renderSelection();
@@ -212,7 +219,7 @@ const PageMainSet = observer(forwardRef<I.PageRef, I.PageComponent>((props, ref)
 		};
 
 		raf(() => {
-			const container = U.Dom.getPageContainer(isPopup);
+			const container = $(U.Dom.getPageContainer(isPopup));
 			const header = container.find('#header');
 			const cover = container.find('.block.blockCover');
 			const hh = isPopup ? header.height() : J.Size.header;

--- a/src/ts/component/page/main/settings/api.tsx
+++ b/src/ts/component/page/main/settings/api.tsx
@@ -24,7 +24,8 @@ const PageMainSettingsApi = observer(forwardRef<I.PageRef, I.PageSettingsCompone
 	};
 
 	const onMore = (item: any) => {
-		const element = $(`#${getId()} #icon-more-${item.hash}`);
+		const element = `#${getId()} #icon-more-${item.hash}`;
+		const el = U.Dom.select(element);
 		const options: any[] = [
 			{ id: 'copyKey', name: translate('popupSettingsApiCopyKey') },
 			{ id: 'copyMcp', name: translate('popupSettingsApiCopyMcp') },
@@ -35,8 +36,8 @@ const PageMainSettingsApi = observer(forwardRef<I.PageRef, I.PageSettingsCompone
 			element,
 			horizontal: I.MenuDirection.Right,
 			offsetY: 4,
-			onOpen: () => element.addClass('active'),
-			onClose: () => element.removeClass('active'),
+			onOpen: () => U.Dom.addClass(el, 'active'),
+			onClose: () => U.Dom.removeClass(el, 'active'),
 			data: {
 				options,
 				onSelect: (e: any, element: any) => {
@@ -75,7 +76,7 @@ const PageMainSettingsApi = observer(forwardRef<I.PageRef, I.PageSettingsCompone
 				</div>
 				<div 
 					className="col" 
-					onMouseEnter={e => Preview.tooltipShow({ text: item.apiKey, element: $(e.currentTarget) })} 
+					onMouseEnter={e => Preview.tooltipShow({ text: item.apiKey, element: e.currentTarget as HTMLElement })}
 					onMouseLeave={() => Preview.tooltipHide()}
 				>
 					{U.String.shortMask(item.apiKey, 3)}

--- a/src/ts/component/page/main/settings/data/publish.tsx
+++ b/src/ts/component/page/main/settings/data/publish.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, useState, useEffect } from 'react';
 import { observer } from 'mobx-react';
 import { Title, IconObject, ObjectName, Icon, EmptyState } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const PageMainSettingsDataPublish = observer(forwardRef<I.PageRef, I.PageSettingsComponent>((props, ref) => {
 

--- a/src/ts/component/page/main/settings/index.tsx
+++ b/src/ts/component/page/main/settings/index.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
-import $ from 'jquery';
 import { Header, Footer } from 'Component';
 import { observer } from 'mobx-react';
 
@@ -159,7 +158,7 @@ const PageMainSettingsIndex = observer(forwardRef<{}, I.PageComponent>((props, r
 			title: translate('popupSettingsSpaceIndexSpaceTypePersonalTooltipTitle'),
 			text: translate('popupSettingsSpaceIndexSpaceTypePersonalTooltipText'),
 			className: 'big',
-			element: $(e.currentTarget),
+			element: e.currentTarget as HTMLElement,
 			typeY: I.MenuDirection.Bottom,
 			typeX: I.MenuDirection.Left,
 		});

--- a/src/ts/component/page/main/settings/membership/intro.tsx
+++ b/src/ts/component/page/main/settings/membership/intro.tsx
@@ -1,6 +1,5 @@
 import React, { forwardRef, useState, useRef, useImperativeHandle } from 'react';
 import { observer } from 'mobx-react';
-import $ from 'jquery';
 import { Title, Label, Button, Icon } from 'Component';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Pagination, Mousewheel } from 'swiper/modules';
@@ -173,7 +172,7 @@ const PageMainSettingsMembershipIntro = observer(forwardRef<I.PageRef, I.PageSet
 		};
 
 		for (const key of Object.keys(breakpoint)) {
-			$(nodeRef.current).toggleClass(key, pw <= breakpoint[key]);
+			U.Dom.toggleClass(nodeRef.current, key, pw <= breakpoint[key]);
 		};
 	};
 

--- a/src/ts/component/page/main/settings/membership/loader.tsx
+++ b/src/ts/component/page/main/settings/membership/loader.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useEffect, useRef } from 'react';
-import $ from 'jquery';
 import { Icon, Label } from 'Component';
 
 const PageMainSettingsMembershipLoader = forwardRef<HTMLDivElement, {}>((props, ref) => {
@@ -9,7 +8,7 @@ const PageMainSettingsMembershipLoader = forwardRef<HTMLDivElement, {}>((props, 
 
 	useEffect(() => {
 		timeoutRef.current = window.setTimeout(() => {
-			$(nodeRef.current).addClass('longWait');
+			U.Dom.addClass(nodeRef.current, 'longWait');
 		}, 5000);
 
 		return () => {

--- a/src/ts/component/page/main/settings/space/list.tsx
+++ b/src/ts/component/page/main/settings/space/list.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef } from 'react';
-import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { Title, IconObject, ObjectName, Icon } from 'Component';
 import * as I from 'Interface';
@@ -49,12 +48,14 @@ const PageMainSettingsSpacesList = observer(forwardRef<I.PageRef, I.PageSettings
 	const onMore = (space: any) => {
 		const element = `#${getId()} #icon-more-${space.id}`;
 
+		const el = U.Dom.select(element);
+
 		U.Menu.spaceContext(space, {
 			element,
 			horizontal: I.MenuDirection.Right,
 			offsetY: 4,
-			onOpen: () => $(element).addClass('active'),
-			onClose: () => $(element).removeClass('active'),
+			onOpen: () => U.Dom.addClass(el, 'active'),
+			onClose: () => U.Dom.removeClass(el, 'active'),
 		}, { 
 			withPin: true,
 			withDelete: true,

--- a/src/ts/component/popup/confirm.tsx
+++ b/src/ts/component/popup/confirm.tsx
@@ -3,6 +3,7 @@ import { Icon, Label, Button, Checkbox, Error, Input, Editable } from 'Component
 import { observer } from 'mobx-react';
 import * as I from 'Interface';
 import Storage from 'Lib/storage';
+import $ from 'jquery';
 
 const PopupConfirm = observer(forwardRef<{}, I.Popup>((props, ref) => {
 

--- a/src/ts/component/popup/introduceChats.tsx
+++ b/src/ts/component/popup/introduceChats.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useState, useRef, useEffect } from 'react';
-import $ from 'jquery';
 import { Title, Label, Button, Icon, } from 'Component';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Keyboard, Navigation } from 'swiper/modules';
@@ -25,10 +24,10 @@ const PopupIntroduceChats = forwardRef<{}, I.Popup>(({ param, close }, ref) => {
 	};
 
 	const initGallery = () => {
-		const wrapper = $(nodeRef.current).find('.step1');
+		const wrapper = nodeRef.current?.querySelector('.step1');
 
 		window.clearTimeout(timeout.current);
-		timeout.current = window.setTimeout(() => wrapper.removeClass('init'), 600);
+		timeout.current = window.setTimeout(() => U.Dom.removeClass(wrapper, 'init'), 600);
 	};
 
 	const onSlideChange = () => {
@@ -41,7 +40,7 @@ const PopupIntroduceChats = forwardRef<{}, I.Popup>(({ param, close }, ref) => {
 
 	useEffect(() => {
 		onStepChange(0, () => {
-			$(nodeRef.current).find('.step0').removeClass('init');
+			U.Dom.removeClass(nodeRef.current?.querySelector('.step0'), 'init');
 		});
 
 		return () => {

--- a/src/ts/component/popup/logout.tsx
+++ b/src/ts/component/popup/logout.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, useState, useRef, useEffect } from 'react';
 import { Title, Label, Button, Phrase } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const PopupLogout = forwardRef<{}, I.Popup>((props, ref) => {
 

--- a/src/ts/component/popup/membership/activation.tsx
+++ b/src/ts/component/popup/membership/activation.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, useRef, useState, useEffect } from 'react';
-import $ from 'jquery';
 import { observer } from 'mobx-react';
 import { Title, Label, Button, Loader, Error, Icon, Input } from 'Component';
 import * as I from 'Interface';
@@ -24,14 +23,14 @@ const PopupMembershipActivation = observer(forwardRef<{}, I.Popup>((props, ref) 
 		inputRef.current?.setValue('');
 		setError('');
 		buttonRef.current?.setDisabled(true);
-		$(inputWrapperRef.current).removeClass('canClear');
+		U.Dom.removeClass(inputWrapperRef.current, 'canClear');
 	};
 
 	const checkButton = () => {
 		const v = inputRef.current?.getValue();
 
 		buttonRef.current?.setDisabled(!v.length);
-		$(inputWrapperRef.current).toggleClass('canClear', v.length > 0);
+		U.Dom.toggleClass(inputWrapperRef.current, 'canClear', v.length > 0);
 	};
 
 	const onSubmit = (e: any) => {

--- a/src/ts/component/popup/page/usecase/list.tsx
+++ b/src/ts/component/popup/page/usecase/list.tsx
@@ -5,6 +5,7 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import { Mousewheel, Navigation } from 'swiper/modules';
 import { AutoSizer, CellMeasurer, CellMeasurerCache, List, WindowScroller } from 'react-virtualized';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const HEIGHT = 378;
 const LIMIT = 2;

--- a/src/ts/component/popup/settings/onboarding.tsx
+++ b/src/ts/component/popup/settings/onboarding.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, useRef, useState } from 'react';
 import { Title, Label, Select, Button, Error } from 'Component';
 import { observer } from 'mobx-react';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const PopupSettingsOnboarding = observer(forwardRef<{}, I.Popup>((props, ref) => {
 

--- a/src/ts/component/popup/settings/onboarding.tsx
+++ b/src/ts/component/popup/settings/onboarding.tsx
@@ -2,7 +2,6 @@ import React, { forwardRef, useRef, useState } from 'react';
 import { Title, Label, Select, Button, Error } from 'Component';
 import { observer } from 'mobx-react';
 import * as I from 'Interface';
-import $ from 'jquery';
 
 const PopupSettingsOnboarding = observer(forwardRef<{}, I.Popup>((props, ref) => {
 
@@ -150,7 +149,7 @@ const PopupSettingsOnboarding = observer(forwardRef<{}, I.Popup>((props, ref) =>
 
 	const onTooltipShow = (e: any, text: string) => {
 		if (text) {
-			Preview.tooltipShow({ text, element: $(e.currentTarget) });
+			Preview.tooltipShow({ text, element: e.currentTarget as HTMLElement });
 		};
 	};
 

--- a/src/ts/component/popup/space/joinByLink.tsx
+++ b/src/ts/component/popup/space/joinByLink.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef, useRef, useState, } from 'react';
 import { observer } from 'mobx-react';
 import { Label, Button, Error, Icon, Input } from 'Component';
-import $ from 'jquery';
 import * as I from 'Interface';
 
 const PopupSpaceJoinByLink = observer(forwardRef<{}, I.Popup>(({ param = {}, getId, close }, ref) => {
@@ -12,7 +11,7 @@ const PopupSpaceJoinByLink = observer(forwardRef<{}, I.Popup>(({ param = {}, get
 	const onKeyUp = () => {
 		const v = inputRef.current.getValue();
 
-		$(`#${getId()} .button`).toggleClass('disabled', !v.length);
+		U.Dom.toggleClass(U.Dom.select(`#${getId()} .button`), 'disabled', !v.length);
 		setError('');
 	};
 

--- a/src/ts/component/popup/usecase.tsx
+++ b/src/ts/component/popup/usecase.tsx
@@ -19,12 +19,14 @@ const PopupUsecase = observer(forwardRef<{}, I.PopupUsecase>((props, ref) => {
 	const componentRef = useRef(null);
 
 	const onPage = (page: string, data?: any): void => {
-		const obj = $(`#${getId()}-innerWrap`);
+		const obj = U.Dom.get(`${getId()}-innerWrap`);
 
 		data = data || {};
 		param.data = Object.assign(param.data, { ...data, page });
 
-		obj.scrollTop(0);
+		if (obj) {
+			obj.scrollTop = 0;
+		};
 	};
 
 	const getAuthor = (author: string): string => {

--- a/src/ts/component/selection/provider.tsx
+++ b/src/ts/component/selection/provider.tsx
@@ -54,9 +54,15 @@ const SelectionProvider = observer(forwardRef<SelectionRefProps, Props>((props, 
 	const target = useRef(null);
 	const contextMenuHandler = useRef<ContextMenuHandler | null>(null);
 
+	const scrollHandler = useRef<((e: Event) => void) | null>(null);
+
 	const rebind = () => {
 		unbind();
-		U.Dom.getScrollContainer(keyboard.isPopup()).on('scroll.selection', e => onScroll(e));
+		const container = U.Dom.getScrollContainer(keyboard.isPopup());
+		if (container) {
+			scrollHandler.current = (e: Event) => onScroll(e);
+			container.addEventListener('scroll', scrollHandler.current);
+		};
 	};
 
 	const unbind = () => {
@@ -69,10 +75,12 @@ const SelectionProvider = observer(forwardRef<SelectionRefProps, Props>((props, 
 	};
 	
 	const unbindKeyboard = () => {
-		const isPopup = keyboard.isPopup();
-
 		$(window).off('keydown.selection keyup.selection');
-		U.Dom.getScrollContainer(isPopup).off('scroll.selection');
+		const container = U.Dom.getScrollContainer(keyboard.isPopup());
+		if (container && scrollHandler.current) {
+			container.removeEventListener('scroll', scrollHandler.current);
+			scrollHandler.current = null;
+		};
 	};
 
 	const scrollToElement = (id: string, dir: number) => {
@@ -81,20 +89,24 @@ const SelectionProvider = observer(forwardRef<SelectionRefProps, Props>((props, 
 		if (dir > 0) {
 			focus.scroll(isPopup, id);
 		} else {
-			const node = $(`.focusable.c${U.Common.esc(id)}`);
-			if (!node.length) {
+			const node = document.querySelector(`.focusable.c${U.Common.esc(id)}`) as HTMLElement;
+			if (!node) {
 				return;
 			};
 
 			const container = U.Dom.getScrollContainer(isPopup);
-			const no = node.offset().top;
-			const nh = node.outerHeight();
-			const st = container.scrollTop();
+			if (!container) {
+				return;
+			};
+
+			const no = node.getBoundingClientRect().top;
+			const nh = node.offsetHeight;
+			const st = container.scrollTop;
 			const hh = J.Size.header;
-			const y = no - container.offset().top + st;
+			const y = no - container.getBoundingClientRect().top + st;
 
 			if (y <= st + hh) {
-				container.scrollTop(y - nh - hh);
+				container.scrollTop = y - nh - hh;
 			};
 		};
 	};
@@ -124,7 +136,7 @@ const SelectionProvider = observer(forwardRef<SelectionRefProps, Props>((props, 
 		y.current = e.pageY;
 		hasMoved.current = false;
 		focusedId.current = focused;
-		top.current = startTop.current = container.scrollTop();
+		top.current = startTop.current = container?.scrollTop || 0;
 		idsOnStart.current = new Map(ids.current);
 		cacheChildrenMap.current.clear();
 		cacheNodeMap.current.clear();
@@ -132,8 +144,9 @@ const SelectionProvider = observer(forwardRef<SelectionRefProps, Props>((props, 
 
 		keyboard.disablePreview(true);
 
-		if (container.length) {
-			containerOffset.current = container.offset();
+		if (container) {
+			const containerRect = container.getBoundingClientRect();
+			containerOffset.current = { left: containerRect.left, top: containerRect.top + (container.scrollTop || 0) };
 			x.current -= containerOffset.current.left;
 			y.current -= containerOffset.current.top - top.current;
 		};
@@ -151,7 +164,7 @@ const SelectionProvider = observer(forwardRef<SelectionRefProps, Props>((props, 
 			};
 		};
 		
-		scrollOnMove.onMouseDown({ container });
+		scrollOnMove.onMouseDown({ container: container ? $(container) : undefined });
 		unbindMouse();
 
 		win.on(`mousemove.selection`, e => onMouseMove(e));
@@ -159,11 +172,15 @@ const SelectionProvider = observer(forwardRef<SelectionRefProps, Props>((props, 
 	};
 
 	const initNodes = () => {
-		const list = getPageContainer().find('.selectionTarget');
+		const container = getPageContainer();
+		if (!container) {
+			return;
+		};
 
-		list.each((i: number, item: any) => {
-			item = $(item);
+		const list = container.querySelectorAll('.selectionTarget');
 
+		list.forEach((el: Element) => {
+			const item = $(el);
 			const id = item.attr('data-id');
 			if (!id) {
 				return;
@@ -193,7 +210,7 @@ const SelectionProvider = observer(forwardRef<SelectionRefProps, Props>((props, 
 			return;
 		};
 		
-		top.current = U.Dom.getScrollContainer(isPopup).scrollTop();
+		top.current = U.Dom.getScrollContainer(isPopup)?.scrollTop || 0;
 		checkNodes(e);
 		drawRect(e.pageX, e.pageY);
 		hasMoved.current = true;
@@ -208,12 +225,12 @@ const SelectionProvider = observer(forwardRef<SelectionRefProps, Props>((props, 
 
 		const isPopup = keyboard.isPopup();
 		const container = U.Dom.getScrollContainer(isPopup);
-		const st = container.scrollTop();
+		const st = container?.scrollTop || 0;
 		const d = st > top.current ? 1 : -1;
 		const cx = keyboard.mouse.page.x;
 		const cy = keyboard.mouse.page.y + Math.abs(st - top.current) * d;
 		const rect = getRect(x.current, y.current, cx, cy);
-		const wh = container.height();
+		const wh = container?.clientHeight || 0;
 
 		if ((rect.width < THRESHOLD) && (rect.height < THRESHOLD)) {
 			return;
@@ -612,6 +629,10 @@ const SelectionProvider = observer(forwardRef<SelectionRefProps, Props>((props, 
 		frame.current = raf(() => {
 			$('.isSelectionSelected').removeClass('isSelectionSelected');
 
+			if (!container) {
+				return;
+			};
+
 			for (const i in I.SelectType) {
 				const type = I.SelectType[i];
 				const list = get(type, true);
@@ -621,15 +642,15 @@ const SelectionProvider = observer(forwardRef<SelectionRefProps, Props>((props, 
 				};
 
 				for (const id of list) {
-					container.find(`#selectionTarget-${U.Common.esc(id)}`).addClass('isSelectionSelected');
+					container.querySelector(`#selectionTarget-${U.Common.esc(id)}`)?.classList.add('isSelectionSelected');
 
 					if (type == I.SelectType.Block) {
-						container.find(`#block-${U.Common.esc(id)}`).addClass('isSelectionSelected');
+						container.querySelector(`#block-${U.Common.esc(id)}`)?.classList.add('isSelectionSelected');
 
 						const childrenIds = getChildrenIds(id);
 						if (childrenIds.length) {
 							childrenIds.forEach(childId => {
-								container.find(`#block-${U.Common.esc(childId)}`).addClass('isSelectionSelected');
+								container.querySelector(`#block-${U.Common.esc(childId)}`)?.classList.add('isSelectionSelected');
 							});
 						};
 					};
@@ -644,7 +665,7 @@ const SelectionProvider = observer(forwardRef<SelectionRefProps, Props>((props, 
 		};
 
 		const isPopup = keyboard.isPopup();
-		const st = U.Dom.getScrollContainer(isPopup).scrollTop();
+		const st = U.Dom.getScrollContainer(isPopup)?.scrollTop || 0;
 		const { left, top } = containerOffset.current;
 
 		x -= left;

--- a/src/ts/component/sidebar/page/settings/library.tsx
+++ b/src/ts/component/sidebar/page/settings/library.tsx
@@ -4,6 +4,7 @@ import { Button, Filter, Icon, IconObject, ObjectName, Label } from 'Component';
 import { AutoSizer, CellMeasurer, InfiniteLoader, List, CellMeasurerCache } from 'react-virtualized';
 import * as I from 'Interface';
 import Storage from 'Lib/storage';
+import $ from 'jquery';
 
 const LIMIT = 30;
 const HEIGHT_ITEM = 28;

--- a/src/ts/component/sidebar/page/settings/library.tsx
+++ b/src/ts/component/sidebar/page/settings/library.tsx
@@ -272,10 +272,13 @@ const SidebarPageSettingsLibrary = observer(forwardRef<{}, I.SidebarPageComponen
 	};
 
 	const setActive = (id: string) => {
-		const body = $(bodyRef.current);
+		const body = bodyRef.current;
+		if (!body) {
+			return;
+		};
 
-		body.find('.item.active').removeClass('active');
-		body.find(`#item-${U.Common.esc(id)}`).addClass('active');
+		U.Dom.removeClass(body.querySelector('.item.active'), 'active');
+		U.Dom.addClass(body.querySelector(`#item-${U.Common.esc(id)}`), 'active');
 	};
 
 	const onContext = (item: any) => {

--- a/src/ts/component/sidebar/page/type.tsx
+++ b/src/ts/component/sidebar/page/type.tsx
@@ -41,7 +41,7 @@ const SidebarPageType = observer(forwardRef<{}, I.SidebarPageComponent>((props, 
 	};
 
 	const disableButton = (v: boolean) => {
-		$(buttonSaveRef.current?.getNode()).toggleClass('disabled', v);
+		U.Dom.toggleClass(buttonSaveRef.current?.getNode(), 'disabled', v);
 	};
 
 	const getType = () => {

--- a/src/ts/component/sidebar/page/vault.tsx
+++ b/src/ts/component/sidebar/page/vault.tsx
@@ -150,19 +150,23 @@ const SidebarPageVault = observer(forwardRef<{}, I.SidebarPageComponent>((props,
 		if (!vaultIsMinimal) {
 			return;
 		};
-		
+
 		const items = getItems(true);
 		const node = getNode();
-		const element = node.find(`#item-${U.Common.esc(item.id)}`);
-		const iconWrap = element.find('.iconWrap');
+		const el = node.find(`#item-${U.Common.esc(item.id)}`).get(0) as HTMLElement;
+		const iconWrap = node.find(`#item-${U.Common.esc(item.id)} .iconWrap`);
 		const idx = items.findIndex(it => it.id == item.id) + 1;
 		const caption = (idx >= 1) && (idx <= 9) ? keyboard.getCaption(`space${idx}`) : '';
 		const text = Preview.tooltipCaption(U.String.htmlSpecialChars(item.tooltip || item.name), caption);
 
-		Preview.tooltipShow({ 
-			text, 
-			element, 
-			className: 'fromVault', 
+		if (!el) {
+			return;
+		};
+
+		Preview.tooltipShow({
+			text,
+			element: el,
+			className: 'fromVault',
 			typeX: I.MenuDirection.Left,
 			typeY: I.MenuDirection.Center,
 			offsetX: node.width() / 2 + iconWrap.width() / 2,
@@ -737,8 +741,8 @@ const SidebarPageVault = observer(forwardRef<{}, I.SidebarPageComponent>((props,
 							onMouseEnter={e => Preview.tooltipShow({ 
 								...tooltipParam(),
 								typeY: vaultIsMinimal ? I.MenuDirection.Center : I.MenuDirection.Top,
-								text: translate('popupSettingsAccountPersonalInformationTitle'), 
-								element: $(e.currentTarget),
+								text: translate('popupSettingsAccountPersonalInformationTitle'),
+								element: e.currentTarget as HTMLElement,
 							})}
 							onMouseLeave={() => Preview.tooltipHide(false)}
 						>

--- a/src/ts/component/sidebar/page/widget.tsx
+++ b/src/ts/component/sidebar/page/widget.tsx
@@ -6,6 +6,7 @@ import { Button, Icon, Widget, IconObject, ObjectName, Sync } from 'Component';
 import * as I from 'Interface';
 import * as M from 'Model';
 import Storage from 'Lib/storage';
+import $ from 'jquery';
 
 const SidebarPageWidget = observer(forwardRef<{}, I.SidebarPageComponent>((props, ref) => {
 

--- a/src/ts/component/sidebar/preview.tsx
+++ b/src/ts/component/sidebar/preview.tsx
@@ -61,8 +61,8 @@ const SidebarLayoutPreview = observer(forwardRef<RefProps, I.SidebarPageComponen
 		const sidebarRight = sidebar.rightPanelGetNode(isPopup);
 
 		return {
-			width: container.width() - sidebarLeft.outerWidth() - sidebarRight.outerWidth(),
-			height: container.height(),
+			width: (container?.clientWidth ?? 0) - sidebarLeft.outerWidth() - sidebarRight.outerWidth(),
+			height: container?.clientHeight ?? 0,
 		};
 	};
 

--- a/src/ts/component/sidebar/section/object/relation.tsx
+++ b/src/ts/component/sidebar/section/object/relation.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, useEffect, useRef } from 'react';
 import { observer } from 'mobx-react';
 import { Cell, Icon } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const PREFIX = 'sidebarObjectRelation';
 

--- a/src/ts/component/sidebar/section/type/relation.tsx
+++ b/src/ts/component/sidebar/section/type/relation.tsx
@@ -134,12 +134,12 @@ const SidebarSectionTypeRelation = observer(forwardRef<I.SidebarSectionRef, I.Si
 	const onSortStart = (e: any) => {
 		keyboard.disableSelection(true);
 		setActive(e.active);
-		U.Dom.getScrollContainer(isPopup).addClass('isDraggingProperty');
+		U.Dom.getScrollContainer(isPopup)?.classList.add('isDraggingProperty');
 	};
 
 	const onSortCancel = () => {
 		keyboard.disableSelection(false);
-		U.Dom.getScrollContainer(isPopup).removeClass('isDraggingProperty');
+		U.Dom.getScrollContainer(isPopup)?.classList.remove('isDraggingProperty');
 		setActive(null);
 	};
 

--- a/src/ts/component/sidebar/section/type/relation.tsx
+++ b/src/ts/component/sidebar/section/type/relation.tsx
@@ -6,6 +6,7 @@ import { SortableContext, verticalListSortingStrategy, sortableKeyboardCoordinat
 import { restrictToVerticalAxis, restrictToFirstScrollableAncestor } from '@dnd-kit/modifiers';
 import { CSS } from '@dnd-kit/utilities';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const SidebarSectionTypeRelation = observer(forwardRef<I.SidebarSectionRef, I.SidebarSectionComponent>((props, ref) => {
 

--- a/src/ts/component/sidebar/section/type/relation.tsx
+++ b/src/ts/component/sidebar/section/type/relation.tsx
@@ -200,7 +200,7 @@ const SidebarSectionTypeRelation = observer(forwardRef<I.SidebarSectionRef, I.Si
 		const keys = U.Object.getTypeRelationKeys(object.id).concat('description');
 		const ids = list.data.map(it => it.id);
 
-		S.Menu.open('relationSuggest', { 
+		S.Menu.open('relationSuggest', {
 			element: $(e.currentTarget),
 			horizontal: I.MenuDirection.Center,
 			className: 'fixed',

--- a/src/ts/component/sidebar/section/type/template.tsx
+++ b/src/ts/component/sidebar/section/type/template.tsx
@@ -42,7 +42,7 @@ const SidebarSectionTypeTemplate = observer(forwardRef<I.SidebarSectionRef, I.Si
 
 	const onMore = (e: any, template: any) => {
 		const item = U.Common.objectCopy(template);
-		const node = $(`#sidebarRight #preview-${U.Common.esc(item.id)}`);
+		const node = U.Dom.select(`#sidebarRight #preview-${U.Common.esc(item.id)}`);
 
 		e.preventDefault();
 		e.stopPropagation();
@@ -64,8 +64,8 @@ const SidebarSectionTypeTemplate = observer(forwardRef<I.SidebarSectionRef, I.Si
 				subIds: J.Menu.dataviewTemplate,
 				className: 'fixed',
 				classNameWrap: 'fromSidebar',
-				onOpen: () => node.addClass('active'),
-				onClose: () => node.removeClass('active'),
+				onOpen: () => U.Dom.addClass(node, 'active'),
+				onClose: () => U.Dom.removeClass(node, 'active'),
 				data: {
 					template: item,
 					isView: false,

--- a/src/ts/component/sidebar/section/type/template.tsx
+++ b/src/ts/component/sidebar/section/type/template.tsx
@@ -4,6 +4,7 @@ import { Title, Icon, PreviewObject, EmptySearch } from 'Component';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Navigation, Mousewheel, Pagination } from 'swiper/modules';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const SidebarSectionTypeTemplate = observer(forwardRef<I.SidebarSectionRef, I.SidebarSectionComponent>((props, ref) => {
 

--- a/src/ts/component/util/deleted.tsx
+++ b/src/ts/component/util/deleted.tsx
@@ -51,7 +51,9 @@ const Deleted = forwardRef<HTMLDivElement, Props>(({
 	const resize = () => {
 		const container = U.Dom.getPageContainer(isPopup);
 
-		$(nodeRef.current).css({ height: container.height() });
+		if (nodeRef.current && container) {
+			nodeRef.current.style.height = `${container.clientHeight}px`;
+		};
 	};
 
 	useEffect(() => {

--- a/src/ts/component/util/icon.tsx
+++ b/src/ts/component/util/icon.tsx
@@ -1,5 +1,4 @@
 import React, { MouseEvent, forwardRef, useRef, useEffect } from 'react';
-import $ from 'jquery';
 import { motion, AnimatePresence } from 'motion/react';
 import { getIcon } from './icons';
 import * as I from 'Interface';
@@ -72,7 +71,7 @@ const Icon = forwardRef<HTMLDivElement, Props>(({
 		const t = Preview.tooltipCaption(text, caption);
 
 		if (t) {
-			Preview.tooltipShow({ ...tooltipParam, text: t, element: $(nodeRef.current) });
+			Preview.tooltipShow({ ...tooltipParam, text: t, element: nodeRef.current });
 		};
 
 		onMouseEnter?.(e);

--- a/src/ts/component/util/iconObject.tsx
+++ b/src/ts/component/util/iconObject.tsx
@@ -160,7 +160,7 @@ const IconObject = observer(forwardRef<IconObjectRefProps, Props>((props, ref) =
 		const t = Preview.tooltipCaption(text, caption);
 		
 		if (t) {
-			Preview.tooltipShow({ ...tooltipParam, text: t, element: $(nodeRef.current) });
+			Preview.tooltipShow({ ...tooltipParam, text: t, element: nodeRef.current });
 		};
 
 		if (canEdit && U.Object.isTaskLayout(object.layout)) {

--- a/src/ts/component/util/label.tsx
+++ b/src/ts/component/util/label.tsx
@@ -50,7 +50,7 @@ const Label: FC<Props> = ({
 		const t = Preview.tooltipCaption(text, caption);
 
 		if (t) {
-			Preview.tooltipShow({ ...tooltipParam, text: t, element: $(nodeRef.current) });
+			Preview.tooltipShow({ ...tooltipParam, text: t, element: nodeRef.current });
 		};
 
 		onMouseEnter?.(e);

--- a/src/ts/component/util/layoutPlug.tsx
+++ b/src/ts/component/util/layoutPlug.tsx
@@ -26,7 +26,7 @@ const LayoutPlug = forwardRef<{}, Props>(({
 		const container = U.Dom.getPageFlexContainer(isPopup);
 		const sidebarRight = sidebar.getData(I.SidebarPanel.Right, isPopup);
 
-		return container.width() - (sidebarRight.isClosed ? 0 : sidebarRight.width) - sidebar.getDummyWidth();
+		return (container?.clientWidth || 0) - (sidebarRight.isClosed ? 0 : sidebarRight.width) - sidebar.getDummyWidth();
 	};
 
 	const getWidth = () => {

--- a/src/ts/component/util/loader.tsx
+++ b/src/ts/component/util/loader.tsx
@@ -46,7 +46,9 @@ const Loader = forwardRef<HTMLDivElement, Props>(({
 		};
 
 		const container = U.Dom.getScrollContainer(isPopup);
-		$(nodeRef.current).css({ height: container.height() });
+		if (nodeRef.current && container) {
+			nodeRef.current.style.height = `${container.clientHeight}px`;
+		};
 	};
 
 	useEffect(() => {

--- a/src/ts/component/util/menu/optionSelect.tsx
+++ b/src/ts/component/util/menu/optionSelect.tsx
@@ -549,10 +549,10 @@ const OptionSelect = observer(forwardRef<OptionSelectRefProps, Props>((props, re
 			setActive(item, false);
 		};
 
-		Preview.tooltipShow({
-			text: item.name,
-			element: $(nodeRef.current).find(`#item-${U.Common.esc(item.id)}`)
-		});
+		const el = nodeRef.current?.querySelector(`#item-${U.Common.esc(item.id)}`) as HTMLElement;
+		if (el) {
+			Preview.tooltipShow({ text: item.name, element: el });
+		};
 	};
 
 	const onMouseEnter = (e: MouseEvent, item: SelectItem): void => {
@@ -560,10 +560,10 @@ const OptionSelect = observer(forwardRef<OptionSelectRefProps, Props>((props, re
 			setActive(item, false);
 		};
 
-		Preview.tooltipShow({
-			text: item.name,
-			element: $(nodeRef.current).find(`#item-${U.Common.esc(item.id)}`)
-		});
+		const el = nodeRef.current?.querySelector(`#item-${U.Common.esc(item.id)}`) as HTMLElement;
+		if (el) {
+			Preview.tooltipShow({ text: item.name, element: el });
+		};
 	};
 
 	const onMouseLeave = (): void => {

--- a/src/ts/component/util/progressBar.tsx
+++ b/src/ts/component/util/progressBar.tsx
@@ -1,5 +1,4 @@
 import React, { FC, MouseEvent } from 'react';
-import $ from 'jquery';
 import { Label } from 'Component';
 
 interface Segment {
@@ -36,7 +35,7 @@ const ProgressBar: FC<Props> = ({
 		const t = Preview.tooltipCaption(name, caption);
 
 		if (t) {
-			Preview.tooltipShow({ text: t, element: $(e.currentTarget) });
+			Preview.tooltipShow({ text: t, element: e.currentTarget as HTMLElement });
 		};
 	};
 

--- a/src/ts/component/util/sync.tsx
+++ b/src/ts/component/util/sync.tsx
@@ -2,7 +2,6 @@ import React, { forwardRef, useRef, MouseEvent } from 'react';
 import { observer } from 'mobx-react';
 import { Icon } from 'Component';
 import * as I from 'Interface';
-import $ from 'jquery';
 
 interface Props {
 	id?: string;
@@ -50,7 +49,7 @@ const Sync = observer(forwardRef<HTMLDivElement, Props>(({
 			id={id}
 			className={cn.join(' ')}
 			onClick={onClickHandler}
-			onMouseEnter={e => Preview.tooltipShow({ text: tooltip, element: $(e.currentTarget), typeY: I.MenuDirection.Bottom })}
+			onMouseEnter={e => Preview.tooltipShow({ text: tooltip, element: e.currentTarget as HTMLElement, typeY: I.MenuDirection.Bottom })}
 			onMouseLeave={() => Preview.tooltipHide(false)}
 		>
 			<Icon name={iconInfo.name} color={iconInfo.color} className={iconCn.join(' ')} />

--- a/src/ts/component/util/sync.tsx
+++ b/src/ts/component/util/sync.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, useRef, MouseEvent } from 'react';
 import { observer } from 'mobx-react';
 import { Icon } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 interface Props {
 	id?: string;

--- a/src/ts/component/util/updateBanner.tsx
+++ b/src/ts/component/util/updateBanner.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, useCallback, useEffect, useRef } from 'react';
 import { observer } from 'mobx-react';
 import { Icon, Label, Button } from 'Component';
 import Storage from 'Lib/storage';
+import $ from 'jquery';
 
 const STORAGE_KEY = 'updateBanner';
 

--- a/src/ts/component/widget/object.tsx
+++ b/src/ts/component/widget/object.tsx
@@ -6,6 +6,7 @@ import { restrictToVerticalAxis, restrictToFirstScrollableAncestor } from '@dnd-
 import { CSS } from '@dnd-kit/utilities';
 import { IconObject, ObjectName, ChatCounter, Icon } from 'Component';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const WidgetObject = observer(forwardRef<{}, I.WidgetComponent>((props, ref) => {
 

--- a/src/ts/component/widget/space.tsx
+++ b/src/ts/component/widget/space.tsx
@@ -4,6 +4,7 @@ import { Icon, IconObject, ObjectName, Label } from 'Component';
 import MemberCnt from 'Component/util/memberCnt';
 import ChatCounter from 'Component/util/chatCounter';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const WidgetSpace = observer(forwardRef<{}, I.WidgetComponent>((props, ref) => {
 

--- a/src/ts/component/widget/tree/item.tsx
+++ b/src/ts/component/widget/tree/item.tsx
@@ -3,6 +3,7 @@ import { observer } from 'mobx-react';
 import { DropTarget, Icon, IconObject, ObjectName, Label, ChatCounter } from 'Component';
 import * as I from 'Interface';
 import Storage from 'Lib/storage';
+import $ from 'jquery';
 
 interface Props extends I.WidgetTreeItem {
 	index: number;

--- a/src/ts/component/widget/view/board/group.tsx
+++ b/src/ts/component/widget/view/board/group.tsx
@@ -4,6 +4,7 @@ import { Icon, Cell } from 'Component';
 import Item from './item';
 import * as I from 'Interface';
 import Storage from 'Lib/storage';
+import $ from 'jquery';
 
 const ANIMATION = 200;
 

--- a/src/ts/component/widget/view/calendar/index.tsx
+++ b/src/ts/component/widget/view/calendar/index.tsx
@@ -76,8 +76,8 @@ const WidgetViewCalendar = observer(forwardRef<WidgetViewCalendarRefProps, I.Wid
 				classNameWrap: 'fromSidebar',
 				horizontal: I.MenuDirection.Center,
 				noFlipX: true,
-				onOpen: () => $(element).addClass('active'),
-				onClose: () => $(element).removeClass('active'),
+				onOpen: () => U.Dom.addClass(U.Dom.select(element), 'active'),
+				onClose: () => U.Dom.removeClass(U.Dom.select(element), 'active'),
 				data: {
 					rootId,
 					blockId: J.Constant.blockId.dataview,

--- a/src/ts/component/widget/view/index.tsx
+++ b/src/ts/component/widget/view/index.tsx
@@ -425,7 +425,7 @@ const WidgetView = observer(forwardRef<WidgetViewRefProps, I.WidgetComponent>((p
 	}, [ searchIds ]);
 
 	useEffect(() => {
-		$(`#widget-${U.Common.esc(parent.id)}`).toggleClass('isEmpty', isEmpty);
+		U.Dom.toggleClass(U.Dom.get(`widget-${U.Common.esc(parent.id)}`), 'isEmpty', isEmpty);
 		checkShowAllButton(subId);
 	});
 

--- a/src/ts/component/widget/view/list/index.tsx
+++ b/src/ts/component/widget/view/list/index.tsx
@@ -7,6 +7,7 @@ import { SortableContext, verticalListSortingStrategy, sortableKeyboardCoordinat
 import { restrictToVerticalAxis, restrictToFirstScrollableAncestor } from '@dnd-kit/modifiers';
 import WidgetListItem from './item';
 import * as I from 'Interface';
+import $ from 'jquery';
 
 const LIMIT = 30;
 const HEIGHT_COMPACT = 28;

--- a/src/ts/interface/common.ts
+++ b/src/ts/interface/common.ts
@@ -335,7 +335,7 @@ export interface PageRef {
 };
 
 export interface TooltipParam {
-	element?: any;
+	element?: HTMLElement;
 	title?: string;
 	text?: string;
 	caption?: string;

--- a/src/ts/interface/preview.ts
+++ b/src/ts/interface/preview.ts
@@ -28,7 +28,7 @@ export interface Preview {
 	classNameWrap?: string;
 	target?: string; /** object ID or URL */
 	object?: any;
-	element?: JQuery<HTMLElement>;
+	element?: HTMLElement | string;
 	rect?: any;
 	range?: I.TextRange;
 	marks?: I.Mark[];

--- a/src/ts/lib/focus.ts
+++ b/src/ts/lib/focus.ts
@@ -195,15 +195,20 @@ class Focus {
 		};
 
 		const container = U.Dom.getScrollContainer(isPopup);
-		const ch = container.height();
-		const st = container.scrollTop();
+		if (!container) {
+			return;
+		};
+
+		const ch = container.clientHeight;
+		const st = container.scrollTop;
 		const { header } = J.Size;
-		const y = rect.top + st - container.offset().top;
+		const containerRect = container.getBoundingClientRect();
+		const y = rect.top + st - containerRect.top;
 		const top = st + header;
 		const bottom = st + ch;
 
 		if ((y < top) || (y > bottom)) {
-			container.scrollTop(Math.max(0, y - ch / 2));
+			container.scrollTop = Math.max(0, y - ch / 2);
 		};
 	};
 

--- a/src/ts/lib/keyboard.ts
+++ b/src/ts/lib/keyboard.ts
@@ -104,7 +104,7 @@ class Keyboard {
 		const { hideSidebar } = S.Common;
 		const isPopup = this.isPopup();
 		const container = U.Dom.getPageContainer(isPopup);
-		const cw = container.width();
+		const cw = container?.clientWidth || 0;
 		const data = sidebar.getData(I.SidebarPanel.Left, false);
 		const threshold = J.Size.sidebar.left.threshold.close;
 
@@ -1301,7 +1301,8 @@ class Keyboard {
 		};
 
 		const menuId = isChat ? 'searchChat' : 'searchText';
-		const element = U.Dom.getScrollContainer(isPopup).find('#header .side.center');
+		const el = U.Dom.getScrollContainer(isPopup)?.querySelector('#header .side.center');
+		const element = el ? $(el) : null;
 		const menuParam: Partial<I.MenuParam> = {
 			element,
 			horizontal: I.MenuDirection.Center,

--- a/src/ts/lib/onboarding.ts
+++ b/src/ts/lib/onboarding.ts
@@ -179,15 +179,16 @@ class Onboarding {
 
 			const recalcRect = () => {
 				const container = U.Dom.getScrollContainer(isPopup);
-				const height = container.height();
-				const width = container.width();
+				const height = container?.clientHeight ?? 0;
+				const width = container?.clientWidth ?? 0;
 				const scrollTop = $(window).scrollTop();
+				const bounds = container?.getBoundingClientRect();
 
 				let offset = { left: 0, top: 0 };
 				let rect: any = { x: 0, y: 0, width: 0, height: 0 };
-	
-				if (container.length) {
-					offset = container.offset();
+
+				if (container && bounds) {
+					offset = { left: bounds.left, top: bounds.top };
 				};
 	
 				switch (param.containerVertical) {

--- a/src/ts/lib/onboarding.ts
+++ b/src/ts/lib/onboarding.ts
@@ -1,6 +1,7 @@
 import * as Docs from 'Docs';
 import * as I from 'Interface';
 import Storage from 'Lib/storage';
+import $ from 'jquery';
 
 /**
  * Onboarding manages the user onboarding and tutorial flows.

--- a/src/ts/lib/preview.ts
+++ b/src/ts/lib/preview.ts
@@ -1,13 +1,8 @@
-import $ from 'jquery';
 import * as I from 'Interface';
 
 const BORDER = 12;
 const DELAY_TOOLTIP = 650;
 const DELAY_PREVIEW = 300;
-
-/**
- * Preview class for handling tooltips, previews, and toasts.
- */
 
 class Preview {
 
@@ -21,12 +16,13 @@ class Preview {
 	isPreviewOpen = false;
 	isTooltipOpen = false;
 
-	/**
-	 * Displays a tooltip with the given parameters.
-	 * @param {Partial<I.TooltipParam>} param - Tooltip parameters.
-	 */
+	private clickTooltipHandler: ((e: Event) => void) | null = null;
+	private previewLeaveHandler: ((e: Event) => void) | null = null;
+	private toastEnterHandler: ((e: Event) => void) | null = null;
+	private toastLeaveHandler: ((e: Event) => void) | null = null;
+
 	tooltipShow (param: Partial<I.TooltipParam>) {
-		const { element } = param;
+		const el = param.element instanceof HTMLElement ? param.element : null;
 		const typeX = Number(param.typeX) || I.MenuDirection.Center;
 		const typeY = Number(param.typeY) || I.MenuDirection.Top;
 		const offsetX = Number(param.offsetX) || 0;
@@ -37,7 +33,7 @@ class Preview {
 			delay = param.delay;
 		};
 
-		if (!element.length || keyboard.isResizing) {
+		if (!el || keyboard.isResizing) {
 			return;
 		};
 
@@ -48,30 +44,40 @@ class Preview {
 
 		window.clearTimeout(this.timeout.tooltip);
 		this.timeout.tooltip = window.setTimeout(() => {
-			const win = $(window);
-			const obj = $('#tooltipContainer');
-			const { left, top } = element.offset();
-			const st = win.scrollTop(); 
-			const ew = element.outerWidth();
-			const eh = element.outerHeight();
+			const obj = U.Dom.get('tooltipContainer');
+			if (!obj) {
+				return;
+			};
+
+			const rect = el.getBoundingClientRect();
+			const st = window.scrollY;
+			const ew = el.offsetWidth;
+			const eh = el.offsetHeight;
 			const { ww } = U.Dom.getWindowDimensions();
-			const node = $(`<div class="tooltip anim"><div class="txt">${text}</div></div>`);
+
+			const node = document.createElement('div');
+			node.className = 'tooltip anim';
+			node.innerHTML = `<div class="txt">${text}</div>`;
 
 			if (param.className) {
-				node.addClass(param.className);
+				U.Dom.addClass(node, param.className);
 			};
 
 			if (param.title) {
-				node.prepend(`<div class="title">${param.title}</div>`);
+				const titleEl = document.createElement('div');
+				titleEl.className = 'title';
+				titleEl.innerHTML = param.title;
+				node.prepend(titleEl);
 			};
 
-			obj.html('').append(node);
-			
-			const ow = node.outerWidth();
-			const oh = node.outerHeight();
+			obj.innerHTML = '';
+			obj.appendChild(node);
 
-			let x = left + offsetX;
-			let y = top + offsetY;
+			const ow = node.offsetWidth;
+			const oh = node.offsetHeight;
+
+			let x = rect.left + offsetX;
+			let y = rect.top + st + offsetY;
 
 			switch (typeX) {
 				default:
@@ -96,7 +102,7 @@ class Preview {
 					y -= oh + 6 + st;
 					break;
 				};
-				
+
 				case I.MenuDirection.Bottom: {
 					y += eh + 6 - st;
 					break;
@@ -107,45 +113,48 @@ class Preview {
 					break;
 				};
 			};
-			
+
 			x = Math.max(BORDER, x);
 			x = Math.min(ww - ow - BORDER, x);
 
 			y = Math.max(BORDER, y);
 
-			node.css({ left: x, top: y }).addClass('show');
+			Object.assign(node.style, { left: `${x}px`, top: `${y}px` });
+			U.Dom.addClass(node, 'show');
 
 			window.clearTimeout(this.timeout.delay);
 			this.timeout.delay = window.setTimeout(() => this.delayTooltip = delay, 500);
 			this.delayTooltip = 100;
 
-			win.off('click.tooltip').on('click.tooltip', () => {
-				this.tooltipHide(true);
+			if (this.clickTooltipHandler) {
+				window.removeEventListener('click', this.clickTooltipHandler);
+			};
 
-				win.off('click.tooltip');
-			});
+			this.clickTooltipHandler = () => {
+				this.tooltipHide(true);
+				window.removeEventListener('click', this.clickTooltipHandler);
+				this.clickTooltipHandler = null;
+			};
+
+			window.addEventListener('click', this.clickTooltipHandler);
 
 		}, this.delayTooltip);
 
 		this.isTooltipOpen = true;
 	};
 
-	/**
-	 * Hides the tooltip, if any is being shown.
-	 * @param {boolean} [force] - If true, hides the tooltip immediately.
-	 */
 	tooltipHide (force?: boolean) {
 		if (!this.isTooltipOpen) {
 			return;
 		};
 
-		const obj = $('.tooltip');
+		const tooltips = U.Dom.selectAll('.tooltip');
 
 		if (force) {
-			obj.removeClass('anim');
+			tooltips.forEach(el => U.Dom.removeClass(el, 'anim'));
 		};
 
-		obj.removeClass('show');
+		tooltips.forEach(el => U.Dom.removeClass(el, 'show'));
 
 		window.clearTimeout(this.timeout.tooltip);
 		window.clearTimeout(this.timeout.delay);
@@ -153,12 +162,6 @@ class Preview {
 		this.isTooltipOpen = false;
 	};
 
-	/**
-	 * Combines text and caption for tooltip display.
-	 * @param {string} text - The main text.
-	 * @param {string} caption - The caption text.
-	 * @returns {string} The combined tooltip HTML.
-	 */
 	tooltipCaption (text: string, caption: string): string {
 		const t = [];
 		if (text) {
@@ -170,14 +173,10 @@ class Preview {
 		return t.length ? t.join(' ') : '';
 	};
 
-	/**
-	 * Displays a preview popup with the given parameters.
-	 * @param {I.Preview} param - Preview parameters.
-	 */
 	previewShow (param: I.Preview) {
 		if (
-			keyboard.isPreviewDisabled || 
-			keyboard.isResizing || 
+			keyboard.isPreviewDisabled ||
+			keyboard.isResizing ||
 			keyboard.isDragging
 		) {
 			window.clearTimeout(this.timeout.preview);
@@ -186,39 +185,45 @@ class Preview {
 
 		param.type = param.type || I.PreviewType.Default;
 		param.delay = (undefined === param.delay) ? DELAY_PREVIEW : param.delay;
-		
-		const { rect, passThrough } = param;
-		const element = $(param.element);
-		const obj = $('#preview');
 
-		if (!element && !rect) {
+		const { rect, passThrough } = param;
+		const el = param.element instanceof HTMLElement ? param.element : (typeof param.element === 'string' ? U.Dom.select(param.element) : null);
+		const obj = U.Dom.get('preview');
+
+		if (!el && !rect) {
 			return;
 		};
 
 		if (rect) {
 			param = Object.assign(param, rect);
-		} else 
-		if (element && element.length) {
-			const offset = element.offset();
+		} else
+		if (el) {
+			const elRect = el.getBoundingClientRect();
 
-			param = Object.assign(param, { 
-				x: offset.left, 
-				y: offset.top, 
-				width: element.outerWidth(), 
-				height: element.outerHeight(),
+			param = Object.assign(param, {
+				x: elRect.left,
+				y: elRect.top + window.scrollY,
+				width: el.offsetWidth,
+				height: el.offsetHeight,
 			});
 		};
 
-		if (element) {
-			element.off('mouseleave.preview').on('mouseleave.preview', () => {
-				window.clearTimeout(this.timeout.preview); 
+		if (el) {
+			if (this.previewLeaveHandler) {
+				el.removeEventListener('mouseleave', this.previewLeaveHandler);
+			};
+
+			this.previewLeaveHandler = () => {
+				window.clearTimeout(this.timeout.preview);
 				if (rect) {
 					this.previewHide(true);
 				};
-			});
+			};
+
+			el.addEventListener('mouseleave', this.previewLeaveHandler);
 		};
 
-		obj.toggleClass('passThrough', Boolean(passThrough));
+		U.Dom.toggleClass(obj, 'passThrough', Boolean(passThrough));
 		this.previewHide(true);
 
 		if (param.delay) {
@@ -231,20 +236,19 @@ class Preview {
 		this.isPreviewOpen = true;
 	};
 
-	/**
-	 * Hides preview, if any is being shown.
-	 * @param force - hide the preview immediately, without 250ms delay
-	 */
 	previewHide (force?: boolean) {
 		if (!this.isPreviewOpen) {
 			return;
 		};
 
-		const obj = $('#preview');
+		const obj = U.Dom.get('preview');
 		const cb = () => {
-			obj.hide();
-			obj.removeClass('anim top bottom withImage').css({ transform: '' });
-			
+			if (obj) {
+				obj.style.display = 'none';
+				U.Dom.removeClass(obj, 'anim', 'top', 'bottom', 'withImage');
+				obj.style.transform = '';
+			};
+
 			S.Common.previewClear();
 		};
 
@@ -253,17 +257,15 @@ class Preview {
 		if (force) {
 			cb();
 		} else {
-			obj.css({ opacity: 0, transform: 'translateY(0%)' });
+			if (obj) {
+				Object.assign(obj.style, { opacity: '0', transform: 'translateY(0%)' });
+			};
 			this.timeout.preview = window.setTimeout(() => cb(), DELAY_PREVIEW);
 		};
 
 		this.isPreviewOpen = false;
 	};
 
-	/**
-	 * Show a toast (an on-screen short lived notification)
-	 * @param param 
-	 */
 	toastShow (param: I.Toast) {
 		const setTimeout = () => {
 			window.clearTimeout(this.timeout.toast);
@@ -272,33 +274,42 @@ class Preview {
 
 		S.Common.toastSet(param);
 
-		const obj = $('#toast');
+		const obj = U.Dom.get('toast');
 
 		setTimeout();
-		obj.off('mouseenter.toast mouseleave.toast');
-		obj.on('mouseenter.toast', () => window.clearTimeout(this.timeout.toast));
-		obj.on('mouseleave.toast', () => setTimeout());
+
+		if (obj) {
+			if (this.toastEnterHandler) {
+				obj.removeEventListener('mouseenter', this.toastEnterHandler);
+			};
+			if (this.toastLeaveHandler) {
+				obj.removeEventListener('mouseleave', this.toastLeaveHandler);
+			};
+
+			this.toastEnterHandler = () => window.clearTimeout(this.timeout.toast);
+			this.toastLeaveHandler = () => setTimeout();
+
+			obj.addEventListener('mouseenter', this.toastEnterHandler);
+			obj.addEventListener('mouseleave', this.toastLeaveHandler);
+		};
 	};
 
-	/**
-	 * show hide any toast being shown
-	 * @param force - hide the preview immediately, without 250ms delay
-	 */
 	toastHide (force?: boolean) {
-		const obj = $('#toast');
+		const obj = U.Dom.get('toast');
 
-		obj.css({ opacity: 0, transform: 'scale3d(0.7,0.7,1)' });
+		if (obj) {
+			Object.assign(obj.style, { opacity: '0', transform: 'scale3d(0.7,0.7,1)' });
+		};
 
 		window.clearTimeout(this.timeout.toast);
 		this.timeout.toast = window.setTimeout(() => {
-			obj.hide();
+			if (obj) {
+				obj.style.display = 'none';
+			};
 			S.Common.toastClear();
 		}, force ? 0 : 250);
 	};
 
-	/**
-	 * Force hides all tooltips, previews, and toasts.
-	 */
 	hideAll () {
 		this.tooltipHide(true);
 		this.previewHide(true);

--- a/src/ts/lib/sidebar.ts
+++ b/src/ts/lib/sidebar.ts
@@ -598,11 +598,11 @@ class Sidebar {
 
 		const pageFlex = U.Dom.getPageFlexContainer(isPopup);
 		const page = U.Dom.getPageContainer(isPopup);
-		const header = page.find('#header');
-		const footer = page.find('#footer');
-		const loader = page.find('#loader');
+		const header = page?.querySelector('#header') as HTMLElement;
+		const footer = page?.querySelector('#footer') as HTMLElement;
+		const loader = page?.querySelector('#loader') as HTMLElement;
 
-		if (!pageFlex || !pageFlex.length) {
+		if (!pageFlex) {
 			return;
 		};
 
@@ -653,50 +653,63 @@ class Sidebar {
 		widthRight = Number(widthRight) || 0;
 
 		const container = U.Dom.getScrollContainer(isPopup);
-		const pageWidth = pageFlex.width() - widthLeft - widthRight;
+		const pageWidth = (pageFlex?.clientWidth ?? 0) - widthLeft - widthRight;
 		const ho = isMainHistory || isPopupMainHistory ? J.Size.history.panel : 0;
 		const hw = pageWidth - ho;
-		const pageCss: any = { width: pageWidth };
+		const pageCss: any = { width: `${pageWidth}px` };
 		const offset = singleTab && !alwaysShowTabs ? 0 : 8;
 
 		if (!isPopup) {
-			pageCss.height = U.Dom.getAppContainerHeight() - offset;
+			pageCss.height = `${U.Dom.getAppContainerHeight() - offset}px`;
 		};
 
-		header.css({ width: '' }).toggleClass('sidebarAnimation', animate);
-		header.css({ width: hw });
+		if (header) {
+			header.style.width = '';
+			U.Dom.toggleClass(header, 'sidebarAnimation', animate);
+			header.style.width = `${hw}px`;
+		};
 
-		footer.css({ width: '' }).toggleClass('sidebarAnimation', animate);
-		footer.css({ width: hw });
+		if (footer) {
+			footer.style.width = '';
+			U.Dom.toggleClass(footer, 'sidebarAnimation', animate);
+			footer.style.width = `${hw}px`;
+		};
 
-		page.toggleClass('sidebarAnimation', animate);
-		page.css(pageCss);
-		pageFlex.toggleClass('withSidebarRight', !!widthRight);
+		if (page) {
+			U.Dom.toggleClass(page, 'sidebarAnimation', animate);
+			Object.assign(page.style, pageCss);
+		};
 
-		loader.css({ width: pageWidth, right: 0 });
+		U.Dom.toggleClass(pageFlex, 'withSidebarRight', !!widthRight);
+
+		if (loader) {
+			Object.assign(loader.style, { width: `${pageWidth}px`, right: '0px' });
+		};
 
 		if (!isPopup) {
-			pageFlex.toggleClass('sidebarAnimation', animate);
+			U.Dom.toggleClass(pageFlex, 'sidebarAnimation', animate);
 
 			dummyLeft.toggleClass('sidebarAnimation', animate);
 			dummyLeft.css({ width: widthLeft });
 
 			subPageWrapperLeft.toggleClass('withSidebarLeft', !isLeftClosed);
-			
-			pageFlex.toggleClass('withSidebarTotalLeft', !!widthLeft);
-			pageFlex.toggleClass('withSidebarLeft', !isLeftClosed);
-			pageFlex.toggleClass('withSidebarSubLeft', !isSubLeftClosed);
 
-			header.toggleClass('withSidebarTotalLeft', !!widthLeft);
-			header.toggleClass('withSidebarLeft', !isLeftClosed);
-			header.toggleClass('withSidebarSubLeft', !isSubLeftClosed);
+			U.Dom.toggleClass(pageFlex, 'withSidebarTotalLeft', !!widthLeft);
+			U.Dom.toggleClass(pageFlex, 'withSidebarLeft', !isLeftClosed);
+			U.Dom.toggleClass(pageFlex, 'withSidebarSubLeft', !isSubLeftClosed);
+
+			if (header) {
+				U.Dom.toggleClass(header, 'withSidebarTotalLeft', !!widthLeft);
+				U.Dom.toggleClass(header, 'withSidebarLeft', !isLeftClosed);
+				U.Dom.toggleClass(header, 'withSidebarSubLeft', !isSubLeftClosed);
+			};
 
 			pageWrapperLeft.toggleClass('sidebarAnimation', animate);
 
 			subPageWrapperLeft.toggleClass('sidebarAnimation', animate);
 			subPageWrapperLeft.toggleClass('withSidebarLeft', !isLeftClosed);
 		} else {
-			objRight.css({ height: container.height() });
+			objRight.css({ height: container?.clientHeight ?? 0 });
 		};
 
 		$(window).trigger('sidebarResize');

--- a/src/ts/lib/util/dom.ts
+++ b/src/ts/lib/util/dom.ts
@@ -4,6 +4,50 @@ import * as I from 'Interface';
 
 class UtilDom {
 
+	get (id: string): HTMLElement | null {
+		return document.getElementById(id);
+	};
+
+	select (selector: string, root: ParentNode = document): HTMLElement | null {
+		return root.querySelector(selector);
+	};
+
+	selectAll (selector: string, root: ParentNode = document): HTMLElement[] {
+		return Array.from(root.querySelectorAll(selector));
+	};
+
+	addClass (el: HTMLElement, ...names: string[]) {
+		if (el) {
+			el.classList.add(...names);
+		};
+	};
+
+	removeClass (el: HTMLElement, ...names: string[]) {
+		if (el) {
+			el.classList.remove(...names);
+		};
+	};
+
+	hasClass (el: HTMLElement, name: string): boolean {
+		return el ? el.classList.contains(name) : false;
+	};
+
+	toggleClass (el: HTMLElement, name: string, force?: boolean) {
+		if (el) {
+			el.classList.toggle(name, force);
+		};
+	};
+
+	contentWidth (el: HTMLElement): number {
+		const style = getComputedStyle(el);
+		return el.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight);
+	};
+
+	contentHeight (el: HTMLElement): number {
+		const style = getComputedStyle(el);
+		return el.clientHeight - parseFloat(style.paddingTop) - parseFloat(style.paddingBottom);
+	};
+
 	/**
 	 * Returns the current selection range in the window.
 	 * @returns {Range|null} The selection range or null if none.

--- a/src/ts/lib/util/dom.ts
+++ b/src/ts/lib/util/dom.ts
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import raf from 'raf';
 import * as I from 'Interface';
 
@@ -95,7 +94,7 @@ class UtilDom {
 	 * Clears the current selection in the document.
 	 */
 	clearSelection () {
-		$(document.activeElement).trigger('blur');
+		(document.activeElement as HTMLElement)?.blur();
 		const selection = window.getSelection();
 		if (selection) {
 			selection.removeAllRanges();
@@ -111,40 +110,20 @@ class UtilDom {
 		return isPopup ? 'isPopup' : 'isFull';
 	};
 
-	/**
-	 * Returns the scroll container jQuery object depending on popup state.
-	 * @param {boolean} isPopup - Whether the context is a popup.
-	 * @returns {JQuery<HTMLElement>} The scroll container.
-	 */
-	getScrollContainer (isPopup: boolean) {
-		return $(`#page.${this.getContainerClassName(isPopup)}`);
+	getScrollContainer (isPopup: boolean): HTMLElement | null {
+		return this.select(`#page.${this.getContainerClassName(isPopup)}`);
 	};
 
-	/**
-	 * Returns the scroll top position of the scroll container.
-	 * @param {boolean} isPopup - Whether the context is a popup.
-	 * @returns {number} The scroll top position.
-	 */
-	getScrollContainerTop (isPopup: boolean) {
-		return Math.ceil(this.getScrollContainer(isPopup).scrollTop());
+	getScrollContainerTop (isPopup: boolean): number {
+		return Math.ceil(this.getScrollContainer(isPopup)?.scrollTop ?? 0);
 	};
 
-	/**
-	 * Returns the page flex container jQuery object depending on popup state.
-	 * @param {boolean} isPopup - Whether the context is a popup.
-	 * @returns {JQuery<HTMLElement>} The page flex container.
-	 */
-	getPageFlexContainer (isPopup: boolean) {
-		return $(`#pageFlex.${this.getContainerClassName(isPopup)}`);
+	getPageFlexContainer (isPopup: boolean): HTMLElement | null {
+		return this.select(`#pageFlex.${this.getContainerClassName(isPopup)}`);
 	};
 
-	/**
-	 * Returns the page container jQuery object depending on popup state.
-	 * @param {boolean} isPopup - Whether the context is a popup.
-	 * @returns {JQuery<HTMLElement>} The page container.
-	 */
-	getPageContainer (isPopup: boolean) {
-		return $(`#page.${this.getContainerClassName(isPopup)}`);
+	getPageContainer (isPopup: boolean): HTMLElement | null {
+		return this.select(`#page.${this.getContainerClassName(isPopup)}`);
 	};
 
 	/**
@@ -186,37 +165,25 @@ class UtilDom {
 	 * @param {boolean} isPopup - Whether the context is a popup.
 	 */
 	triggerResizeEditor (isPopup: boolean) {
-		$(window).trigger(`resize.editor${this.getEventNamespace(isPopup)}`);
+		window.dispatchEvent(new CustomEvent(`resize.editor${this.getEventNamespace(isPopup)}`));
 	};
 
-	/**
-	 * Get width and height of window DOM node
-	 */
 	getWindowDimensions (): { ww: number; wh: number } {
-		const win = $(window);
-		return { ww: win.width(), wh: win.height() };
+		return { ww: window.innerWidth, wh: window.innerHeight };
 	};
 
-	/**
-	 * Returns the max scroll height of a container.
-	 * @param {boolean} isPopup - Whether the context is a popup.
-	 * @returns {number} The max scroll height.
-	 */
 	getMaxScrollHeight (isPopup: boolean): number {
-		const container = this.getScrollContainer(isPopup);
-		if (!container.length) {
+		const el = this.getScrollContainer(isPopup);
+		if (!el) {
 			return 0;
 		};
 
-		const el = container.get(0);
 		return el.scrollHeight - el.clientHeight;
 	};
 
-	/**
-	 * Returns the height of the app container.
-	 */
-	getAppContainerHeight () {
-		return $('#appContainer').height();
+	getAppContainerHeight (): number {
+		const el = this.get('appContainer');
+		return el ? this.contentHeight(el) : 0;
 	};
 
 	/**
@@ -225,15 +192,15 @@ class UtilDom {
 	 * @param {string} v - The value to append.
 	 */
 	addBodyClass (prefix: string, v: string) {
-		const obj = $('html');
+		const el = document.documentElement;
 		const reg = new RegExp(`^${prefix}`);
-		const c = String(obj.attr('class') || '').split(' ').filter(it => !it.match(reg));
+		const c = String(el.className || '').split(' ').filter(it => !it.match(reg));
 
 		if (v) {
 			c.push(U.String.toCamelCase(`${prefix}-${v}`));
 		};
 
-		obj.attr({ class: c.join(' ') });
+		el.className = c.join(' ');
 	};
 
 	/**
@@ -242,11 +209,16 @@ class UtilDom {
 	 * @param {string} css - The CSS string.
 	 */
 	injectCss (id: string, css: string) {
-		const head = $('head');
-		const element = $(`<style id="${id}" type="text/css">${css}</style>`);
+		const existing = this.select(`style#${id}`, document.head);
+		if (existing) {
+			existing.remove();
+		};
 
-		head.find(`style#${id}`).remove();
-		head.append(element);
+		const style = document.createElement('style');
+		style.id = id;
+		style.type = 'text/css';
+		style.textContent = css;
+		document.head.appendChild(style);
 	};
 
 	/**
@@ -298,24 +270,39 @@ class UtilDom {
 	 * Pauses all audio and video elements on the page.
 	 */
 	pauseMedia () {
-		$('audio, video').each((i: number, item: any) => item.pause());
+		this.selectAll('audio, video').forEach((el: HTMLMediaElement) => el.pause());
 	};
 
-	/**
-	 * Attaches click handlers to links in a jQuery object to open URLs or paths.
-	 * @param {any} obj - The jQuery object containing links.
-	 */
 	renderLinks (obj: any) {
-		const links = obj.find('a');
+		if (!obj) {
+			return;
+		};
 
-		links.off('click auxclick');
-		links.on('auxclick', e => e.preventDefault());
-		links.click((e: any) => {
-			const el = $(e.currentTarget);
-			const href = el.attr('href') || el.attr('xlink:href');
+		const root = obj instanceof HTMLElement ? obj : (obj.get ? obj.get(0) : obj);
+		if (!root) {
+			return;
+		};
 
-			e.preventDefault();
-			el.hasClass('path') ? Action.openPath(href) : Action.openUrl(href);
+		const links = root.querySelectorAll('a');
+
+		links.forEach((link: HTMLElement) => {
+			link.removeEventListener('click', link['_rl_click']);
+			link.removeEventListener('auxclick', link['_rl_aux']);
+
+			const onClick = (e: MouseEvent) => {
+				const href = link.getAttribute('href') || link.getAttribute('xlink:href');
+
+				e.preventDefault();
+				link.classList.contains('path') ? Action.openPath(href) : Action.openUrl(href);
+			};
+
+			const onAux = (e: MouseEvent) => e.preventDefault();
+
+			link['_rl_click'] = onClick;
+			link['_rl_aux'] = onAux;
+
+			link.addEventListener('click', onClick);
+			link.addEventListener('auxclick', onAux);
 		});
 	};
 
@@ -327,26 +314,37 @@ class UtilDom {
 	 * @param {function} [callBack] - Optional callback after toggle.
 	 */
 	toggle (obj: any, delay: number, isOpen: boolean, callBack?: () => void) {
+		const el: HTMLElement = obj instanceof HTMLElement ? obj : (obj?.get ? obj.get(0) : obj);
+		if (!el) {
+			return;
+		};
+
 		if (isOpen) {
-			const height = obj.outerHeight();
+			const height = el.offsetHeight;
 
-			obj.css({ height, overflow: 'hidden' });
+			Object.assign(el.style, { height: `${height}px`, overflow: 'hidden' });
 
-			raf(() => obj.addClass('anim').css({ height: 0 }));
+			raf(() => {
+				this.addClass(el, 'anim');
+				el.style.height = '0px';
+			});
 			window.setTimeout(() => {
-				obj.removeClass('isOpen anim');
+				this.removeClass(el, 'isOpen', 'anim');
 				callBack?.();
 			}, delay);
 		} else {
-			obj.css({ height: 'auto' });
+			el.style.height = 'auto';
 
-			const height = obj.outerHeight();
+			const height = el.offsetHeight;
 
-			obj.css({ height: 0 }).addClass('anim');
+			el.style.height = '0px';
+			this.addClass(el, 'anim');
 
-			raf(() => obj.css({ height }));
+			raf(() => { el.style.height = `${height}px`; });
 			window.setTimeout(() => {
-				obj.removeClass('anim').addClass('isOpen').css({ height: 'auto', overflow: 'visible' });
+				this.removeClass(el, 'anim');
+				this.addClass(el, 'isOpen');
+				Object.assign(el.style, { height: 'auto', overflow: 'visible' });
 				callBack?.();
 			}, delay);
 		};
@@ -411,36 +409,38 @@ class UtilDom {
 	 * @param {boolean} isPopup - Whether the context is a popup.
 	 */
 	scrollToHeader (rootId: string, item: any, isPopup: boolean) {
-		const node = $(`.focusable.c${U.Common.esc(item.id)}`);
+		const node = this.select(`.focusable.c${U.Common.esc(item.id)}`);
 
-		if (!node.length) {
+		if (!node) {
 			return;
 		};
 
 		const container = this.getScrollContainer(isPopup);
 
+		if (!container) {
+			return;
+		};
+
 		if (item.block && item.block.isTextTitle()) {
-			container.scrollTop(0);
+			container.scrollTop = 0;
 			return;
 		};
 
 		const toggleClasses = [ I.TextStyle.Toggle, I.TextStyle.ToggleHeader1, I.TextStyle.ToggleHeader2, I.TextStyle.ToggleHeader3 ]
 			.map(s => `.block.${U.Data.blockTextClass(s)}`).join(',');
-		const toggles = node.parents(toggleClasses);
+		const toggle = node.closest(toggleClasses);
 
-		if (toggles.length) {
-			const toggle = $(toggles.get(0));
-			if (!toggle.hasClass('isToggled')) {
-				S.Block.toggle(rootId, toggle.attr('data-id'), true);
-			};
+		if (toggle && !this.hasClass(toggle as HTMLElement, 'isToggled')) {
+			S.Block.toggle(rootId, (toggle as HTMLElement).dataset.id, true);
 		};
 
-		const no = node.offset().top;
-		const st = container.scrollTop();
+		const no = node.getBoundingClientRect().top;
+		const co = container.getBoundingClientRect().top;
+		const st = container.scrollTop;
 		const offset = 20;
-		const y = Math.max(J.Size.header + offset, no - container.offset().top + st - J.Size.header - offset);
+		const y = Math.max(J.Size.header + offset, no - co + st - J.Size.header - offset);
 
-		container.scrollTop(y);
+		container.scrollTop = y;
 	};
 
 };

--- a/src/ts/store/menu.ts
+++ b/src/ts/store/menu.ts
@@ -173,15 +173,16 @@ class MenuStore {
 		const { param } = item;
 		const { noAnimation, subIds, onClose } = param;
 		const t = noAnimation ? 0 : J.Constant.delay.menu;
-		const el = $(`#${U.String.toCamelCase(`menu-${id}`)}`);
+		const el = U.Dom.get(U.String.toCamelCase(`menu-${id}`));
 
 		if (subIds && subIds.length) {
 			this.closeAll(subIds);
 		};
 
-		if (el.length) {
-			el.toggleClass('noAnimation', noAnimation);
-			el.css({ transform: '' }).removeClass('show');
+		if (el) {
+			U.Dom.toggleClass(el, 'noAnimation', noAnimation);
+			el.style.transform = '';
+			U.Dom.removeClass(el, 'show');
 		};
 
 		U.Data.updateTabsDimmer(null, this.menuList.filter(it => it.id != id));


### PR DESCRIPTION
## Summary
- Removes `import $ from 'jquery'` from `lib/util/dom.ts` entirely — all methods now use native DOM APIs
- Changes `getScrollContainer`, `getPageContainer`, `getPageFlexContainer` to return `HTMLElement | null` instead of jQuery objects
- Updates ~80 consumer call sites across 53 files to use native DOM APIs (`scrollTop`, `addEventListener`/`removeEventListener`, `clientHeight`/`clientWidth`, `getBoundingClientRect`, `querySelector`, `dispatchEvent`)
- Converts internal dom.ts utilities: `clearSelection`, `addBodyClass`, `injectCss`, `pauseMedia`, `renderLinks`, `toggle`, `scrollToHeader`, `getWindowDimensions`, `triggerResizeEditor`, `getAppContainerHeight`

**Depends on:** #2103 (U.Dom helpers + Phase 1a class manipulation)

## Test plan
- [ ] Scroll position preservation when navigating between pages
- [ ] Editor scroll events (rebind/unbind on page switch)
- [ ] Block embed scroll-based visibility detection
- [ ] Dataview views: grid scroll sync, timeline scroll, board scroll, list/gallery WindowScroller
- [ ] Chat message scrolling (scroll to bottom, scroll to message, date headers on scroll)
- [ ] Comment section scroll-to-bottom and scroll-to-message
- [ ] Selection provider scroll tracking and rubber-band selection
- [ ] Menu positioning relative to scroll containers
- [ ] Sidebar resize (page flex container dimensions)
- [ ] Table of contents scroll-to-header navigation
- [ ] History left panel scroll position restore
- [ ] Window resize handling (getWindowDimensions consumers)
- [ ] triggerResizeEditor still fires for all listeners

🤖 Generated with [Claude Code](https://claude.com/claude-code)