### PR TITLE
Bugfix/JS-9638: Fix pin/unpin chat messages

### DIFF
--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -919,7 +919,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			if (message.isPinned) {
 				options.push({ id: 'unpin', iconParam: { name: 'menu/action/unpin' }, name: translate('commonUnpin') });
 			} else {
-				options.push({ id: 'pin', iconParam: { name: 'menu/action/unpin' }, name: translate('commonPin') });
+				options.push({ id: 'pin', iconParam: { name: 'menu/action/pin' }, name: translate('commonPin') });
 			};
 		};
 

--- a/src/ts/lib/api/command.ts
+++ b/src/ts/lib/api/command.ts
@@ -1927,14 +1927,14 @@ export const ChatSearch = (spaceId: string, chatId: string, fullText: string, of
 
 export const ChatSetPinnedMessages = (objectId: string, messageIds: string[], pinned: boolean, callBack?: (message: any) => void) => {
 	dispatcher.request('ChatSetPinnedMessages', {
-		objectId,
+		chatObjectId: objectId,
 		messageIds,
 		pinned,
 	}, callBack);
 };
 
 export const ChatGetPinnedMessages = (objectId: string, callBack?: (message: any) => void) => {
-	dispatcher.request('ChatGetPinnedMessages', { objectId }, callBack);
+	dispatcher.request('ChatGetPinnedMessages', { chatObjectId: objectId }, callBack);
 };
 
 export const RelationListWithValue = (spaceId: string, value: any, callBack?: (message: any) => void) => {

--- a/src/ts/lib/api/dispatcher.ts
+++ b/src/ts/lib/api/dispatcher.ts
@@ -1348,7 +1348,11 @@ class Dispatcher {
 						};
 					});
 
-					$(window).trigger('pinnedStatusUpdate', [ mapped.message, mapped.isPinned, mapped.subIds ]);
+					U.Dom.eventDispatch(window, 'pinnedStatusUpdate', {
+						message: mapped.message,
+						isPinned: mapped.isPinned,
+						subIds: mapped.subIds,
+					});
 					break;
 				};
 

--- a/src/ts/lib/api/mapper.ts
+++ b/src/ts/lib/api/mapper.ts
@@ -1851,6 +1851,7 @@ export const Mapper = {
 			return {
 				message: obj.message ? Mapper.From.ChatMessage(obj.message) : null,
 				isPinned: obj.isPinned,
+				subIds: obj.subIds || [],
 			};
 		},
 


### PR DESCRIPTION
- rename payload key objectId → chatObjectId in ChatSetPinnedMessages and ChatGetPinnedMessages to match middleware proto
- include subIds in ChatUpdatePinnedStatus mapper to avoid undefined.length crash
- replace jQuery $(window).trigger with U.Dom.eventDispatch for pinnedStatusUpdate
- use pin icon (not unpin) for the pin action in chat message menu

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
