### PR TITLE
JS-9432: fix link menu using stale text for search filter

### DIFF
--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -1426,7 +1426,7 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 			filter = mark.param;
 			newType = mark.type;
 		} else {
-			filter = block.getText().substring(range.from, range.to);
+			filter = text.substring(range.from, range.to);
 		};
 
 		switch (type) {


### PR DESCRIPTION
## Summary
- **Bug:** When typing text in a block and immediately pressing `Cmd+Shift+K` to add a link, the selected text was not correctly pre-filled in the search input. Instead, stale (old) text appeared.
- **Root cause:** `onMarkBlock()` read selected text from the block model (`block.getText()`) which updates asynchronously via gRPC, instead of using the `text` parameter already read from the DOM.
- **Fix:** Use the `text` parameter (current DOM content) instead of `block.getText()` for extracting the selected text filter.

## Test plan
- [ ] Type new text in a block, select it, press `Cmd+Shift+K` — selected text should appear in the link search input
- [ ] Delete text, type new text, select it, press `Cmd+Shift+K` — new text should appear, not the old deleted text
- [ ] Click away from block, return, select text, press `Cmd+Shift+K` — should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)