### PR TITLE
Refine socialBlock gradient and comment counter style

### DIFF
--- a/src/scss/component/comment.scss
+++ b/src/scss/component/comment.scss
@@ -3,19 +3,22 @@
 .socialBlockWrap { position: sticky; bottom: 0; height: 0; z-index: 2; }
 
 .socialBlock {
-	position: absolute; bottom: 0; width: 100%;
-	display: flex; justify-content: center;
-	padding: 26px 0px 12px 0px;
-	background: linear-gradient(to bottom, transparent, var(--color-bg-primary) 50%);
-	transition: opacity 0.3s $easeInQuint;
+	position: absolute; bottom: 0; width: 100%; height: 140px;
+	display: flex; justify-content: center; align-items: flex-end;
+	padding: 0px 0px 12px 0px;
+	background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.04) 20%, rgba(255, 255, 255, 0.18) 40%, rgba(255, 255, 255, 0.50) 60%, rgba(255, 255, 255, 0.82) 80%, rgba(255, 255, 255, 0.96) 100%);
+	transition: opacity 0.15s ease;
 }
 .socialBlock {
-	&.isHidden { opacity: 0; pointer-events: none; transition: opacity 0.3s $easeInQuint; }
+	&.isHidden { opacity: 0; pointer-events: none; }
 
 	.commentCounter {
 		display: inline-flex; align-items: center; gap: 0px 4px;
 		padding: 7px 10px 7px 8px; border-radius: 18px;
-		background: var(--color-shape-tertiary);
+		background: var(--color-text-white60);
+		backdrop-filter: blur(10px);
+		-webkit-backdrop-filter: blur(10px);
+		transition: background 0.15s ease, opacity 0.15s ease;
 		user-select: none;
 	}
 	.commentCounter:hover { background: var(--color-shape-secondary); }


### PR DESCRIPTION
## Summary
- Multi-stop ease-in gradient on `.socialBlock` (140px height) for a smoother fade effect
- Counter button: `--color-text-white60` background with `backdrop-filter: blur(10px)`
- Counter button: `transition: background 0.15s ease, opacity 0.15s ease`
- Simplified show/hide to opacity toggle with `transition: opacity 0.15s ease` on `.socialBlock`

## Test plan
- [ ] Scroll down on a page with comments — gradient fades in smoothly
- [ ] Counter button renders with frosted glass effect
- [ ] Hover state transitions smoothly
- [ ] Hide/show of the block animates with opacity (no snap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)