### PR TITLE
fix: move pin initialization from onAuth to onAuthOnce

### DIFF
--- a/src/ts/app.tsx
+++ b/src/ts/app.tsx
@@ -397,16 +397,16 @@ const App: FC = () => {
 
 				U.Data.onInfo(account.info);
 				S.Common.spaceSet('');
-				U.Data.onAuthOnce();
+				U.Data.onAuthOnce(() => {
+					const param = route ? U.Router.getParam(route) : {};
+					const spaceId = param.spaceId || data.spaceId || Storage.get('spaceId');
 
-				const param = route ? U.Router.getParam(route) : {};
-				const spaceId = param.spaceId || data.spaceId || Storage.get('spaceId');
-
-				if (spaceId) {
-					U.Router.switchSpace(spaceId, '', false, routeParam, true);
-				} else {
-					U.Data.onAuthWithoutSpace(routeParam);
-				};
+					if (spaceId) {
+						U.Router.switchSpace(spaceId, '', false, routeParam, true);
+					} else {
+						U.Data.onAuthWithoutSpace(routeParam);
+					};
+				});
 			});
 		};
 

--- a/src/ts/component/page/auth/login.tsx
+++ b/src/ts/component/page/auth/login.tsx
@@ -86,17 +86,17 @@ const PageAuthLogin = forwardRef<I.PageRef, I.PageComponent>((props, ref: any) =
 				onRouteChange: () => Action.checkDiskSpace(),
 			};
 
-			if (spaceId) {
-				U.Router.switchSpace(spaceId, '', false, routeParam, true);
-			} else {
-				Animation.from(() => {
-					U.Data.onAuthWithoutSpace(routeParam);
-					isSelecting.current = false;
-				});
-			};
-
 			U.Data.onInfo(account.info);
-			U.Data.onAuthOnce();
+			U.Data.onAuthOnce(() => {
+				if (spaceId) {
+					U.Router.switchSpace(spaceId, '', false, routeParam, true);
+				} else {
+					Animation.from(() => {
+						U.Data.onAuthWithoutSpace(routeParam);
+						isSelecting.current = false;
+					});
+				};
+			});
 
 			analytics.event('SelectAccount', { middleTime: message.middleTime });
 		});

--- a/src/ts/component/page/auth/select.tsx
+++ b/src/ts/component/page/auth/select.tsx
@@ -29,16 +29,14 @@ const PageAuthSelect = forwardRef<I.PageRef, I.PageComponent>((props, ref) => {
 			};
 
 			U.Data.onInfo(account.info);
-			U.Data.onAuthOnce();
+			U.Data.onAuthOnce(() => {
+				Storage.set('spaceId', account.info.accountSpaceId);
+				S.Common.showRelativeDatesSet(true);
+				
+				Storage.set('multichatsOnboarding', true);
+				Storage.setOnboarding('objectDescriptionButton');
+				Storage.setOnboarding('typeResetLayout');
 
-			Storage.set('spaceId', account.info.accountSpaceId);
-			S.Common.showRelativeDatesSet(true);
-			
-			Storage.set('multichatsOnboarding', true);
-			Storage.setOnboarding('objectDescriptionButton');
-			Storage.setOnboarding('typeResetLayout');
-
-			U.Subscription.createGlobal(() => {
 				inflate(() => U.Router.go('/auth/onboard', {}));
 			});
 		};

--- a/src/ts/component/page/auth/setup.tsx
+++ b/src/ts/component/page/auth/setup.tsx
@@ -105,14 +105,14 @@ const PageAuthSetup = forwardRef<I.PageRef, I.PageComponent>((props, ref) => {
 			};
 
 			U.Data.onInfo(account.info);
-			U.Data.onAuthOnce();
+			U.Data.onAuthOnce(() => {
+				if (spaceId) {
+					U.Router.switchSpace(spaceId, '', false, routeParam, true);
+				} else {
+					U.Router.go('/main/void/select', { replace: true, onRouteChange: onAuthComplete });
+				};
+			});
 
-			if (spaceId) {
-				U.Router.switchSpace(spaceId, '', false, routeParam, true);
-			} else {
-				U.Router.go('/main/void/select', { replace: true, onRouteChange: onAuthComplete });
-			};
-			
 			analytics.event('SelectAccount', { middleTime: message.middleTime });
 		});
 	};

--- a/src/ts/lib/util/data.ts
+++ b/src/ts/lib/util/data.ts
@@ -310,7 +310,7 @@ class UtilData {
 	 * @param {any} [param] - Optional parameters for authentication.
 	 * @param {() => void} [callBack] - Optional callback after authentication.
 	 */
-	onAuth(param?: any, callBack?: () => void) {
+	onAuth (param?: any, callBack?: () => void) {
 		param = param || {};
 
 		const { widgets } = S.Block;
@@ -327,36 +327,17 @@ class UtilData {
 
 		C.ObjectOpen(widgets, '', space, () => {
 			U.Subscription.createSpace(() => {
-				S.Common.pinInit(() => {
-					const { pin } = S.Common;
+				const rp = route ? U.Router.getParam(route) : {};
+				const isRestorable = route && !(rp.page == 'auth') && !((rp.page == 'main') && [ 'blank', 'void' ].includes(rp.action));
 
-					// Notify main process whether a PIN is set
-					Renderer.send('setHasPinSet', Boolean(pin));
+				if (isRestorable) {
+					U.Router.go(route, routeParam);
+				} else {
+					U.Space.openDashboard(routeParam);
+				};
 
-					// If no PIN, user is considered checked
-					if (!pin) {
-						keyboard.setPinChecked(true);
-					};
-
-					keyboard.initPinCheck();
-
-					// Redirect
-					if (pin && !keyboard.isPinChecked) {
-						U.Router.go('/auth/pin-check', routeParam);
-					} else {
-						const rp = route ? U.Router.getParam(route) : {};
-						const isRestorable = route && !(rp.page == 'auth') && !((rp.page == 'main') && [ 'blank', 'void' ].includes(rp.action));
-
-						if (isRestorable) {
-							U.Router.go(route, routeParam);
-						} else {
-							U.Space.openDashboard(routeParam);
-						};
-					};
-
-					S.Common.redirectSet('');
-					callBack?.();
-				});
+				S.Common.redirectSet('');
+				callBack?.();
 			});
 		});
 	};
@@ -364,7 +345,32 @@ class UtilData {
 	/**
 	 * Handles one-time authentication tasks after login.
 	 */
-	onAuthOnce() {
+	onAuthOnce (callBack?: () => void) {
+		S.Common.pinInit(() => {
+			const { pin } = S.Common;
+
+			Renderer.send('setHasPinSet', Boolean(pin));
+
+			if (!pin) {
+				keyboard.setPinChecked(true);
+			};
+
+			keyboard.initPinCheck();
+
+			U.Subscription.createGlobal(() => {
+				if (S.Record.spaceMap.size) {
+					Storage.clearDeletedSpaces(false);
+					Storage.clearDeletedSpaces(true);
+				};
+
+				if (pin && !keyboard.isPinChecked) {
+					U.Router.go('/auth/pin-check', {});
+				} else {
+					callBack?.();
+				};
+			});
+		});
+		
 		C.NotificationList(false, J.Constant.limit.notification, (message: any) => {
 			if (!message.error.code) {
 				S.Notification.set(message.list);
@@ -402,13 +408,6 @@ class UtilData {
 		U.Common.applyAutoDownload(S.Common.autoDownload);
 
 		this.getMembershipData();
-
-		U.Subscription.createGlobal(() => {
-			if (S.Record.spaceMap.size) {
-				Storage.clearDeletedSpaces(false);
-				Storage.clearDeletedSpaces(true);
-			};
-		});
 	};
 
 	/**


### PR DESCRIPTION
## Summary
- Move pin init logic (pinInit, setHasPinSet, setPinChecked, initPinCheck) from `onAuth` to `onAuthOnce` so it runs once during authentication, not on every space switch
- `onAuthOnce` now accepts a callback, gating `switchSpace` behind pin initialization completion
- If a pin is set and unchecked, redirects to `/auth/pin-check` before any space switch
- `createGlobal` subscription moved into `onAuthOnce` pin init callback for correct sequencing

## Test plan
- [ ] Login with PIN set — should show pin-check screen before entering space
- [ ] Login without PIN — should enter space normally
- [ ] Switch spaces after login — should not re-trigger pin initialization
- [ ] New account onboarding flow (select.tsx) — should complete without issues
- [ ] App relaunch with existing session — should restore correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)