### PR TITLE
Fix: use mid-level color for isSelect tag dot

### DIFF
--- a/src/scss/color.scss
+++ b/src/scss/color.scss
@@ -1,16 +1,16 @@
-.textColor-default { --color: var(--color-text-primary); color: var(--color-text-primary) !important; }
-.textColor-black { --color: var(--color-text-primary); color: var(--color-text-primary) !important; }
-.textColor-grey { --color: var(--color-grey); color: var(--color-dark-grey) !important; }
-.textColor-yellow { --color: var(--color-yellow); color: var(--color-dark-yellow) !important; }
-.textColor-orange { --color: var(--color-orange); color: var(--color-dark-orange) !important; }
-.textColor-red { --color: var(--color-red); color: var(--color-dark-red) !important; }
-.textColor-pink { --color: var(--color-pink); color: var(--color-dark-pink) !important; }
-.textColor-purple { --color: var(--color-purple); color: var(--color-dark-purple) !important; }
-.textColor-blue { --color: var(--color-blue); color: var(--color-dark-blue) !important; }
-.textColor-ice { --color: var(--color-ice); color: var(--color-dark-ice) !important; }
-.textColor-teal { --color: var(--color-teal); color: var(--color-dark-teal) !important; }
-.textColor-lime { --color: var(--color-lime); color: var(--color-dark-lime) !important; }
-.textColor-destructive { --color: var(--color-system-destructive); color: var(--color-system-destructive) !important; }
+.textColor-default { color: var(--color-text-primary) !important; }
+.textColor-black { color: var(--color-text-primary) !important; }
+.textColor-grey { color: var(--color-dark-grey) !important; }
+.textColor-yellow { color: var(--color-dark-yellow) !important; }
+.textColor-orange { color: var(--color-dark-orange) !important; }
+.textColor-red { color: var(--color-dark-red) !important; }
+.textColor-pink { color: var(--color-dark-pink) !important; }
+.textColor-purple { color: var(--color-dark-purple) !important; }
+.textColor-blue { color: var(--color-dark-blue) !important; }
+.textColor-ice { color: var(--color-dark-ice) !important; }
+.textColor-teal { color: var(--color-dark-teal) !important; }
+.textColor-lime { color: var(--color-dark-lime) !important; }
+.textColor-destructive { color: var(--color-system-destructive) !important; }
 
 .bgColor-default { background: var(--color-shape-tertiary) !important; }
 .bgColor-black { background: var(--color-shape-tertiary) !important; }

--- a/src/scss/color.scss
+++ b/src/scss/color.scss
@@ -1,16 +1,16 @@
-.textColor-default { color: var(--color-text-primary) !important; }
-.textColor-black { color: var(--color-text-primary) !important; }
-.textColor-grey { color: var(--color-dark-grey) !important; }
-.textColor-yellow { color: var(--color-dark-yellow) !important; }
-.textColor-orange { color: var(--color-dark-orange) !important; }
-.textColor-red { color: var(--color-dark-red) !important; }
-.textColor-pink { color: var(--color-dark-pink) !important; }
-.textColor-purple { color: var(--color-dark-purple) !important; }
-.textColor-blue { color: var(--color-dark-blue) !important; }
-.textColor-ice { color: var(--color-dark-ice) !important; }
-.textColor-teal { color: var(--color-dark-teal) !important; }
-.textColor-lime { color: var(--color-dark-lime) !important; }
-.textColor-destructive { color: var(--color-system-destructive) !important; }
+.textColor-default { --color: var(--color-text-primary); color: var(--color-text-primary) !important; }
+.textColor-black { --color: var(--color-text-primary); color: var(--color-text-primary) !important; }
+.textColor-grey { --color: var(--color-grey); color: var(--color-dark-grey) !important; }
+.textColor-yellow { --color: var(--color-yellow); color: var(--color-dark-yellow) !important; }
+.textColor-orange { --color: var(--color-orange); color: var(--color-dark-orange) !important; }
+.textColor-red { --color: var(--color-red); color: var(--color-dark-red) !important; }
+.textColor-pink { --color: var(--color-pink); color: var(--color-dark-pink) !important; }
+.textColor-purple { --color: var(--color-purple); color: var(--color-dark-purple) !important; }
+.textColor-blue { --color: var(--color-blue); color: var(--color-dark-blue) !important; }
+.textColor-ice { --color: var(--color-ice); color: var(--color-dark-ice) !important; }
+.textColor-teal { --color: var(--color-teal); color: var(--color-dark-teal) !important; }
+.textColor-lime { --color: var(--color-lime); color: var(--color-dark-lime) !important; }
+.textColor-destructive { --color: var(--color-system-destructive); color: var(--color-system-destructive) !important; }
 
 .bgColor-default { background: var(--color-shape-tertiary) !important; }
 .bgColor-black { background: var(--color-shape-tertiary) !important; }

--- a/src/scss/component/tag.scss
+++ b/src/scss/component/tag.scss
@@ -28,8 +28,18 @@
 .tagItem.isSelect {
 	&::before {
 		content: ""; display: inline-block; width: 6px; height: 6px; border-radius: 50%;
-		flex-shrink: 0; margin-right: 6px; background-color: var(--color);
+		flex-shrink: 0; margin-right: 6px; background-color: currentColor;
 	}
+	&.textColor-grey::before { background-color: var(--color-grey); }
+	&.textColor-yellow::before { background-color: var(--color-yellow); }
+	&.textColor-orange::before { background-color: var(--color-orange); }
+	&.textColor-red::before { background-color: var(--color-red); }
+	&.textColor-pink::before { background-color: var(--color-pink); }
+	&.textColor-purple::before { background-color: var(--color-purple); }
+	&.textColor-blue::before { background-color: var(--color-blue); }
+	&.textColor-ice::before { background-color: var(--color-ice); }
+	&.textColor-teal::before { background-color: var(--color-teal); }
+	&.textColor-lime::before { background-color: var(--color-lime); }
 	.inner { color: var(--color-text-primary); }
 	.tagRemove { display: none; }
 }

--- a/src/scss/component/tag.scss
+++ b/src/scss/component/tag.scss
@@ -30,16 +30,16 @@
 		content: ""; display: inline-block; width: 6px; height: 6px; border-radius: 50%;
 		flex-shrink: 0; margin-right: 6px; background-color: currentColor;
 	}
-	&.textColor-grey::before { background-color: var(--color-grey); }
-	&.textColor-yellow::before { background-color: var(--color-yellow); }
-	&.textColor-orange::before { background-color: var(--color-orange); }
-	&.textColor-red::before { background-color: var(--color-red); }
-	&.textColor-pink::before { background-color: var(--color-pink); }
-	&.textColor-purple::before { background-color: var(--color-purple); }
-	&.textColor-blue::before { background-color: var(--color-blue); }
-	&.textColor-ice::before { background-color: var(--color-ice); }
-	&.textColor-teal::before { background-color: var(--color-teal); }
-	&.textColor-lime::before { background-color: var(--color-lime); }
+	&.textColor-grey::before { color: var(--color-grey) !important; }
+	&.textColor-yellow::before { color: var(--color-yellow) !important; }
+	&.textColor-orange::before { color: var(--color-orange) !important; }
+	&.textColor-red::before { color: var(--color-red) !important; }
+	&.textColor-pink::before { color: var(--color-pink) !important; }
+	&.textColor-purple::before { color: var(--color-purple) !important; }
+	&.textColor-blue::before { color: var(--color-blue) !important; }
+	&.textColor-ice::before { color: var(--color-ice) !important; }
+	&.textColor-teal::before { color: var(--color-teal) !important; }
+	&.textColor-lime::before { color: var(--color-lime) !important; }
 	.inner { color: var(--color-text-primary); }
 	.tagRemove { display: none; }
 }

--- a/src/scss/component/tag.scss
+++ b/src/scss/component/tag.scss
@@ -28,7 +28,7 @@
 .tagItem.isSelect {
 	&::before {
 		content: ""; display: inline-block; width: 6px; height: 6px; border-radius: 50%;
-		flex-shrink: 0; margin-right: 6px; background-color: currentColor;
+		flex-shrink: 0; margin-right: 6px; background-color: var(--color);
 	}
 	.inner { color: var(--color-text-primary); }
 	.tagRemove { display: none; }


### PR DESCRIPTION
## Summary
- Expose `--color` CSS custom property on each `.textColor-*` class pointing to the base `--color-[name]` palette (e.g. `--color-grey: #9b9b9b`)
- Change `.tagItem.isSelect::before` dot to use `var(--color)` instead of `currentColor` (which resolved to `--color-dark-[name]`)
- Result: dot uses a lighter, mid-level shade rather than the dark text color — text color itself is unchanged

## Test plan
- [ ] Open a page with a Status/Select relation displayed inline
- [ ] Verify the colored dot is visible and uses the mid-level color (lighter than the text label)
- [ ] Check all color variants (grey, yellow, orange, red, pink, purple, blue, ice, teal, lime)
- [ ] Verify dark mode renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)