### PR TITLE
JS-9577: Fix infinite sync spinner on deleted attachments

### DIFF
--- a/src/ts/component/block/chat/attachment/index.tsx
+++ b/src/ts/component/block/chat/attachment/index.tsx
@@ -25,6 +25,9 @@ const ChatAttachment = forwardRef<RefProps, Props>((props, ref) => {
 	const { object, showAsFile, bookmarkAsDefault, isDownload, withInlineSize = true, onPreview, onClick, updateAttachments, onRemove } = props;
 
 	let syncStatus = Number(object.syncStatus) || I.SyncStatusObject.Synced;
+	if (object.isDeleted) {
+		syncStatus = I.SyncStatusObject.Synced;
+	} else
 	if (object.syncStatus === undefined) {
 		syncStatus = object.isTmp ? I.SyncStatusObject.Queued : I.SyncStatusObject.Syncing;
 	};

--- a/src/ts/component/comment/post.tsx
+++ b/src/ts/component/comment/post.tsx
@@ -506,7 +506,7 @@ const CommentPost = (props: Props) => {
 		return (message.attachments || [])
 			.filter(it => !linkTargets.has(it.target))
 			.map(it => S.Detail.get(subId, it.target))
-			.filter(it => !it._empty_);
+			.filter(it => !it._empty_ && !it.isDeleted);
 	}, [ message.attachments, parts, subId ]);
 
 	const onAttachmentPreview = useCallback((preview: any) => {

--- a/src/ts/component/comment/reply.tsx
+++ b/src/ts/component/comment/reply.tsx
@@ -336,7 +336,7 @@ const CommentReply = (props: Props) => {
 		const list = (message.attachments || [])
 			.filter(it => !linkTargets.has(it.target))
 			.map(it => S.Detail.get(subId, it.target))
-			.filter(it => !it._empty_);
+			.filter(it => !it._empty_ && !it.isDeleted);
 
 		if (!list.length) {
 			return null;


### PR DESCRIPTION
## Summary
- The original fix (9ad55cd2d6) only filtered deleted attachments in chat messages but missed discussion comments and the attachment component itself
- Filters `isDeleted` objects from `getAttachments()` in `comment/post.tsx` and `comment/reply.tsx` so deleted attachments are not rendered
- Treats deleted objects as `Synced` in `block/chat/attachment/index.tsx` — deleted objects have no `syncStatus`, which fell through to `Syncing` and showed an infinite spinner

## Test plan
- [ ] Send a discussion comment with an attachment
- [ ] Permanently delete the attached object
- [ ] Verify the comment no longer shows an infinite sync spinner
- [ ] Verify reply previews also hide deleted attachments
- [ ] Verify chat message attachments still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)