### PR TITLE
JS-9423: use _final_score for global search and mention search

### DIFF
--- a/src/ts/component/menu/block/mention.tsx
+++ b/src/ts/component/menu/block/mention.tsx
@@ -110,6 +110,7 @@ const MenuBlockMention = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => 
 	const load = (clear: boolean, callBack?: (value: any) => void) => {
 		const skipLayouts = U.Object.getSystemLayouts().filter(it => !U.Object.isDateLayout(it) && !U.Object.isTypeLayout(it));
 		const sorts = [
+			{ relationKey: '_final_score', type: I.SortType.Desc },
 			{ relationKey: 'lastOpenedDate', type: I.SortType.Desc },
 			{ relationKey: 'lastModifiedDate', type: I.SortType.Desc },
 			{ relationKey: 'type', type: I.SortType.Asc },
@@ -134,6 +135,7 @@ const MenuBlockMention = observer(forwardRef<I.MenuRef, I.Menu>((props, ref) => 
 		U.Subscription.search({
 			filters,
 			sorts,
+			keys: J.Relation.default.concat([ '_final_score' ]),
 			fullText: filterText,
 			offset: offset.current,
 			limit: J.Constant.limit.menuRecords,

--- a/src/ts/component/popup/search.tsx
+++ b/src/ts/component/popup/search.tsx
@@ -304,7 +304,7 @@ const PopupSearch = observer(forwardRef<{}, I.Popup>((props, ref) => {
 			{ relationKey: 'type.uniqueKey', condition: I.FilterCondition.NotEqual, value: J.Constant.typeKey.template },
 		]);
 		const sorts = [
-			{ relationKey: '_score', type: I.SortType.Desc },
+			{ relationKey: '_final_score', type: I.SortType.Desc },
 			{ relationKey: 'lastOpenedDate', type: I.SortType.Desc },
 			{ relationKey: 'lastModifiedDate', type: I.SortType.Desc },
 			{ relationKey: 'type', type: I.SortType.Asc },
@@ -331,7 +331,7 @@ const PopupSearch = observer(forwardRef<{}, I.Popup>((props, ref) => {
 			setIsLoading(true);
 		};
 
-		C.ObjectSearchWithMeta(space, filters, sorts, J.Relation.default.concat([ 'pluralName', 'links', 'backlinks', '_score' ]), filterValueRef.current, offsetRef.current, limit, (message) => {
+		C.ObjectSearchWithMeta(space, filters, sorts, J.Relation.default.concat([ 'pluralName', 'links', 'backlinks', '_final_score' ]), filterValueRef.current, offsetRef.current, limit, (message) => {
 			if (message.error.code) {
 				setIsLoading(false);
 				return;


### PR DESCRIPTION
## Summary

- Replace `_score` (raw BM25) with `_final_score` as the primary sort key in global search (`popup/search.tsx`) and mention menu (`menu/block/mention.tsx`)
- `_final_score` blends BM25 score with recency decay (30-day half-life on `lastOpenedDate`/`lastModifiedDate`) and a name-field boost, computed in anytype-heart
- Also adds `_final_score` to the requested keys in both places so the field is available client-side

## Test plan

- [ ] Open global search, type a query — recently opened/modified objects with name matches should rank above older body-text matches
- [ ] Type `@` in the editor to open mention menu — same ranking improvement applies
- [ ] Verify empty-query state (no filter text) still works — falls back to `lastOpenedDate` sort gracefully