### PR TITLE
fix: strip trailing newlines when copying block text

### DIFF
--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -1311,8 +1311,10 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 		const length = block.getLength();
 
 		C.BlockCopy(rootId, [ block ], { from: 0, to: length }, (message: any) => {
+			const text = String(message.textSlot || '').replace(/\n+$/, '');
+
 			U.Common.clipboardCopy({
-				text: message.textSlot,
+				text,
 				html: message.htmlSlot,
 				anytype: {
 					range: { from: 0, to: length },


### PR DESCRIPTION
---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---

### Description

This PR fixes extra blank lines appearing when pasting text copied from a block's "Copy" button. The `BlockCopy` gRPC callback returns `textSlot` with trailing newlines, which were passed through to the clipboard as-is. Now trailing newlines are stripped before copying.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

### Mobile & Desktop Screenshots/Recordings

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?