### PR TITLE
Feature/JS-9482: Improve bin tree view — arrow replaces icon, badge styling, …

### DIFF
--- a/src/json/text.json
+++ b/src/json/text.json
@@ -50,7 +50,7 @@
 	"binSwitchToTree": "Switch to tree view",
 	"binSwitchToCompact": "Switch to compact view",
 	"binSwitchToDetailed": "Switch to detailed view",
-	"binStackCount": "+%d objects",
+	"binStackCount": "+%d",
 	"commonToday": "Today",
 	"commonTomorrow": "Tomorrow",
 	"commonYesterday": "Yesterday",

--- a/src/scss/page/main/archive.scss
+++ b/src/scss/page/main/archive.scss
@@ -129,9 +129,8 @@
 						border-radius: 15px; padding: 0px 6px; flex-shrink: 0; white-space: nowrap;
 					}
 
+					.iconWrap { position: relative; flex-shrink: 0; }
 					.iconWrap {
-						position: relative; flex-shrink: 0;
-
 						.icon.expandArrow {
 							position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%) rotate(-90deg);
 							width: 16px; height: 16px; transition: transform 0.15s ease, opacity 0.15s ease;

--- a/src/scss/page/main/archive.scss
+++ b/src/scss/page/main/archive.scss
@@ -126,14 +126,25 @@
 				.row:not(.isHead) {
 					.stackBadge {
 						@include text-small; color: var(--color-text-secondary); background-color: var(--color-shape-highlight-medium);
-						border-radius: 4px; padding: 1px 5px; flex-shrink: 0; white-space: nowrap;
+						border-radius: 15px; padding: 0px 6px; flex-shrink: 0; white-space: nowrap;
 					}
 
-					.icon.expandArrow {
-						width: 16px; height: 16px; flex-shrink: 0; transform: rotate(-90deg); transition: transform 0.15s ease;
-						color: var(--color-text-secondary);
+					.iconWrap {
+						position: relative; flex-shrink: 0;
+
+						.icon.expandArrow {
+							position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%) rotate(-90deg);
+							width: 16px; height: 16px; transition: transform 0.15s ease, opacity 0.15s ease;
+							color: var(--color-text-primary); opacity: 0; z-index: 1;
+						}
+						.icon.expandArrow.isExpanded { transform: translate(-50%, -50%) rotate(0deg); }
 					}
-					.icon.expandArrow.isExpanded { transform: rotate(0deg); }
+
+					&.canExpand:hover .iconWrap,
+					&.isExpanded .iconWrap {
+						.iconObject { opacity: 0; }
+						.icon.expandArrow { opacity: 1; }
+					}
 				}
 			}
 		}

--- a/src/ts/component/page/main/archiveListTree.tsx
+++ b/src/ts/component/page/main/archiveListTree.tsx
@@ -170,6 +170,12 @@ const ArchiveListTree = ({ subId, canWrite, isShared, isPopup, selectedIds, filt
 		if (depth > 0) {
 			cn.push('isChild');
 		};
+		if (canExpand) {
+			cn.push('canExpand');
+		};
+		if (expanded) {
+			cn.push('isExpanded');
+		};
 
 		const handleRowClick = () => {
 			if (canExpand) {
@@ -185,6 +191,10 @@ const ArchiveListTree = ({ subId, canWrite, isShared, isPopup, selectedIds, filt
 		const handleCheck = (e: any) => {
 			e.stopPropagation();
 			onSelectChange(subtreeIds, e);
+
+			if (canExpand && !isChecked && !expanded) {
+				toggleExpand(node.id);
+			};
 		};
 
 		const arrowCn = [ 'expandArrow' ];
@@ -206,13 +216,22 @@ const ArchiveListTree = ({ subId, canWrite, isShared, isPopup, selectedIds, filt
 					<div className="cell">
 						<div className="cellContent isName">
 							<div className="flex" style={nameIndent}>
-								<IconObject object={obj} onClick={handleOpen} />
+								<div className="iconWrap">
+									<IconObject object={obj} onClick={handleOpen} />
+									{canExpand && (
+										<Icon
+											name="arrow/selectBig"
+											className={arrowCn.join(' ')}
+											onClick={(e: MouseEvent) => {
+												e.stopPropagation();
+												toggleExpand(node.id);
+											}}
+										/>
+									)}
+								</div>
 								<span onClick={handleOpen} onAuxClick={handleOpen}><ObjectName object={obj} /></span>
 								{canExpand && (
 									<span className="stackBadge">{translate('binStackCount').replace('%d', String(childCount))}</span>
-								)}
-								{canExpand && (
-									<Icon name="arrow/select" className={arrowCn.join(' ')} />
 								)}
 							</div>
 						</div>

--- a/src/ts/component/widget/index.tsx
+++ b/src/ts/component/widget/index.tsx
@@ -175,6 +175,10 @@ const WidgetIndex = forwardRef<{}, Props>((props, ref) => {
 			};
 		};
 
+		if ((layout == I.WidgetLayout.Tree) && !U.Object.isSetLayout(object.layout)) {
+			details.createdInContext = object.id;
+		};
+
 		if (!typeKey) {
 			return;
 		};


### PR DESCRIPTION
…auto-expand on select, set createdInContext for widget-created objects

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
