### PR TITLE
JS-9577: Filter deleted attachments in discussion comments

### DIFF
--- a/src/ts/component/comment/post.tsx
+++ b/src/ts/component/comment/post.tsx
@@ -506,7 +506,7 @@ const CommentPost = (props: Props) => {
 		return (message.attachments || [])
 			.filter(it => !linkTargets.has(it.target))
 			.map(it => S.Detail.get(subId, it.target))
-			.filter(it => !it._empty_);
+			.filter(it => !it._empty_ && !it.isDeleted);
 	}, [ message.attachments, parts, subId ]);
 
 	const onAttachmentPreview = useCallback((preview: any) => {

--- a/src/ts/component/comment/reply.tsx
+++ b/src/ts/component/comment/reply.tsx
@@ -336,7 +336,7 @@ const CommentReply = (props: Props) => {
 		const list = (message.attachments || [])
 			.filter(it => !linkTargets.has(it.target))
 			.map(it => S.Detail.get(subId, it.target))
-			.filter(it => !it._empty_);
+			.filter(it => !it._empty_ && !it.isDeleted);
 
 		if (!list.length) {
 			return null;


### PR DESCRIPTION
## Summary
- The original fix (9ad55cd2d6) only filtered deleted attachments in chat messages (`block/chat/message/index.tsx`), but the same bug exists in discussion comments
- Adds `!it.isDeleted` filter to `getAttachments()` in `comment/post.tsx` and attachment rendering in `comment/reply.tsx`
- Deleted attachment objects have no `syncStatus`, causing the status to fall through to Syncing and show an infinite spinner

## Test plan
- [ ] Send a discussion comment with an attachment
- [ ] Permanently delete the attached object
- [ ] Verify the comment no longer shows an infinite sync spinner
- [ ] Verify reply previews also hide deleted attachments

🤖 Generated with [Claude Code](https://claude.com/claude-code)