### PR TITLE
JS-9583: Fix duplicate scrolling in pop-up lists

### DIFF
--- a/src/ts/component/menu/dataview/filter/list.tsx
+++ b/src/ts/component/menu/dataview/filter/list.tsx
@@ -179,6 +179,7 @@ const MenuFilterList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		};
 
 		if (Dataview.isAdvancedFilter(item)) {
+			unbind();
 			S.Menu.open('dataviewFilterAdvanced', {
 				element: `#${getId()} #item-${U.Common.esc(item.id)}`,
 				classNameWrap: 'fromBlock',
@@ -186,6 +187,7 @@ const MenuFilterList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 				offsetY: 4,
 				noFlipY: true,
 				rebind,
+				parentId: props.id,
 				data: {
 					rootId,
 					blockId,
@@ -201,6 +203,7 @@ const MenuFilterList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 
 		const view = getView();
 
+		unbind();
 		S.Menu.open('dataviewFilterValues', {
 			element: `#${getId()} #item-${U.Common.esc(item.id)}`,
 			classNameWrap: 'fromBlock',
@@ -208,6 +211,7 @@ const MenuFilterList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			offsetY: 4,
 			noFlipY: true,
 			rebind,
+			parentId: props.id,
 			data: {
 				rootId,
 				blockId,
@@ -258,12 +262,14 @@ const MenuFilterList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		e.preventDefault();
 		e.stopPropagation();
 
+		unbind();
 		S.Menu.open('select', {
 			element: `#${getId()} #item-${U.Common.esc(item.id)} .icon.more`,
 			classNameWrap: 'fromBlock',
 			horizontal: I.MenuDirection.Right,
 			offsetY: 4,
 			rebind,
+			parentId: props.id,
 			data: {
 				options: [
 					{ id: 'clear', name: translate('commonClear') },
@@ -309,6 +315,7 @@ const MenuFilterList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 
 	const onAdd = () => {
+		unbind();
 		U.Menu.sortOrFilterRelationSelect({
 			element: `#${getId()} #item-add`,
 			classNameWrap: 'fromBlock',
@@ -316,6 +323,7 @@ const MenuFilterList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			horizontal: I.MenuDirection.Left,
 			offsetY: 4,
 			rebind,
+			parentId: props.id,
 		}, {
 			rootId,
 			blockId,

--- a/src/ts/component/menu/dataview/sort.tsx
+++ b/src/ts/component/menu/dataview/sort.tsx
@@ -105,8 +105,10 @@ const MenuSort = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			};
 
 			default: {
+				unbind();
 				S.Menu.open('select', {
 					rebind,
+					parentId: props.id,
 					element: `#${getId()} #item-${U.Common.esc(item.id)}`,
 					className,
 					classNameWrap,
@@ -136,8 +138,10 @@ const MenuSort = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			{ id: I.EmptyType.End, name: translate('menuDataviewSortShowEmptyBottom') },
 		];
 
+		unbind();
 		S.Menu.open('select', {
 			rebind,
+			parentId: props.id,
 			className,
 			classNameWrap,
 			element: `${elementId} .more`,
@@ -171,7 +175,12 @@ const MenuSort = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			offsetY: 4,
 		};
 
-		U.Menu.sortOrFilterRelationSelect(menuParam, {
+		unbind();
+		U.Menu.sortOrFilterRelationSelect({
+			...menuParam,
+			rebind,
+			parentId: props.id,
+		}, {
 			rootId,
 			blockId,
 			getView,
@@ -182,6 +191,7 @@ const MenuSort = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 
 	const onAdd = () => {
+		unbind();
 		const menuParam = {
 			className,
 			classNameWrap,
@@ -190,6 +200,8 @@ const MenuSort = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			vertical: I.MenuDirection.Bottom,
 			offsetY: 4,
 			offsetX: 8,
+			rebind,
+			parentId: props.id,
 		};
 		U.Menu.sortOrFilterRelationSelect(menuParam, {
 			rootId,

--- a/src/ts/component/menu/relation/suggest.tsx
+++ b/src/ts/component/menu/relation/suggest.tsx
@@ -194,7 +194,8 @@ const MenuRelationSuggest = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		};
 
 		if (item.isType || (item.id == 'add')) {
-			S.Menu.open(menuIdEdit, { 
+			unbind();
+			S.Menu.open(menuIdEdit, {
 				element: `#${getId()} #item-${U.Common.esc(item.id)}`,
 				offsetX: getSize().width,
 				offsetY: -80,
@@ -224,13 +225,16 @@ const MenuRelationSuggest = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		e.preventDefault();
 		e.stopPropagation();
 
-		S.Menu.open(menuIdEdit, { 
+		unbind();
+		S.Menu.open(menuIdEdit, {
 			element: `#${getId()} #item-${U.Common.esc(item.id)}`,
 			offsetX: getSize().width,
 			vertical: I.MenuDirection.Center,
 			noAnimation: true,
 			className,
 			classNameWrap,
+			rebind,
+			parentId: props.id,
 			data: {
 				...data,
 				rootId,


### PR DESCRIPTION
## Summary
- Extends the `unbind()`/`rebind()` pattern from `dataview/relation/list.tsx` to three more menu components that were missing it
- Adds `unbind()` before `S.Menu.open()` and passes `parentId` in `menu/relation/suggest.tsx`, `menu/dataview/filter/list.tsx`, and `menu/dataview/sort.tsx`
- Prevents parent menu keydown handler from catching arrow key events while a child submenu is open

## Test plan
- [ ] Open a Set → Properties → click a property type → arrow keys should only scroll the type submenu, not the parent property list
- [ ] Open a Set → Filter → click "New filter" → arrow keys should only scroll the relation picker, not the filter list
- [ ] Open a Set → Filter → click an existing filter → arrow keys should only scroll the filter values menu
- [ ] Open a Set → Sort → click "Add sort" → arrow keys should only scroll the relation picker
- [ ] Open a Set → Sort → click the "..." more button → arrow keys should only scroll the options menu
- [ ] Closing any submenu should restore keyboard navigation in the parent menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)