### PR TITLE
Unify editor quote block style with discussion quote protocol

### DIFF
--- a/src/scss/block/text.scss
+++ b/src/scss/block/text.scss
@@ -187,7 +187,10 @@
 			> .selectionTarget > .dropTarget { padding: 1px 0px 2px 0px; }
 
 			> .additional {
-				> .line { width: 0px; height: 100%; position: absolute; left: 11px; top: 0px; border-left: 1.5px solid; }
+				> .line {
+					width: 4px; height: 100%; position: absolute; left: 11px; top: 0px;
+					background-color: currentColor; color: var(--color-control-inactive); border-radius: 100px;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

The discussion/comment system already has an established quote protocol — a 4px rounded vertical bar in `--color-control-inactive`, used by both the comment editor (`commentEditor-quote`) and rendered posts (`commentBlockquote`). The block-based editor's `textQuote` block uses a different visual: a 1.5px solid `border-left` colored with the text color.

This PR aligns the editor's quote block with the discussion protocol so quotes look the same wherever they appear:

- `src/scss/block/text.scss` — `.block.blockText.textQuote > .wrapContent > .additional > .line` now renders as a `4px` wide bar with `border-radius: 100px` and a default `color: var(--color-control-inactive)`.
- The bar uses `background-color: currentColor`, so the existing `textColor-{color}` override still works — picking a text color tints the bar to match, preserving current color-picker behavior.
- Position (`left: 11px`) and content `padding-left: 28px` are unchanged to preserve text alignment within the editor's marker column.
- The `align2` (right-aligned) variant continues to work — only the line shape changed, not its anchoring.

No changes needed to comment quote rendering — `commentBlockquote` and `commentEditor-quote` already define the protocol.

## Test plan

- [ ] In the editor, insert a quote block (e.g. type `> ` at the start of a line) and confirm the left bar is 4px wide, rounded at the ends, and uses the inactive control color (matching a chat reply quote).
- [ ] Apply a text color to a quote block via the toolbar — the bar should tint to the chosen color (currentColor fallback).
- [ ] Right-align a quote block — bar should appear on the right side, same shape.
- [ ] Verify in dark theme — bar should still pick up the themed `--color-control-inactive` value.
- [ ] Compare side-by-side with a chat reply blockquote to confirm visual parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)