### PR TITLE
JS-9633: add Lifetime tab to membership screen

### DIFF
--- a/src/json/text.json
+++ b/src/json/text.json
@@ -1145,6 +1145,7 @@
 
 	"popupSettingsMembershipSwitchMonthly": "Monthly",
 	"popupSettingsMembershipSwitchAnnual": "Annual <span>-20%</span>",
+	"popupSettingsMembershipSwitchLifetime": "Lifetime",
 
 	"popupSettingsMembershipJustEmail": "Just e-mail",
 	"popupSettingsMembershipPerGenericSingle": "per %s",

--- a/src/scss/page/main/settings.scss
+++ b/src/scss/page/main/settings.scss
@@ -934,13 +934,13 @@
             }
 
             .switchWrapper {
-                position: relative; display: flex; justify-content: center; align-items: center; gap: 0px 8px; margin: 0px auto 32px;
-                width: 240px; height: 28px; border-radius: 14px; border: 2px solid var(--color-shape-secondary); 
+                position: relative; display: flex; justify-content: center; align-items: center; gap: 0px 4px; margin: 0px auto 32px;
+                width: 360px; height: 28px; border-radius: 14px; border: 2px solid var(--color-shape-secondary);
                 background: var(--color-shape-secondary);
             }
             .switchWrapper {
-                .label { 
-                    position: relative; z-index: 1; font-weight: 500; width: calc(50% - 4px); flex-shrink: 0; text-align: center; 
+                .label {
+                    position: relative; z-index: 1; font-weight: 500; width: calc(33.333% - 4px); flex-shrink: 0; text-align: center;
                     color: var(--color-text-secondary); @include text-overflow-nw;
                 }
                 .label {
@@ -953,10 +953,12 @@
                 }
 
                 &:before {
-                    content: ''; position: absolute; z-index: 0; width: 50%; height: 100%; left: 50%; top: 0px; border-radius: 12px;
+                    content: ''; position: absolute; z-index: 0; width: 33.333%; height: 100%; top: 0px; border-radius: 12px;
                     background-color: var(--color-bg-primary); transition: left $easeInQuint 0.15s;
                 }
                 &.isMonthly:before { left: 0%; }
+                &.isAnnual:before { left: 33.333%; }
+                &.isLifetime:before { left: 66.666%; }
             }
 
             .swiper { flex-shrink: 0; border-radius: 16px; }

--- a/src/ts/component/page/main/settings/membership/intro.tsx
+++ b/src/ts/component/page/main/settings/membership/intro.tsx
@@ -7,8 +7,8 @@ import * as I from 'Interface';
 const PageMainSettingsMembershipIntro = forwardRef<I.PageRef, I.PageSettingsComponent>((props, ref) => {
 
 	const nodeRef = useRef(null);
-	const [ isAnnual, setIsAnnual ] = useState(true);
-	
+	const [ period, setPeriod ] = useState<I.MembershipPeriod>(I.MembershipPeriod.Yearly);
+
 	const { data } = S.Membership;
 	const current = data?.getTopProduct();
 	const purchased = data?.getTopPurchasedProduct();
@@ -19,9 +19,20 @@ const PageMainSettingsMembershipIntro = forwardRef<I.PageRef, I.PageSettingsComp
 		products.unshift(current);
 	};
 
-	const onSwitch = () => {
-		setIsAnnual(!isAnnual);
-		analytics.event('ScreenMembershipSwitchPeriod', { type: isAnnual ? 'Monthly' : 'Annual' });
+	const periodOptions = [
+		{ id: I.MembershipPeriod.Monthly, key: 'isMonthly', analyticsType: 'Monthly', label: translate('popupSettingsMembershipSwitchMonthly') },
+		{ id: I.MembershipPeriod.Yearly, key: 'isAnnual', analyticsType: 'Annual', label: translate('popupSettingsMembershipSwitchAnnual') },
+		{ id: I.MembershipPeriod.Lifetime, key: 'isLifetime', analyticsType: 'Lifetime', label: translate('popupSettingsMembershipSwitchLifetime') },
+	];
+	const activeOption = periodOptions.find(it => it.id == period) || periodOptions[1];
+
+	const onSwitch = (option: typeof periodOptions[number]) => {
+		if (option.id == period) {
+			return;
+		};
+
+		setPeriod(option.id);
+		analytics.event('ScreenMembershipSwitchPeriod', { type: option.analyticsType });
 	};
 
 	const onLink = (item: any) => {
@@ -63,7 +74,10 @@ const PageMainSettingsMembershipIntro = forwardRef<I.PageRef, I.PageSettingsComp
 	};
 
 	const onPay = (item: any, callBack: () => void) => {
-		C.MembershipV2CartUpdate([ item.id ], isAnnual, (res) => {
+		const isYearly = period == I.MembershipPeriod.Yearly;
+		const isLifetime = period == I.MembershipPeriod.Lifetime;
+
+		C.MembershipV2CartUpdate([ item.id ], isYearly, isLifetime, (res) => {
 			if (res.error.code) {
 				callBack();
 				return;
@@ -83,7 +97,7 @@ const PageMainSettingsMembershipIntro = forwardRef<I.PageRef, I.PageSettingsComp
 	const TierItem = (props: any) => {
 		const { item } = props;
 		const isCurrent = (item.id == current?.id) || (item.isIntro && !current);
-		const price = item.getPriceString(isAnnual);
+		const price = item.getPriceString(period);
 		const cn = [ 'tier', `c${item.id}`, item.colorStr ];
 		const buttonRef = useRef(null);
 
@@ -91,20 +105,27 @@ const PageMainSettingsMembershipIntro = forwardRef<I.PageRef, I.PageSettingsComp
 			cn.push('isCurrent');
 		};
 
-		let period = '';
+		let periodLabel = '';
 
 		if (isCurrent) {
 			if (purchased?.isPending) {
-				period = translate('popupSettingsMembershipPending');
+				periodLabel = translate('popupSettingsMembershipPending');
 			} else
 			if (item.period && purchased?.info.dateEnds) {
-				period = U.String.sprintf(translate('popupSettingsMembershipValidUntil'), U.Date.date('d M Y', purchased?.info.dateEnds));
+				periodLabel = U.String.sprintf(translate('popupSettingsMembershipValidUntil'), U.Date.date('d M Y', purchased?.info.dateEnds));
 			} else {
-				period = translate('popupSettingsMembershipForeverFree');
+				periodLabel = translate('popupSettingsMembershipForeverFree');
 			};
 		} else {
-			const periodName = U.Common.plural(1, isAnnual ? translate('pluralYear') : translate('pluralMonth'));
-			period = U.String.sprintf(translate('popupSettingsMembershipCurrentPricePeriod'), periodName);
+			let periodName = '';
+
+			switch (period) {
+				case I.MembershipPeriod.Monthly: periodName = U.Common.plural(1, translate('pluralMonth')); break;
+				case I.MembershipPeriod.Yearly: periodName = U.Common.plural(1, translate('pluralYear')); break;
+				case I.MembershipPeriod.Lifetime: periodName = translate('membershipPeriod4'); break;
+			};
+
+			periodLabel = U.String.sprintf(translate('popupSettingsMembershipCurrentPricePeriod'), periodName);
 		};
 
 		const onClick = () => {
@@ -144,7 +165,7 @@ const PageMainSettingsMembershipIntro = forwardRef<I.PageRef, I.PageSettingsComp
 				<div className="bottom">
 					{!isCurrent ? (
 						<div className="priceWrapper">
-							<span className="price">{price}</span>{period}
+							<span className="price">{price}</span>{periodLabel}
 						</div>
 					) : ''}
 					{isCurrent ? (
@@ -184,14 +205,22 @@ const PageMainSettingsMembershipIntro = forwardRef<I.PageRef, I.PageSettingsComp
 		resize,
 	}));
 
+	const switchCn = [ 'switchWrapper', activeOption.key ];
+
 	return (
 		<div ref={nodeRef} className="membershipIntro">
 			<div className="content">
 				<Label text={translate('popupSettingsMembershipText')} />
 
-				<div className={[ 'switchWrapper', isAnnual ? 'isAnnual' : 'isMonthly' ].join(' ')} onClick={onSwitch}>
-					<Label className={!isAnnual ? 'active' : ''} text={translate('popupSettingsMembershipSwitchMonthly')} />
-					<Label className={isAnnual ? 'active' : ''} text={translate('popupSettingsMembershipSwitchAnnual')} />
+				<div className={switchCn.join(' ')}>
+					{periodOptions.map(option => (
+						<Label
+							key={option.id}
+							className={period == option.id ? 'active' : ''}
+							text={option.label}
+							onClick={() => onSwitch(option)}
+						/>
+					))}
 				</div>
 
 				<div className="tiers">

--- a/src/ts/interface/membership.ts
+++ b/src/ts/interface/membership.ts
@@ -84,6 +84,6 @@ export interface MembershipProduct {
 	featuresList?: { key: string; value: number; }[];
 	colorStr?: string;
 	iconName?: string;
-	getPrice?: (isYearly: boolean) => MembershipAmount | null;
-	getPriceString?: (isYearly: boolean) => string;
+	getPrice?: (period: MembershipPeriod) => MembershipAmount | null;
+	getPriceString?: (period: MembershipPeriod) => string;
 };

--- a/src/ts/lib/api/command.ts
+++ b/src/ts/lib/api/command.ts
@@ -1674,10 +1674,11 @@ export const MembershipV2GetPortalLink = (callBack?: (message: any) => void) => 
 	dispatcher.request('MembershipV2GetPortalLink', {}, callBack);
 };
 
-export const MembershipV2CartUpdate = (productIds: string[], isYearly: boolean, callBack?: (message: any) => void) => {
+export const MembershipV2CartUpdate = (productIds: string[], isYearly: boolean, isLifetime: boolean, callBack?: (message: any) => void) => {
 	dispatcher.request('MembershipV2CartUpdate', {
 		productIds,
 		isYearly,
+		isLifetime,
 	}, callBack);
 };
 

--- a/src/ts/lib/api/dispatcher.ts
+++ b/src/ts/lib/api/dispatcher.ts
@@ -1348,7 +1348,7 @@ class Dispatcher {
 						};
 					});
 
-					$(window).trigger('pinnedStatusUpdate', [ mapped.message, mapped.isPinned, mapped.subIds ]);
+					U.Dom.eventDispatch(window, 'pinnedStatusUpdate', { message: mapped.message, isPinned: mapped.isPinned, subIds: mapped.subIds });
 					break;
 				};
 

--- a/src/ts/model/membershipProduct.ts
+++ b/src/ts/model/membershipProduct.ts
@@ -101,13 +101,20 @@ class MembershipProduct implements I.MembershipProduct {
 		return `tier/${this.colorStr == 'default' ? 'purple' : this.colorStr}`;
 	};
 
-	getPrice (isYearly: boolean): I.MembershipAmount | null {
-		const prices = isYearly ? this.pricesYearly : this.pricesMonthly;
+	getPrice (period: I.MembershipPeriod): I.MembershipAmount | null {
+		let prices: I.MembershipAmount[] = [];
+
+		switch (period) {
+			case I.MembershipPeriod.Monthly: prices = this.pricesMonthly; break;
+			case I.MembershipPeriod.Yearly: prices = this.pricesYearly; break;
+			case I.MembershipPeriod.Lifetime: prices = this.pricesLifetime; break;
+		};
+
 		return prices.length ? prices[0] : null;
 	};
 
-	getPriceString (isYearly: boolean): string {
-		return U.Common.getMembershipPriceString(this.getPrice(isYearly));
+	getPriceString (period: I.MembershipPeriod): string {
+		return U.Common.getMembershipPriceString(this.getPrice(period));
 	};
 
 };


### PR DESCRIPTION
## Summary
- Adds a third **Lifetime** tab next to Monthly/Annual on the membership screen; Annual remains the default.
- Replaces the `isAnnual` boolean with a `MembershipPeriod` state so `getPrice`/`getPriceString` can pick from `pricesMonthly`, `pricesYearly`, or `pricesLifetime`.
- `MembershipV2CartUpdate` now forwards an `isLifetime` flag alongside `isYearly`, ready for the anytype-heart proto change from PR [anyproto/anytype-heart#3103](https://github.com/anyproto/anytype-heart/pull/3103).
- Drive-by: replaces the last remaining `$(window).trigger(...)` in `dispatcher.ts` with `U.Dom.eventDispatch`, matching the CustomEvent shape the chat listener already consumes.

## Notes
- Middleware bundled in this repo (`middleware.version` = `0.50.0-rc02`) does not yet include the `isLifetime` field on `CartUpdate_Request` — it ships on the `GO-7118-v2crypto` branch. Until that lands, ts-proto will silently drop the extra field and a Lifetime selection will reach the backend as `isYearly: false`. Forward-compatible as-is; no additional JS change needed once the middleware is updated.

## Test plan
- [ ] Open Settings → Membership (Intro page) while logged in as a user without an active membership.
- [ ] Verify three tabs render: Monthly / Annual / Lifetime; Annual is selected by default and the indicator sits in the middle.
- [ ] Click each tab — indicator slides, active label styling updates, tier prices update from the corresponding price list, and period label under the price reads `per seat / month`, `per seat / year`, `per seat / lifetime`.
- [ ] Analytics: `ScreenMembershipSwitchPeriod` fires with `type = Monthly | Annual | Lifetime`.
- [ ] Click "Select plan" on each period — verify the portal URL opens (backend flow already in place for monthly/annual).
- [ ] Pin/unpin a chat message after the dispatcher change — confirm the pinned banner still updates live (sanity check on the jQuery removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)