### PR TITLE
Feature/JS-9511: Notification preferences and unread tracking

### DIFF
--- a/src/json/constant.ts
+++ b/src/json/constant.ts
@@ -143,6 +143,8 @@ export default {
 		chatPreview:	 		'chatPreview',
 		chat:			 		'chat',
 		chatGlobal:	 			'chatGlobal',
+		discussion:		 		'discussion',
+		discussionGlobal: 		'discussionGlobal',
 		recentEditMe:	 		'recentEditMe',
 		recentEditAll:	 		'recentEditAll',
 	},

--- a/src/scss/component/comment.scss
+++ b/src/scss/component/comment.scss
@@ -25,6 +25,9 @@
 	.commentCounter {
 		.icon.discussion { width: 13px; height: 12px; color: var(--color-text-secondary); }
 		.count { @include text-small; color: var(--color-text-secondary); line-height: 18px; font-weight: 500; }
+
+		.unreadDot { width: 8px; height: 8px; border-radius: 50%; background: var(--color-system-accent-50); }
+		.unreadDot.isMuted { background: var(--color-text-tertiary); }
 	}
 }
 

--- a/src/ts/component/comment/section.tsx
+++ b/src/ts/component/comment/section.tsx
@@ -13,12 +13,21 @@ const SCROLL_THRESHOLD = 16;
 const CommentSection = (props: I.CommentSectionProps) => {
 
 	const { rootId, targetId, targetType, readonly, isPopup, messageId } = props;
+	const { space: spaceId } = S.Common;
+	const spaceview = U.Space.getSpaceviewBySpaceId(spaceId);
 	const object = S.Detail.get(rootId, rootId, [ 'discussionId', 'isArchived' ]);
 	const [ localDiscussionId, setLocalDiscussionId ] = useState('');
 	const [ isExpanded, setIsExpanded ] = useState(false);
 	const isHiddenRef = useRef(false);
 	const discussionId = object.discussionId || localDiscussionId || '';
 	const subId = U.Comment.getSubId(targetType, discussionId || targetId);
+	const chatState = discussionId ? S.Chat.getState(subId) : null;
+	const chatMode = (discussionId && spaceview) ? U.Object.getChatNotificationMode(spaceview, discussionId) : I.NotificationMode.All;
+	const messageCounter = Number(chatState?.messageCounter) || 0;
+	const mentionCounter = Number(chatState?.mentionCounter) || 0;
+	const reactionCounter = Number(chatState?.reactionCounter) || 0;
+	const hasUnread = !!(messageCounter || mentionCounter || reactionCounter);
+	const dotIsMuted = (chatMode != I.NotificationMode.All) && !mentionCounter && !reactionCounter;
 	const formRef = useRef<any>(null);
 	const isLoaded = useRef(false);
 	const isBottom = useRef(false);
@@ -566,6 +575,7 @@ const CommentSection = (props: I.CommentSectionProps) => {
 				};
 			};
 
+			S.Detail.update(rootId, { id: rootId, details: { discussionId: id } }, false);
 			setLocalDiscussionId(id);
 			subscribe(id);
 			callBack(id);
@@ -660,15 +670,40 @@ const CommentSection = (props: I.CommentSectionProps) => {
 		updateSocialVisibility();
 		resize();
 
-		window.setTimeout(() => {
-			const container = U.Dom.getScrollContainer(isPopup);
-			if (container) {
-				container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
-			};
+		const unreadOrderId = chatState?.mentionOrderId || chatState?.messageOrderId || '';
+		let unreadMessageId = '';
 
-			window.setTimeout(() => formRef.current?.focus(), 300);
+		if (unreadOrderId) {
+			const posts = S.Comment.getPosts(subId);
+			const post = posts.find(p => p.orderId == unreadOrderId);
+			if (post) {
+				unreadMessageId = post.id;
+			} else {
+				for (const p of posts) {
+					const reply = (S.Comment.getReplies(p.id) || []).find(r => r.orderId == unreadOrderId);
+					if (reply) {
+						unreadMessageId = reply.id;
+						break;
+					};
+				};
+			};
+		};
+
+		window.setTimeout(() => {
+			if (unreadMessageId) {
+				scrollToMessage(unreadMessageId);
+			} else {
+				const container = U.Dom.getScrollContainer(isPopup);
+				const node = sectionRef.current;
+				if (container && node) {
+					const rect = node.getBoundingClientRect();
+					const containerRect = container.getBoundingClientRect();
+					const top = container.scrollTop + (rect.top - containerRect.top);
+					container.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
+				};
+			};
 		}, 50);
-	}, [ isPopup, resize ]);
+	}, [ isPopup, resize, chatState, subId, scrollToMessage ]);
 
 	const counterLabel = postCount > 0
 		? `${postCount} ${U.Common.plural(postCount, translate('pluralComment'))}`
@@ -712,6 +747,7 @@ const CommentSection = (props: I.CommentSectionProps) => {
 					<div className="commentCounter" onClick={onCounterClick}>
 						<Icon name="comment/discussion" className="discussion" size={18} />
 						<span className="count">{counterLabel}</span>
+						{hasUnread ? <div className={[ 'unreadDot', (dotIsMuted ? 'isMuted' : '') ].join(' ')} /> : null}
 					</div>
 					<div className="grad" />
 				</div>

--- a/src/ts/component/menu/object.tsx
+++ b/src/ts/component/menu/object.tsx
@@ -27,6 +27,7 @@ const MenuObject = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	const isRelation = U.Object.isRelationLayout(object.layout);
 	const isType = U.Object.isTypeLayout(object.layout);
 	const isVideoOrAudio = U.Object.isVideoOrAudioLayout(object.layout);
+	const hasDiscussion = !!object.discussionId;
 	const canWrite = U.Space.canMyParticipantWrite();
 	const canDelete = S.Block.checkFlags(rootId, rootId, [ I.RestrictionObject.Delete ]);
 	const route = analytics.route.menuObject;
@@ -144,7 +145,7 @@ const MenuObject = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			S.Block.isAllowed(type?.restrictions, [ I.RestrictionObject.Details ])
 		);
 		const allowedEditChat = canWrite && isChat;
-		const allowedNotification = isChat;
+		const allowedNotification = (isChat || hasDiscussion) && canWrite;
 		const allowedCopyMedia = U.Object.isImageLayout(object.layout);
 		if (!allowedPageLink) {
 			pageLink = null;
@@ -172,7 +173,7 @@ const MenuObject = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		if (!allowedNotification) {
 			notification = null;
 		} else
-		if (spaceview.isOneToOne) {
+		if (isChat && spaceview.isOneToOne) {
 			const chatMode = U.Object.getChatNotificationMode(spaceview, object.id);
 			const isMuted = chatMode != I.NotificationMode.All;
 
@@ -367,12 +368,15 @@ const MenuObject = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			};
 
 			case 'notification': {
+				const targetId = isChat ? object.id : (object.discussionId || object.id);
+				const mode = U.Object.getChatNotificationMode(spaceview, targetId);
+
 				menuId = 'select';
 				menuParam.data = {
-					value: String(U.Object.getChatNotificationMode(spaceview, object.id) || ''),
-					options: U.Menu.notificationModeOptions(),
+					value: String(mode ?? ''),
+					options: U.Menu.notificationModeOptions(false, hasDiscussion),
 					onSelect: (e, option) => {
-						Action.setChatNotificationMode(space, [ object.id ], Number(option.id), analytics.route.menuObject);
+						Action.setChatNotificationMode(space, [ targetId ], Number(option.id), analytics.route.menuObject);
 						close();
 					},
 				};

--- a/src/ts/component/sidebar/page/vault.tsx
+++ b/src/ts/component/sidebar/page/vault.tsx
@@ -215,7 +215,15 @@ const SidebarPageVault = forwardRef<{}, I.SidebarPageComponent>((props, ref) => 
 	const getItems = (skipUi?: boolean) => {
 		let items = U.Menu.getVaultItems().map(it => {
 			if (it.lastMessage) {
-				it.chat = S.Detail.get(J.Constant.subId.chatGlobal, it.lastMessage.chatId, J.Relation.chatGlobal, true);
+				const lastChatId = it.lastMessage.chatId;
+				const chat = S.Detail.get(J.Constant.subId.chatGlobal, lastChatId, J.Relation.chatGlobal, true);
+
+				if (!chat._empty_) {
+					it.chat = chat;
+				} else {
+					const parent = S.Record.getRecords(J.Constant.subId.discussionGlobal).find(r => r.discussionId == lastChatId);
+					it.chat = parent || chat;
+				};
 			};
 			return it;
 		});

--- a/src/ts/component/widget/object.tsx
+++ b/src/ts/component/widget/object.tsx
@@ -246,11 +246,13 @@ const WidgetObject = forwardRef<{}, I.WidgetComponent>((props, ref) => {
 			transition,
 		};
 		const isChat = U.Object.isChatLayout(item.layout);
+		const hasDiscussion = !isChat && !!item.discussionId;
+		const counterId = isChat ? item.id : (hasDiscussion ? item.discussionId : '');
 		const canAdd = canWrite && (realId == J.Constant.widgetId.type) && isAllowedObject(item);
 		const spaceview = U.Space.getSpaceview();
 		const itemCn = [ 'item' ];
 
-		if (isChat && (U.Object.getChatNotificationMode(spaceview, item.id) == I.NotificationMode.Nothing)) {
+		if (counterId && (U.Object.getChatNotificationMode(spaceview, counterId) == I.NotificationMode.Nothing)) {
 			itemCn.push('isMuted');
 		};
 
@@ -284,7 +286,7 @@ const WidgetObject = forwardRef<{}, I.WidgetComponent>((props, ref) => {
 					<ObjectName object={item} withPlural={true} />
 				</div>
 				<div className="side right">
-					{isChat && (!hasUnreadSection || isUnread) ? <ChatCounter chatId={item.id} /> : ''}
+					{counterId && (!hasUnreadSection || isUnread) ? <ChatCounter chatId={counterId} /> : ''}
 					{canAdd ? (
 						<div className="buttons">
 							<Icon

--- a/src/ts/lib/util/data.ts
+++ b/src/ts/lib/util/data.ts
@@ -1364,17 +1364,24 @@ class UtilData {
 
 	getWidgetChats(): any[] {
 		const spaceview = U.Space.getSpaceview();
+		const spaceId = S.Common.space;
 
-		return S.Record.getRecords(U.Subscription.spaceSubId(J.Constant.subId.chat)).filter(it => {
-			const counters = S.Chat.getChatCounters(S.Common.space, it.id);
-			const mode = U.Object.getChatNotificationMode(spaceview, it.id);
+		const hasUnread = (id: string): boolean => {
+			const counters = S.Chat.getChatCounters(spaceId, id);
+			const mode = U.Object.getChatNotificationMode(spaceview, id);
 
 			if (mode == I.NotificationMode.Nothing) {
 				return (counters.mentionCounter > 0) || (counters.reactionCounter > 0);
 			};
 
 			return (counters.messageCounter > 0) || (counters.mentionCounter > 0) || (counters.reactionCounter > 0);
-		});
+		};
+
+		const chats = S.Record.getRecords(U.Subscription.spaceSubId(J.Constant.subId.chat)).filter(it => hasUnread(it.id));
+		const discussions = S.Record.getRecords(U.Subscription.spaceSubId(J.Constant.subId.discussion))
+			.filter(it => it.discussionId && hasUnread(it.discussionId));
+
+		return chats.concat(discussions);
 	};
 
 	getWidgetObjects (rootId: string, withHome: boolean): any[] {

--- a/src/ts/lib/util/menu.ts
+++ b/src/ts/lib/util/menu.ts
@@ -1704,7 +1704,7 @@ class UtilMenu {
 		].map(it => ({ ...it, name: translate(`spaceType${it.id}`) }));
 	};
 
-	notificationModeOptions (forSettings?: boolean): I.Option[] {
+	notificationModeOptions (forSettings?: boolean, forDiscussion?: boolean): I.Option[] {
 		const spaceview = U.Space.getSpaceview();
 
 		let ret = [
@@ -1719,6 +1719,9 @@ class UtilMenu {
 			return { ...it, name };
 		});
 
+		if (forDiscussion) {
+			ret = ret.filter(it => it.id != I.NotificationMode.Nothing);
+		} else
 		if (spaceview.isOneToOne) {
 			ret = ret.filter(it => it.id != I.NotificationMode.Mentions);
 		};

--- a/src/ts/lib/util/subscription.ts
+++ b/src/ts/lib/util/subscription.ts
@@ -455,6 +455,16 @@ class UtilSubscription {
 				noDeps: true,
 				crossSpace: true,
 			},
+			{
+				subId: J.Constant.subId.discussionGlobal,
+				filters: [
+					{ relationKey: 'discussionId', condition: I.FilterCondition.NotEmpty, value: null },
+					{ relationKey: 'resolvedLayout', condition: I.FilterCondition.NotEqual, value: I.ObjectLayout.Chat },
+				],
+				keys: J.Relation.chatGlobal.concat([ 'discussionId' ]),
+				noDeps: true,
+				crossSpace: true,
+			},
 		];
 		
 		this.destroyList(list.map(it => it.subId), true, () => {
@@ -570,6 +580,19 @@ class UtilSubscription {
 				keys: this.chatRelationKeys(),
 				filters: [
 					{ relationKey: 'resolvedLayout', condition: I.FilterCondition.Equal, value: I.ObjectLayout.Chat },
+				],
+				sorts: [
+					{ relationKey: 'lastMessageDate', type: I.SortType.Desc, format: I.RelationType.Date, includeTime: true },
+					{ relationKey: 'name', type: I.SortType.Asc },
+				],
+				noDeps: true,
+			},
+			{
+				subId: this.spaceSubId(J.Constant.subId.discussion),
+				keys: this.chatRelationKeys().concat([ 'discussionId' ]),
+				filters: [
+					{ relationKey: 'discussionId', condition: I.FilterCondition.NotEmpty, value: null },
+					{ relationKey: 'resolvedLayout', condition: I.FilterCondition.NotEqual, value: I.ObjectLayout.Chat },
 				],
 				sorts: [
 					{ relationKey: 'lastMessageDate', type: I.SortType.Desc, format: I.RelationType.Date, includeTime: true },


### PR DESCRIPTION
for object discussions

- Three-dot menu: Notifications submenu for objects with discussions (writers only)
- notificationModeOptions: forDiscussion flag filters out Nothing
- Comments button: blue/grey unread dot, click scrolls to first unread
- Unread widget: includes discussion-bearing objects via new per-space sub
- Pinned widget: counter badge for items with discussionId
- Vault preview: resolves discussion previews to parent object via new global sub

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
