### PR TITLE
fix: dark mode gradient and button background in social block

### DIFF
--- a/src/scss/theme/dark/common.scss
+++ b/src/scss/theme/dark/common.scss
@@ -247,6 +247,14 @@ html.themeDark {
 		.icon.close { background-color: var(--color-bg-secondary); }
 	}
 
+	/* Comments */
+
+	.socialBlock { background: linear-gradient(to bottom, rgba(23, 23, 23, 0) 0%, rgba(23, 23, 23, 0.04) 20%, rgba(23, 23, 23, 0.18) 40%, rgba(23, 23, 23, 0.50) 60%, rgba(23, 23, 23, 0.82) 80%, rgba(23, 23, 23, 0.96) 100%); }
+	.socialBlock {
+		.commentCounter { background: rgba(23, 23, 23, 0.6); }
+		.commentCounter:hover { background: var(--color-shape-primary); }
+	}
+
 	@import "./menu";
 	@import "./popup";
 	@import "./page";


### PR DESCRIPTION
## Summary

- Replace white `rgba(255,255,255,...)` gradient stops in `.socialBlock` with dark `rgba(23,23,23,...)` (`--color-bg-primary`) for correct dark mode rendering
- Override `.commentCounter` button background to `rgba(23,23,23,0.6)` (dark background at 60% opacity) in dark mode, replacing the light-mode `--color-text-white60`
- Adjust `.commentCounter:hover` to use `--color-shape-primary` in dark mode

## Test plan

- [ ] Open a page with comments in dark mode and verify the fade gradient at the bottom blends into the dark background
- [ ] Verify the "View comments" counter button has a semi-transparent dark background instead of white/grey
- [ ] Hover over the counter button and confirm the hover state looks correct in dark mode
- [ ] Confirm no visual regressions in light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)