### PR TITLE
fix: update red button background colors

### DIFF
--- a/src/scss/_vars.scss
+++ b/src/scss/_vars.scss
@@ -67,7 +67,7 @@
 	--color-orange: #fe9a00;
 	--color-dark-orange: #b66934;
 
-	--color-very-light-red: #ffe2e2;
+	--color-very-light-red: #ffede9;
 	--color-light-red: #fcd1c3;
 	--color-red: #fb592c;
 	--color-dark-red: #cb360d;


### PR DESCRIPTION
## Summary
- Updated `--color-very-light-red` from `#ffe2e2` to `#ffede9`
- `--color-light-red` was already `#fcd1c3` (no change needed)

These values are used by `.button.red` default and hover background states.

## Test plan
- [ ] Verify `.button.red` default background uses new `#ffede9` tone
- [ ] Verify `.button.red` hover background remains `#fcd1c3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)