### PR TITLE
feat: add system-highlight color and apply to active filter pills

### DIFF
--- a/src/scss/_vars.scss
+++ b/src/scss/_vars.scss
@@ -52,6 +52,7 @@
 	--color-system-accent-100: #377aff;
 	--color-system-accent-50: #699bff;
 	--color-system-accent-25: #9bbcff;
+	--color-system-highlight: rgba(55, 122, 255, 0.15);
 	--color-system-selection: rgba(55, 122, 255, 0.25);
 	--color-system-drop-zone: rgba(55, 122, 255, 0.25);
 

--- a/src/scss/block/dataview.scss
+++ b/src/scss/block/dataview.scss
@@ -215,9 +215,9 @@
 					.icon.relation { width: 20px; height: 20px; }
 					.icon.arrow { width: 8px; height: 8px; }
 
-					&.isActive { color: var(--color-system-accent-100); background-color: var(--color-system-selection); }
+					&.isActive { color: var(--color-system-accent-100); background-color: var(--color-system-highlight); }
 					&.isActive {
-						&:hover, &.hover { background-color: var(--color-system-drop-zone); }
+						&:hover, &.hover { background-color: var(--color-system-selection); }
 						.name { font-weight: 500; }
 
 						.icon.hasSvg { color: var(--color-system-accent-100); }

--- a/src/scss/menu/dataview/filter.scss
+++ b/src/scss/menu/dataview/filter.scss
@@ -13,6 +13,8 @@
 			.filterInner {
 				display: flex; flex-direction: row; align-items: center;  gap: 0px 6px; border-radius: 16px;
 				@include text-common; padding: 0px 8px; height: 28px; max-width: calc(100% - 32px);
+
+				.icon { margin-right: 0px; }
 			}
 
 			.icon.filterIcon { width: 20px; height: 20px; margin-right: 0px; }
@@ -33,13 +35,14 @@
 			}
 
 			&.isActive {
-				.filterInner { color: var(--color-system-accent-100); background-color: var(--color-system-selection); }
+				.filterInner { color: var(--color-system-accent-100); background-color: var(--color-system-highlight); }
 				.relationName { font-weight: 500; }
+				.icon.hasSvg { color: var(--color-system-accent-100); }
 				.icon.relation { background-color: var(--color-system-accent-100); }
 
 				&:hover,
 				&.hover {
-					.filterInner { background-color: var(--color-system-drop-zone); }
+					.filterInner { background-color: var(--color-system-selection); }
 				}
 			}
 		}

--- a/src/scss/theme/dark/common.scss
+++ b/src/scss/theme/dark/common.scss
@@ -87,6 +87,7 @@ html.themeDark {
 	--color-system-accent-125: #105aef;
 	--color-system-accent-50: #699bff;
 	--color-system-accent-25: #9bbcff;
+	--color-system-highlight: rgba(55, 122, 255, 0.15);
 	--color-system-selection: rgba(55, 122, 255, 0.25);
 
 	/* Icon */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig(({ mode }) => {
 		publicDir: false,
 
 		resolve: {
+			dedupe: [ 'react', 'react-dom' ],
 			extensions: ['.ts', '.tsx', '.js', '.jsx'],
 			alias: [
 				{ find: 'dist', replacement: path.resolve(__dirname, 'dist') },


### PR DESCRIPTION
## Summary
- Add `--color-system-highlight` CSS variable (`rgba(55, 122, 255, 0.15)`) to both light (`_vars.scss`) and dark (`theme/dark/common.scss`) themes
- Apply `--color-system-highlight` as default background for active filter pills in dataview and filter list menu; `--color-system-selection` on hover
- Set `--color-system-accent-100` icon color for active state in filter list menu
- Remove inherited `margin-right: 6px` from icons inside `.filterInner`
- Fix duplicate React instance crash in dev by adding `resolve.dedupe: ['react', 'react-dom']` to Vite config

## Test plan
- [ ] Active filter pills show lighter blue background (highlight) by default
- [ ] Hover on active filter pills shows the stronger blue (selection)
- [ ] Icons inside active filter pills are accent-colored
- [ ] No extra spacing between icon and label in filter list menu
- [ ] Dark mode: highlight color renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)