### PR TITLE
Bugfix/JS-9631: Fix editors disappearing when creating group over tier limit

### DIFF
--- a/src/ts/component/popup/space/create.tsx
+++ b/src/ts/component/popup/space/create.tsx
@@ -85,9 +85,7 @@ const PopupSpaceCreate = forwardRef<{}, I.Popup>(({ param = {}, close, position 
 	};
 
 	const getSeatCounters = () => {
-		const product = S.Membership.data?.getTopProduct();
-		const writersLimit = product?.features?.spaceWriters || 0;
-		const readersLimit = product?.features?.spaceReaders || 0;
+		const { writersLimit, readersLimit } = U.Space.getTierLimits();
 		const writersCount = Math.min(selectedCount, writersLimit);
 		const readersCount = Math.min(Math.max(selectedCount - writersLimit, 0), readersLimit);
 
@@ -243,8 +241,7 @@ const PopupSpaceCreate = forwardRef<{}, I.Popup>(({ param = {}, close, position 
 					};
 
 					if (isShared) {
-						const product = S.Membership.data?.getTopProduct();
-						const writersLimit = product?.features?.spaceWriters || 0;
+						const { writersLimit } = U.Space.getTierLimits();
 
 						if (!S.Common.isOnline) {
 							Action.savePendingMembers(spaceId, identities);

--- a/src/ts/lib/action.ts
+++ b/src/ts/lib/action.ts
@@ -953,8 +953,7 @@ class Action {
 			return;
 		};
 
-		const product = S.Membership.data?.getTopProduct();
-		const writersLimit = product?.features?.spaceWriters || 0;
+		const { writersLimit } = U.Space.getTierLimits();
 		const maxRetries = 5;
 		const failed: { spaceId: string; identities: string[] }[] = [];
 

--- a/src/ts/lib/util/space.ts
+++ b/src/ts/lib/util/space.ts
@@ -463,6 +463,19 @@ class UtilSpace {
 	};
 
 	/**
+	 * Gets writer/reader slots available to invitees from the current membership tier.
+	 * writersLimit subtracts 1 because the owner occupies one writer seat in the middleware's count.
+	 * @returns {{ writersLimit: number, readersLimit: number }} Tier-level slots for new members.
+	 */
+	getTierLimits () {
+		const product = S.Membership.data?.getTopProduct();
+		return {
+			writersLimit: Math.max(0, (product?.features?.spaceWriters || 0) - 1),
+			readersLimit: product?.features?.spaceReaders || 0,
+		};
+	};
+
+	/**
 	 * Gets the invite link for a given CID and key.
 	 * @param {string} cid - The CID.
 	 * @param {string} key - The key.


### PR DESCRIPTION
Owner occupies one writer seat in the middleware's count, so splitting identities at the full spaceWriters value sent a writer batch that SpaceParticipantsAddList rejected as LIMIT_REACHED — leaving only overflow viewers visible. Subtract 1 to reserve the owner's seat.

Extracted to U.Space.getTierLimits() for the three call sites (group creation submission, offline reconnect retry, seat counter).

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
