### PR TITLE
JS-9471: exclude featuredRelations block from BlockCopy

### DIFF
--- a/src/ts/lib/action.ts
+++ b/src/ts/lib/action.ts
@@ -633,7 +633,7 @@ class Action {
 		const tree = S.Block.wrapTree(rootId, rootId);
 
 		let next = null;
-		let blocks = S.Block.unwrapTree([ tree ]).filter(it => ids.includes(it.id));
+		let blocks = S.Block.unwrapTree([ tree ]).filter(it => ids.includes(it.id) && !it.isFeatured());
 
 		ids.forEach((id: string) => {
 			const block = S.Block.getLeaf(rootId, id);


### PR DESCRIPTION
## Summary
- **Bug:** `Cmd+A` → paste duplicated the `featuredRelations` block because it was included in the `BlockCopy` payload.
- **Root cause:** `copyBlocks()` in `action.ts` filtered blocks only by selected IDs, without excluding non-copyable block types like `featured`.
- **Fix:** Added `!it.isFeatured()` filter in `copyBlocks()`, consistent with `isDraggable()` and `isDeletable()` which already exclude featured blocks.

## Test plan
- [ ] Open a Page object, press `Cmd+A`, then `Cmd+V` — featured relations block should not be duplicated
- [ ] Select individual blocks (not featured) and copy/paste — should work as before
- [ ] Cut (`Cmd+X`) with all selected — featured block should remain, not be cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)