### PR TITLE
JS-9645: integrate GO-7143 profile/report RPCs

### DIFF
--- a/electron/js/preload.cjs
+++ b/electron/js/preload.cjs
@@ -61,6 +61,8 @@ contextBridge.exposeInMainWorld('Electron', {
 
 	webFilePath: file => webUtils && webUtils.getPathForFile(file),
 
+	fileRead: fp => new Uint8Array(fs.readFileSync(fp)),
+
 	fileWrite: (name, data, options) => {
 		name = String(name || 'temp');
 		options = options || {};

--- a/electron/js/preload.cjs
+++ b/electron/js/preload.cjs
@@ -5,6 +5,11 @@ const os = require('os');
 const path = require('path');
 const mime = require('mime-types');
 const tmpPath = () => app.getPath('temp');
+const commonPath = () => {
+	const dir = path.join(app.getPath('userData'), 'common');
+	try { fs.mkdirSync(dir, { recursive: true }); } catch (e) {};
+	return dir;
+};
 
 contextBridge.exposeInMainWorld('Electron', {
 	version: {
@@ -23,6 +28,7 @@ contextBridge.exposeInMainWorld('Electron', {
 	isPackaged: app.isPackaged,
 	userPath: () => app.getPath('userData'),
 	tmpPath,
+	commonPath,
 	downloadPath: () => app.getPath('downloads'),
 	logPath: () => path.join(app.getPath('userData'), 'logs'),
 	dirName: fp => path.dirname(fp),
@@ -61,7 +67,15 @@ contextBridge.exposeInMainWorld('Electron', {
 
 	webFilePath: file => webUtils && webUtils.getPathForFile(file),
 
-	fileRead: fp => new Uint8Array(fs.readFileSync(fp)),
+	logRead: fp => {
+		const base = commonPath();
+		const resolved = path.resolve(fp);
+		const rel = path.relative(base, resolved);
+		if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) {
+			throw new Error('logRead: path is outside of the common folder');
+		};
+		return new Uint8Array(fs.readFileSync(resolved));
+	},
 
 	fileWrite: (name, data, options) => {
 		name = String(name || 'temp');

--- a/electron/ts/menu.ts
+++ b/electron/ts/menu.ts
@@ -293,6 +293,7 @@ class MenuManager {
 					{ label: Util.translate('electronMenuTutorial'), click: () => Util.send(this.win, 'commandGlobal', 'tutorial') },
 					{ label: Util.translate('electronMenuContact'), click: () => Util.send(this.win, 'commandGlobal', 'contact') },
 					{ label: Util.translate('electronMenuTech'), click: () => Util.send(this.win, 'commandGlobal', 'tech') },
+					{ label: Util.translate('electronMenuSubmitReport'), click: () => Util.send(this.win, 'commandGlobal', 'submitReport') },
 
 					Separator,
 
@@ -388,6 +389,10 @@ class MenuManager {
 				{ label: Util.translate('electronMenuDebugNet'), click: () => Util.send(this.win, 'commandGlobal', 'debugNet') },
 				{ label: Util.translate('electronMenuDebugLog'), click: () => Util.send(this.win, 'commandGlobal', 'debugLog') },
 				{ label: Util.translate('electronMenuDebugProfiler'), click: () => Util.send(this.win, 'commandGlobal', 'debugProfiler') },
+				{ label: Util.translate('electronMenuDebugReport'), click: (item: Electron.MenuItem, window: BrowserWindow | undefined, event: Electron.KeyboardEvent) => {
+					const full = event && (event as Electron.KeyboardEvent & { altKey?: boolean }).altKey;
+					Util.send(this.win, 'commandGlobal', 'debugReport', { full });
+				}},
 
 				Separator,
 

--- a/src/json/text.json
+++ b/src/json/text.json
@@ -234,6 +234,7 @@
 	"commonOpenType": "Open Type",
 	"commonSize": "Size",
 	"commonLogout": "Log out",
+	"commonShowInFolder": "Show in folder",
 	"commonShowMore": "Show more",
 	"commonShowLess": "Show less",
 	"commonWarning": "Warning",
@@ -359,6 +360,7 @@
 	"electronMenuDebugNet": "Network",
 	"electronMenuDebugLog": "Export log",
 	"electronMenuDebugProfiler": "Export CPU trace",
+	"electronMenuDebugReport": "Generate report",
 	"electronMenuClose": "Close Window",
 	"electronMenuEdit": "Edit",
 	"electronMenuUndo": "Undo",
@@ -386,6 +388,7 @@
 	"electronMenuGallery": "ANY Experience Gallery",
 	"electronMenuTutorial": "Help and Tutorials",
 	"electronMenuContact": "Contact Us",
+	"electronMenuSubmitReport": "Submit report",
 	"electronMenuTech": "Technical Information",
 	"electronMenuTerms": "Terms of Use",
 	"electronMenuPrivacy": "Privacy Policy",
@@ -1393,6 +1396,13 @@
 	"popupConfirmActionRestrictedText": "You cannot do this in read-only space",
 
 	"popupConfirmActionReconcileText": "This operation will clean up the incorrectly occupied space in the remote file storage. Are you sure?",
+
+	"popupConfirmDebugReportTitle": "Report generated",
+	"popupConfirmDebugReportText": "Share the archive with support@anytype.io and describe your issue.<br/><br/>The report includes recent error logs, object and channel IDs, your public identity ID, and basic device info (OS, processor, etc). It does not include object content. Feel free to review the archive before sending.",
+	"popupSubmitReportTitle": "Submit report",
+	"popupSubmitReportPrivacy": "The report includes recent error logs, object and channel IDs, your public identity ID, and basic device info (OS, processor, etc). It does not include object content. It is sent to the Anytype team along with your description below.",
+	"popupSubmitReportPlaceholder": "Describe the issue you are facing…",
+	"popupSubmitReportButton": "Submit",
 
 	"popupConfirmOpenExternalLinkTitle": "Are you sure?",
 	"popupConfirmOpenExternalLinkText": "You are trying to open an url that is potentially harmful. Are you sure you want to proceed?<br/>Url: %s",

--- a/src/scss/popup/common.scss
+++ b/src/scss/popup/common.scss
@@ -73,3 +73,4 @@ html.platformWindows {
 @import "./aiOnboarding";
 @import "./introduceChats";
 @import "./upload";
+@import "./submitReport";

--- a/src/scss/popup/submitReport.scss
+++ b/src/scss/popup/submitReport.scss
@@ -1,0 +1,18 @@
+.popups {
+	.popup.popupSubmitReport {
+		.innerWrap { width: 424px; padding: 32px; text-align: center; }
+		.title { @include text-header3; margin-bottom: 6px; }
+		.label { margin-bottom: 16px; user-select: text !important; word-wrap: break-word; }
+
+		.inputs { margin-bottom: 16px; }
+		.inputs {
+			.textarea { width: 100%; padding: 10px 12px; border: 1px solid var(--color-shape-secondary); border-radius: 8px; resize: vertical; min-height: 96px; @include text-common; }
+		}
+
+		.buttons { display: flex; flex-direction: column; gap: 8px 0px; }
+		.buttons {
+			.button { width: 100%; }
+			.button.blank:not(:hover):not(.hover) { background-color: var(--color-bg-primary); }
+		}
+	}
+}

--- a/src/ts/component/form/textarea.tsx
+++ b/src/ts/component/form/textarea.tsx
@@ -138,7 +138,7 @@ const Textarea = forwardRef<TextareaRefProps, Props>(({
 		U.Dom.removeClass(nodeRef.current, v);
 	};
 	
-	useEffect(() => setValue(initialValue));
+	useEffect(() => setValue(initialValue), [ initialValue ]);
 	useImperativeHandle(ref, () => ({ 
 		focus, 
 		select, 

--- a/src/ts/component/popup/index.tsx
+++ b/src/ts/component/popup/index.tsx
@@ -31,6 +31,7 @@ import PopupApiCreate from './api/create';
 import PopupAIOnboarding from './aiOnboarding';
 import PopupIntroduceChats from './introduceChats';
 import PopupUpload from './upload';
+import PopupSubmitReport from './submitReport';
 import * as I from 'Interface';
 import Storage from 'Lib/storage';
 
@@ -191,6 +192,7 @@ const Popup = forwardRef<{}, I.Popup>((props, ref) => {
 		aiOnboarding:			 PopupAIOnboarding,
 		introduceChats:			 PopupIntroduceChats,
 		upload:					 PopupUpload,
+		submitReport:			 PopupSubmitReport,
 	};
 	
 	const popupId = getId();

--- a/src/ts/component/popup/submitReport.tsx
+++ b/src/ts/component/popup/submitReport.tsx
@@ -1,0 +1,59 @@
+import React, { forwardRef, useEffect, useRef } from 'react';
+import { Title, Label, Button, Textarea } from 'Component';
+import * as I from 'Interface';
+
+const PopupSubmitReport = forwardRef<{}, I.Popup>((props, ref) => {
+
+	const { param, close } = props;
+	const { data } = param;
+	const { onSubmit } = data;
+	const textareaRef = useRef(null);
+
+	const onSubmitHandler = () => {
+		const value = String(textareaRef.current?.getValue() || '').trim();
+
+		close();
+		onSubmit?.(value);
+	};
+
+	const onCancelHandler = () => {
+		close();
+	};
+
+	useEffect(() => {
+		textareaRef.current?.focus();
+	}, []);
+
+	return (
+		<div className="wrap">
+			<Title text={translate('popupSubmitReportTitle')} />
+			<Label text={translate('popupSubmitReportPrivacy')} />
+
+			<div className="inputs">
+				<Textarea
+					ref={textareaRef}
+					placeholder={translate('popupSubmitReportPlaceholder')}
+					rows={5}
+				/>
+			</div>
+
+			<div className="buttons">
+				<Button
+					text={translate('popupSubmitReportButton')}
+					color="accent"
+					size={36}
+					onClick={onSubmitHandler}
+				/>
+				<Button
+					text={translate('commonCancel')}
+					color="blank"
+					size={36}
+					onClick={onCancelHandler}
+				/>
+			</div>
+		</div>
+	);
+
+});
+
+export default PopupSubmitReport;

--- a/src/ts/interface/common.ts
+++ b/src/ts/interface/common.ts
@@ -7,6 +7,15 @@ export enum Platform {
 	Linux	 = 'Linux',
 };
 
+export enum ProfilerReason {
+	Unknown					 = 0,
+	UserRequest				 = 1,
+	MemoryPressureWarn		 = 2,
+	MemoryPressureCritical	 = 3,
+	ThermalSerious			 = 4,
+	ThermalCritical			 = 5,
+};
+
 export enum DropType {
 	None	 = '',
 	Block	 = 'block',

--- a/src/ts/lib/api/command.ts
+++ b/src/ts/lib/api/command.ts
@@ -5,7 +5,7 @@ export const InitialSetParameters = (platform: I.Platform, version: string, work
 	dispatcher.request('InitialSetParameters', {
 		platform,
 		version,
-		workDir,
+		workdir: workDir,
 		logLevel,
 		doNotSendLogs,
 		doNotSaveLogs,
@@ -1634,8 +1634,16 @@ export const DebugExportLog = (path: string, callBack?: (message: any) => void) 
 	dispatcher.request('DebugExportLog', { dir: path }, callBack);
 };
 
-export const DebugRunProfiler = (duration: number, callBack?: (message: any) => void) => {
-	dispatcher.request('DebugRunProfiler', { durationInSeconds: duration }, callBack);
+export const DebugRunProfiler = (duration: number, reason: I.ProfilerReason, reasonDesc: string, callBack?: (message: any) => void) => {
+	dispatcher.request('DebugRunProfiler', { durationInSeconds: duration, reason, reasonDesc }, callBack);
+};
+
+export const DebugExportReport = (path: string, full: boolean, callBack?: (message: any) => void) => {
+	dispatcher.request('DebugExportReport', { dir: path, full }, callBack);
+};
+
+export const DebugCleanupReport = (ts: number, callBack?: (message: any) => void) => {
+	dispatcher.request('DebugCleanupReport', { ts }, callBack);
 };
 
 // ---------------------- NOTIFICATION ---------------------- //

--- a/src/ts/lib/api/dispatcher.ts
+++ b/src/ts/lib/api/dispatcher.ts
@@ -294,11 +294,11 @@ class Dispatcher {
 
 								scope.addAttachment({
 									filename: electron.fileName(mapped.path),
-									data: electron.fileRead(mapped.path),
+									data: electron.logRead(mapped.path),
 									contentType: electron.fileMime(mapped.path) || 'application/octet-stream',
 								});
 							} catch (e) {
-								console.error('[DebugProfileCreated] fileRead failed:', mapped.path, e);
+								console.error('[DebugProfileCreated] logRead failed:', mapped.path, e);
 							};
 						};
 

--- a/src/ts/lib/api/dispatcher.ts
+++ b/src/ts/lib/api/dispatcher.ts
@@ -1,6 +1,7 @@
 
 import { arrayMove } from '@dnd-kit/sortable';
 import { observable, set, runInAction } from 'mobx';
+import * as Sentry from '@sentry/browser';
 import type { Event } from 'Proto/pb/protos/events';
 import * as Response from './response';
 import type { ClientReadableStream } from 'grpc-web';
@@ -264,6 +265,44 @@ class Dispatcher {
 						...mapped,
 						theme: S.Common.getThemeClass(),
 						lang: S.Common.interfaceLang,
+					});
+					break;
+				};
+
+				case 'DebugProfileCreated': {
+					const reason = mapped.reason || 'Unknown';
+					const electron = U.Common.getElectron();
+
+					console.log('[DebugProfileCreated] event:', mapped);
+
+					Sentry.withScope(scope => {
+						scope.setLevel('info');
+						scope.setTag('report', 'mw_profile');
+						scope.setTag('reason', reason);
+						scope.setFingerprint([ 'mw-profile', reason ]);
+
+						try {
+							scope.setContext('info', JSON.parse(mapped.jsonInfo));
+						} catch (e) {
+							scope.setExtra('info', mapped.jsonInfo);
+						};
+
+						if (mapped.path) {
+							try {
+								const size = electron.fileSize(mapped.path);
+								console.log('[DebugProfileCreated] attaching file:', mapped.path, 'size:', size);
+
+								scope.addAttachment({
+									filename: electron.fileName(mapped.path),
+									data: electron.fileRead(mapped.path),
+									contentType: electron.fileMime(mapped.path) || 'application/octet-stream',
+								});
+							} catch (e) {
+								console.error('[DebugProfileCreated] fileRead failed:', mapped.path, e);
+							};
+						};
+
+						Sentry.captureMessage(`MW_${reason}`);
 					});
 					break;
 				};

--- a/src/ts/lib/api/mapper.ts
+++ b/src/ts/lib/api/mapper.ts
@@ -1317,6 +1317,15 @@ export const Mapper = {
 			};
 		},
 
+		DebugProfileCreated: (obj: any) => {
+			return {
+				reason: String(obj.reason || ''),
+				jsonInfo: String(obj.jsonInfo || ''),
+				path: String(obj.path || ''),
+				full: Boolean(obj.full),
+			};
+		},
+
 		AccountUpdate: (obj: any) => {
 			return {
 				status: Mapper.From.AccountStatus(obj.status || {}),

--- a/src/ts/lib/api/response.ts
+++ b/src/ts/lib/api/response.ts
@@ -101,6 +101,14 @@ export const DebugRunProfiler = (response: any) => {
 	};
 };
 
+export const DebugExportReport = (response: any) => {
+	return {
+		path: response.path,
+		summary: response.summary,
+		lastModifiedTs: response.lastModifiedTs,
+	};
+};
+
 export const Export = (response: any) => {
 	return {
 		path: response.path,

--- a/src/ts/lib/keyboard.ts
+++ b/src/ts/lib/keyboard.ts
@@ -1007,13 +1007,13 @@ class Keyboard {
 					data: {
 						onSubmit: (description: string) => {
 							C.DebugRunProfiler(0, I.ProfilerReason.UserRequest, '', () => {
-								C.DebugExportReport(tmpPath, false, (message: any) => {
+								C.DebugExportReport(electron.commonPath(), false, (message: any) => {
 									if (message.error.code) {
 										return;
 									};
 
 									// Sentry envelope limit is ~20MB; keep attachments under ~10MB to be safe.
-									const data = electron.fileRead(message.path);
+									const data = electron.logRead(message.path);
 
 									Sentry.withScope(scope => {
 										scope.setLevel('info');

--- a/src/ts/lib/keyboard.ts
+++ b/src/ts/lib/keyboard.ts
@@ -1,5 +1,6 @@
 import { history as historyPopup } from 'Lib/history';
 import * as I from 'Interface';
+import * as Sentry from '@sentry/browser';
 import Storage from 'Lib/storage';
 import { focus } from 'Lib/focus';
 
@@ -968,10 +969,81 @@ class Keyboard {
 			};
 
 			case 'debugProfiler': {
-				C.DebugRunProfiler(30, (message: any) => {
+				C.DebugRunProfiler(30, I.ProfilerReason.UserRequest, '', (message: any) => {
 					if (!message.error.code) {
 						Action.openPath(message.path);
 					};
+				});
+				break;
+			};
+
+			case 'debugReport': {
+				const full = arg?.full || false;
+
+				Action.openDirectoryDialog({ buttonLabel: translate('commonExport') }, paths => {
+					C.DebugRunProfiler(0, I.ProfilerReason.UserRequest, '', () => {
+						C.DebugExportReport(paths[0], full, (message: any) => {
+							if (message.error.code) {
+								return;
+							};
+
+							S.Popup.open('confirm', {
+								data: {
+									title: translate('popupConfirmDebugReportTitle'),
+									text: translate('popupConfirmDebugReportText'),
+									textConfirm: translate('commonShowInFolder'),
+									canCancel: true,
+									onConfirm: () => Action.openPath(U.Common.getElectron().dirName(message.path)),
+								},
+							});
+						});
+					});
+				});
+				break;
+			};
+
+			case 'submitReport': {
+				S.Popup.open('submitReport', {
+					data: {
+						onSubmit: (description: string) => {
+							C.DebugRunProfiler(0, I.ProfilerReason.UserRequest, '', () => {
+								C.DebugExportReport(tmpPath, false, (message: any) => {
+									if (message.error.code) {
+										return;
+									};
+
+									// Sentry envelope limit is ~20MB; keep attachments under ~10MB to be safe.
+									const data = electron.fileRead(message.path);
+
+									Sentry.withScope(scope => {
+										scope.setLevel('info');
+										scope.setTag('report', 'user_submitted');
+										scope.setFingerprint([ 'debug-report' ]);
+
+										if (description) {
+											scope.setContext('report', { description });
+										};
+
+										try {
+											scope.setContext('summary', JSON.parse(message.summary));
+										} catch (e) {
+											scope.setExtra('summary', message.summary);
+										};
+
+										scope.addAttachment({
+											filename: 'debug-report.zip',
+											data,
+											contentType: 'application/zip',
+										});
+										Sentry.captureMessage('Debug report');
+									});
+
+									C.DebugCleanupReport(message.lastModifiedTs);
+									Preview.toastShow({ text: translate('commonDone') });
+								});
+							});
+						},
+					},
 				});
 				break;
 			};


### PR DESCRIPTION
## Summary
- Wire desktop-side changes for [JS-9645](https://linear.app/anytype/issue/JS-9645) (backend [GO-7143](https://linear.app/anytype/issue/GO-7143), heart PR [#3115](https://github.com/anyproto/anytype-heart/pull/3115))
- Fix `InitialSetParameters` payload key (`workDir` → `workdir`) so middleware picks it up and profiler / export stop failing with "log path not configured"
- New `DebugExportReport` and `DebugCleanupReport` command wrappers; `DebugRunProfiler` gains `reason` + `reasonDesc` via new `I.ProfilerReason` enum
- Debug menu → **Generate report**: writes archive to a directory of user's choice
- Help menu → **Submit report**: opens a dedicated popup (title, privacy disclosure, description textarea), then generates a fast profile snapshot, exports the archive, attaches the zip to Sentry with description + summary context, and calls `DebugCleanupReport` so the same logs aren't shipped twice
- Fix `<Textarea>` bug where `useEffect` missing its dep array wiped state on every keystroke

## Finding submissions in Sentry
Events are captured with `level: info`, `tag report=user_submitted`, `fingerprint debug-report`. Search `report:user_submitted` to see all submissions grouped into a single "Debug report" issue; zip lives under the event's **Attachments** tab.

## Test plan
- [x] Debug → Generate report writes the archive to the chosen folder and opens the confirm popup
- [x] Help → Submit report opens the new popup; typing in the description persists; Submit attaches the zip + description to Sentry and shows "Done" toast
- [x] Verify `DebugCleanupReport` is called after the Sentry capture (check heart logs / logs folder)
- [x] No "log path not configured" errors on fresh launch (thanks to the `workdir` fix)
- [ ] Existing "Export CPU trace" (Debug → Profiler) still works with the new `reason`/`reasonDesc` arguments