### PR TITLE
feat: introduce --color-system-destructive token for destructive menu actions

### DIFF
--- a/src/scss/_vars.scss
+++ b/src/scss/_vars.scss
@@ -55,6 +55,7 @@
 	--color-system-highlight: rgba(55, 122, 255, 0.15);
 	--color-system-selection: rgba(55, 122, 255, 0.25);
 	--color-system-drop-zone: rgba(55, 122, 255, 0.25);
+	--color-system-destructive: #fb592c;
 
 	/* Color */
 

--- a/src/scss/color.scss
+++ b/src/scss/color.scss
@@ -10,6 +10,7 @@
 .textColor-ice { color: var(--color-dark-ice) !important; }
 .textColor-teal { color: var(--color-dark-teal) !important; }
 .textColor-lime { color: var(--color-dark-lime) !important; }
+.textColor-destructive { color: var(--color-system-destructive) !important; }
 
 .bgColor-default { background: var(--color-shape-tertiary) !important; }
 .bgColor-black { background: var(--color-shape-tertiary) !important; }

--- a/src/scss/component/icon.scss
+++ b/src/scss/component/icon.scss
@@ -35,6 +35,7 @@
 .icon.iconColor-accent100 { color: var(--color-system-accent-100); }
 .icon.iconColor-accent50 { color: var(--color-system-accent-50); }
 .icon.iconColor-accent25 { color: var(--color-system-accent-25); }
+.icon.iconColor-destructive { color: var(--color-system-destructive); }
 
 .icon.menuBlockTextParagraph,
 .icon.menuBlockTextHeader,

--- a/src/scss/theme/dark/common.scss
+++ b/src/scss/theme/dark/common.scss
@@ -88,6 +88,7 @@ html.themeDark {
 	--color-system-accent-25: #9bbcff;
 	--color-system-highlight: rgba(55, 122, 255, 0.15);
 	--color-system-selection: rgba(55, 122, 255, 0.25);
+	--color-system-destructive: #fb592c;
 
 	/* Icon */
 

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -826,7 +826,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			options.push({ id: 'edit', iconParam: { name: 'common/edit' }, name: translate('commonEdit') });
 			options.push({ isDiv: true });
 			options.push({ id: 'link', iconParam: { name: 'menu/action/pageLink' }, name: translate('commonCopyLink') });
-			options.push({ id: 'delete', iconParam: { name: 'menu/action/remove', color: 'darkRed' }, name: translate('commonDelete'), color: 'red' });
+			options.push({ id: 'delete', iconParam: { name: 'menu/action/remove', color: 'destructive' }, name: translate('commonDelete'), color: 'destructive' });
 		} else {
 			if (options.length) {
 				options.push({ isDiv: true });

--- a/src/ts/component/comment/post.tsx
+++ b/src/ts/component/comment/post.tsx
@@ -404,7 +404,7 @@ const CommentPost = (props: Props) => {
 
 		if (isSelf) {
 			menuItems.push({ isDiv: true });
-			menuItems.push({ id: 'delete', name: translate('commentDelete'), iconParam: { name: 'menu/action/remove', color: 'darkRed' }, color: 'red' });
+			menuItems.push({ id: 'delete', name: translate('commentDelete'), iconParam: { name: 'menu/action/remove', color: 'destructive' }, color: 'destructive' });
 		};
 
 		setHover(true);

--- a/src/ts/component/comment/reply.tsx
+++ b/src/ts/component/comment/reply.tsx
@@ -182,7 +182,7 @@ const CommentReply = (props: Props) => {
 
 		if (isSelf) {
 			menuItems.push({ isDiv: true });
-			menuItems.push({ id: 'delete', name: translate('commentDelete'), iconParam: { name: 'menu/action/remove', color: 'darkRed' }, color: 'red' });
+			menuItems.push({ id: 'delete', name: translate('commentDelete'), iconParam: { name: 'menu/action/remove', color: 'destructive' }, color: 'destructive' });
 		};
 
 		setHover(true);

--- a/src/ts/component/menu/dataview/template/context.tsx
+++ b/src/ts/component/menu/dataview/template/context.tsx
@@ -29,7 +29,7 @@ const MenuDataviewTemplateContext = forwardRef<I.MenuRef, I.Menu>((props, ref) =
 			isDefault && onSetDefault ? ({ id: 'unsetDefault', name: unsetDefaultName }) : null,
 			{ id: 'edit', name: translate('menuDataviewTemplateEdit') },
 			{ id: 'duplicate', name: translate('commonDuplicate') },
-			{ id: 'remove', name: translate('commonDelete'), color: 'red' },
+			{ id: 'remove', name: translate('commonDelete'), color: 'destructive' },
 		].filter(it => it);
 	};
 

--- a/src/ts/component/menu/syncStatus.tsx
+++ b/src/ts/component/menu/syncStatus.tsx
@@ -70,7 +70,7 @@ const MenuSyncStatus = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		];
 
 		if (canWrite && canDelete) {
-			options.push({ id: 'delete', color: 'red', name: translate('commonDeleteImmediately') });
+			options.push({ id: 'delete', color: 'destructive', name: translate('commonDeleteImmediately') });
 		};
 
 		S.Menu.open('select', {

--- a/src/ts/component/page/main/settings/api.tsx
+++ b/src/ts/component/page/main/settings/api.tsx
@@ -28,7 +28,7 @@ const PageMainSettingsApi = forwardRef<I.PageRef, I.PageSettingsComponent>((prop
 		const options: any[] = [
 			{ id: 'copyKey', name: translate('popupSettingsApiCopyKey') },
 			{ id: 'copyMcp', name: translate('popupSettingsApiCopyMcp') },
-			{ id: 'revoke', name: translate('popupSettingsApiRevoke'), color: 'red' },
+			{ id: 'revoke', name: translate('popupSettingsApiRevoke'), color: 'destructive' },
 		];
 
 		S.Menu.open('select', {

--- a/src/ts/component/page/main/settings/data/publish.tsx
+++ b/src/ts/component/page/main/settings/data/publish.tsx
@@ -28,7 +28,7 @@ const PageMainSettingsDataPublish = forwardRef<I.PageRef, I.PageSettingsComponen
 			{ isDiv: true },
 			{ id: 'view', name: translate('menuPublishButtonView') },
 			{ id: 'copy', name: translate('menuPublishButtonCopy') },
-			{ id: 'unpublish', name: translate('menuPublishButtonUnpublish'), color: 'red' },
+			{ id: 'unpublish', name: translate('menuPublishButtonUnpublish'), color: 'destructive' },
 		];
 
 		S.Menu.open('select', {

--- a/src/ts/component/page/main/settings/space/share/members.tsx
+++ b/src/ts/component/page/main/settings/space/share/members.tsx
@@ -56,7 +56,7 @@ const Members = forwardRef<I.PageRef, I.PageSettingsComponent>((props, ref) => {
 			items.push({ isDiv: true });
 		};
 
-		items.push({ id: 'remove', name: removeLabel, color: 'red' });
+		items.push({ id: 'remove', name: removeLabel, color: 'destructive' });
 
 		return items;
 	};

--- a/src/ts/component/sidebar/page/object/relation.tsx
+++ b/src/ts/component/sidebar/page/object/relation.tsx
@@ -79,7 +79,7 @@ const SidebarPageObjectRelation = forwardRef<{}, I.SidebarPageComponent>((props,
 			data: {
 				options: [
 					{ id: 'addToType', name: translate('sidebarRelationLocalAddToType') },
-					{ id: 'remove', name: translate('sidebarRelationLocalRemoveFromObject'), color: 'red' },
+					{ id: 'remove', name: translate('sidebarRelationLocalRemoveFromObject'), color: 'destructive' },
 				],
 				onSelect: (e, option) => {
 					switch (option.id) {

--- a/src/ts/component/sidebar/page/settings/index.tsx
+++ b/src/ts/component/sidebar/page/settings/index.tsx
@@ -52,9 +52,9 @@ const SidebarPageSettingsIndex = forwardRef<{}, I.SidebarPageComponent>((props, 
 		const isOwner = U.Space.isMyOwner();
 		const leaveOrRemove = !spaceview.isPersonal ? {
 			id: 'remove',
-			iconParam: isOwner ? { name: 'menu/action/remove', color: 'darkRed' } : { name: 'menu/action/leave', color: 'darkRed' },
+			iconParam: isOwner ? { name: 'menu/action/remove', color: 'destructive' } : { name: 'menu/action/leave', color: 'destructive' },
 			name: isOwner ? translate('pageSettingsSpaceDeleteSpace') : translate('commonLeaveSpace'),
-			color: 'red',
+			color: 'destructive',
 		} : null;
 
 		return [

--- a/src/ts/lib/util/menu.ts
+++ b/src/ts/lib/util/menu.ts
@@ -791,7 +791,7 @@ class UtilMenu {
 		const isOwner = U.Space.isMyOwner();
 		const options: I.Option[] = [
 			{ id: 'spaceInfo', name: translate('popupSettingsSpaceIndexSpaceInfoTitle') },
-			{ id: 'delete', name: isOwner ? translate('pageSettingsSpaceDeleteSpace') : translate('commonLeaveSpace'), color: 'red' }
+			{ id: 'delete', name: isOwner ? translate('pageSettingsSpaceDeleteSpace') : translate('commonLeaveSpace'), color: 'destructive' }
 		];
 
 		S.Menu.open('select', {
@@ -1018,10 +1018,10 @@ class UtilMenu {
 				};
 
 				if (withDelete) {
-					const iconParam = { name: isOwner ? 'menu/action/remove' : 'menu/action/leave', color: 'darkRed' };
+					const iconParam = { name: isOwner ? 'menu/action/remove' : 'menu/action/leave', color: 'destructive' };
 					const name = isOwner ? translate('pageSettingsSpaceDeleteSpace') : translate('commonLeaveSpace');
 
-					sections.delete.push({ id: 'remove', iconParam, name, color: 'red' });
+					sections.delete.push({ id: 'remove', iconParam, name, color: 'destructive' });
 				};
 			};
 
@@ -1433,7 +1433,7 @@ class UtilMenu {
 			if (canDelete) {
 				options = options.concat([
 					{ isDiv: true },
-					{ id: 'remove', name: translate('commonDelete'), color: 'red' },
+					{ id: 'remove', name: translate('commonDelete'), color: 'destructive' },
 				]);
 			};
 


### PR DESCRIPTION
## Summary

- Adds `--color-system-destructive: #fb592c` CSS variable to both light (`_vars.scss`) and dark (`theme/dark/common.scss`) themes
- Adds `.textColor-destructive` and `.icon.iconColor-destructive` utility classes wired to the new token
- Replaces all ad-hoc `color: 'red'` (label) and `iconParam.color: 'darkRed'` (icon) usages across 11 components and `lib/util/menu.ts` with the new `'destructive'` value

## Affected components

- `component/block/chat.tsx` — Delete message
- `component/comment/post.tsx`, `reply.tsx` — Delete comment / reply
- `component/menu/dataview/template/context.tsx` — Delete template
- `component/menu/syncStatus.tsx` — Delete Immediately
- `component/page/main/settings/api.tsx` — Revoke API key
- `component/page/main/settings/data/publish.tsx` — Unpublish
- `component/page/main/settings/space/share/members.tsx` — Remove member
- `component/sidebar/page/object/relation.tsx` — Remove relation from object
- `component/sidebar/page/settings/index.tsx` — Delete / Leave space
- `lib/util/menu.ts` — Delete/Leave space (×2), Delete type object

## Test plan

- [ ] Open a chat message context menu — "Delete" label and icon should render in `#fb592c`
- [ ] Open a comment context menu — same
- [ ] Open a dataview template context menu — "Delete" in destructive color
- [ ] Open space settings sidebar — "Delete Space" / "Leave Space" in destructive color
- [ ] Verify color is consistent between light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)