### PR TITLE
Feature/JS-9425: Add loading state with proper proportions for image blocks

### DIFF
--- a/src/scss/block/media.scss
+++ b/src/scss/block/media.scss
@@ -46,6 +46,9 @@
 		.error { margin: 0px; @include text-small; line-height: 22px; }
 		
 		.wrap { max-width: 100%; position: relative; display: inline-block; overflow: hidden; }
+		.wrap {
+			> .loader { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); z-index: 1; }
+		}
 		.mediaImage { width: 100%; display: block; cursor: zoom-in; }
 		.mediaVideo {
 			.icon.syncStatus { display: none; }

--- a/src/ts/component/block/media/image.tsx
+++ b/src/ts/component/block/media/image.tsx
@@ -1,5 +1,5 @@
-import React, { useRef, useImperativeHandle, forwardRef } from 'react';
-import { InputWithFile, Icon, Error, MediaState } from 'Component';
+import React, { useState, useRef, useImperativeHandle, forwardRef } from 'react';
+import { InputWithFile, Icon, Error, Loader, MediaState } from 'Component';
 import * as I from 'Interface';
 import { focus } from 'Lib/focus';
 
@@ -11,6 +11,7 @@ const BlockImage = forwardRef<I.BlockRef, I.BlockComponent>((props, ref) => {
 	const targetObjectId = block.getTargetObjectId();
 	const nodeRef = useRef(null);
 	const wrapRef = useRef(null);
+	const [ isLoaded, setIsLoaded ] = useState(false);
 
 	const handleKeyDown = (e: any) => {
 		onKeyDown?.(e, '', [], { from: 0, to: 0 }, props);
@@ -165,12 +166,20 @@ const BlockImage = forwardRef<I.BlockRef, I.BlockComponent>((props, ref) => {
 		return Math.min(1, Math.max(0, w / ew));
 	};
 
-	const object = S.Detail.get(rootId, targetObjectId, []);
+	const object = S.Detail.get(rootId, targetObjectId, [ 'widthInPixels', 'heightInPixels' ]);
 	const cn = [ 'focusable', `c${block.id}` ];
 	const css: any = {};
+	const wrapCss: any = {};
 
 	if (width) {
 		css.width = (width * 100) + '%';
+	};
+
+	if (object.widthInPixels && object.heightInPixels) {
+		wrapCss.aspectRatio = `${object.widthInPixels} / ${object.heightInPixels}`;
+	} else
+	if (!isLoaded) {
+		wrapCss.height = 80;
 	};
 
 	const typeName = translate('blockNameImage');
@@ -180,11 +189,13 @@ const BlockImage = forwardRef<I.BlockRef, I.BlockComponent>((props, ref) => {
 
 	if (object.isArchived && (state == I.FileState.Done)) {
 		element = (
-			<div ref={wrapRef} className="wrap" style={css}>
+			<div ref={wrapRef} className="wrap" style={{ ...css, ...wrapCss }}>
+				{!isLoaded ? <Loader type={I.LoaderType.Loader} /> : ''}
 				<img
 					className="mediaImage"
 					src={S.Common.imageUrl(targetObjectId, I.ImageSize.Large)}
 					onDragStart={e => e.preventDefault()}
+					onLoad={() => setIsLoaded(true)}
 					onError={handleError}
 				/>
 				{overlay}
@@ -215,12 +226,14 @@ const BlockImage = forwardRef<I.BlockRef, I.BlockComponent>((props, ref) => {
 
 			case I.FileState.Done: {
 				element = (
-					<div ref={wrapRef} className="wrap" style={css}>
+					<div ref={wrapRef} className="wrap" style={{ ...css, ...wrapCss }}>
+						{!isLoaded ? <Loader type={I.LoaderType.Loader} /> : ''}
 						<img
 							className="mediaImage"
 							src={S.Common.imageUrl(targetObjectId, I.ImageSize.Large)}
 							onDragStart={e => e.preventDefault()}
 							onClick={handleClick}
+							onLoad={() => setIsLoaded(true)}
 							onError={handleError}
 						/>
 						{isDownloading ? <Icon className="downloading" /> : <Icon name="common/download" className="download" onClick={handleDownload} />}


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
