### PR TITLE
JS-9511: notification preferences and unread tracking for object discussions

### DIFF
--- a/src/json/constant.ts
+++ b/src/json/constant.ts
@@ -143,6 +143,7 @@ export default {
 		chatPreview:	 		'chatPreview',
 		chat:			 		'chat',
 		chatGlobal:	 			'chatGlobal',
+		discussion:				'discussion',
 		recentEditMe:	 		'recentEditMe',
 		recentEditAll:	 		'recentEditAll',
 	},

--- a/src/json/text.json
+++ b/src/json/text.json
@@ -915,7 +915,6 @@
 	"popupSettingsPersonalLinkStyleCard": "Compact Card",
 	"popupSettingsPersonalLinkStyleCardMedium": "Medium Card",
 	"popupSettingsPersonalFileStyle": "File block default style",
-	"popupSettingsPersonalVaultStyle": "Channels hub density",
 	"popupSettingsPersonalSidebar": "Automatically show and hide sidebar",
 	"popupSettingsPersonalAlwaysShowTabbar": "Always show tab bar",
 	"popupSettingsPersonalHardwareAcceleration": "Hardware Acceleration",
@@ -941,8 +940,6 @@
 	"popupSettingsPersonalNotificationSoundSystem": "System",
 	"popupSettingsPersonalSectionAdvanced": "Advanced",
 	"popupSettingsPersonalTimeFormat": "Time format",
-	"popupSettingsVaultCompact": "Compact",
-	"popupSettingsVaultWithMessages": "Message previews",
 
 	"popupSettingsMobileQRSubTitle": "Log in your vault on Android and iOS",
 	"popupSettingsMobileQRText": "Launch Anytype app, tap \u201cLogin\u201d and then \u201cScan QR code\u201d. Reveal and scan the code below to login to your vault.",
@@ -2883,6 +2880,9 @@
 	"notificationMode2": "Mute and hide",
 	"notificationMode3": "Custom",
 	"notificationModeDisabled": "Disabled",
+
+	"notificationModeDiscussion0": "All New Replies",
+	"notificationModeDiscussion1": "Mentions Only",
 
 	"filterTemplate0": "Value template",
 	"filterTemplate1": "This Object",

--- a/src/scss/component/comment.scss
+++ b/src/scss/component/comment.scss
@@ -25,6 +25,7 @@
 	.commentCounter {
 		.icon.discussion { width: 13px; height: 12px; color: var(--color-text-secondary); }
 		.count { @include text-small; color: var(--color-text-secondary); line-height: 18px; font-weight: 500; }
+		.unreadDot { width: 6px; height: 6px; border-radius: 50%; background-color: var(--color-system-accent-50); margin-left: 2px; }
 	}
 }
 

--- a/src/ts/component/comment/section.tsx
+++ b/src/ts/component/comment/section.tsx
@@ -569,6 +569,11 @@ const CommentSection = (props: I.CommentSectionProps) => {
 				return;
 			};
 
+			if (message.state) {
+				const chatPreviewSubId = S.Chat.getChatSubId(J.Constant.subId.chatPreview, S.Common.space, id);
+				S.Chat.setState(chatPreviewSubId, message.state);
+			};
+
 			fetchAllMessages(id, sid, () => {
 				isLoaded.current = true;
 				updateSocialVisibility();

--- a/src/ts/component/comment/section.tsx
+++ b/src/ts/component/comment/section.tsx
@@ -674,6 +674,7 @@ const CommentSection = (props: I.CommentSectionProps) => {
 		? `${postCount} ${U.Common.plural(postCount, translate('pluralComment'))}`
 		: translate(object.isArchived ? 'commentDiscussion' : 'commentLeaveComment');
 
+	const hasUnread = !!discussionId && U.Object.discussionHasUnread(S.Common.space, discussionId, rootId);
 	const cn = [ 'commentSection', (isOpen ? 'isVisible' : '') ];
 
 	return (
@@ -712,6 +713,7 @@ const CommentSection = (props: I.CommentSectionProps) => {
 					<div className="commentCounter" onClick={onCounterClick}>
 						<Icon name="comment/discussion" className="discussion" size={18} />
 						<span className="count">{counterLabel}</span>
+						{hasUnread ? <span className="unreadDot" /> : null}
 					</div>
 					<div className="grad" />
 				</div>

--- a/src/ts/component/comment/section.tsx
+++ b/src/ts/component/comment/section.tsx
@@ -27,10 +27,12 @@ const CommentSection = (props: I.CommentSectionProps) => {
 	const sectionRef = useRef<HTMLDivElement>(null);
 	const socialRef = useRef<HTMLDivElement>(null);
 	const scrollTimerRef = useRef(0);
+	const readStopTimerRef = useRef(0);
 	const isSectionVisibleRef = useRef(false);
 	const messageIdHandled = useRef(false);
 	const lastScrollTopRef = useRef(0);
 	const isTypingRef = useRef(false);
+	const scrolledItems = useRef<Set<string>>(new Set());
 
 	const posts = S.Comment.getPosts(subId);
 	const postCount = posts.length;
@@ -58,10 +60,127 @@ const CommentSection = (props: I.CommentSectionProps) => {
 		updateSocialVisibility();
 	}, [ updateSocialVisibility ]);
 
+	const findMessage = useCallback((sid: string, id: string): I.CommentMessage | null => {
+		const post = S.Comment.getPostById(sid, id);
+		if (post) {
+			return post;
+		};
+
+		for (const p of S.Comment.getPosts(sid)) {
+			const reply = S.Comment.getReplies(p.id).find(it => it.id == id);
+			if (reply) {
+				return reply;
+			};
+		};
+
+		return null;
+	}, []);
+
+	const getVisibleMessages = useCallback((): I.CommentMessage[] => {
+		const node = sectionRef.current;
+		if (!node) {
+			return [];
+		};
+
+		const container = U.Dom.getScrollContainer(isPopup);
+		const containerRect = container ? container.getBoundingClientRect() : null;
+		const top = containerRect ? containerRect.top : 0;
+		const bottom = containerRect ? containerRect.bottom : window.innerHeight;
+		const sid = U.Comment.getSubId(targetType, discussionIdRef.current || targetId);
+		const ret: I.CommentMessage[] = [];
+
+		U.Dom.selectAll('[data-message-id]', node).forEach((el: HTMLElement) => {
+			const rect = el.getBoundingClientRect();
+			if ((rect.bottom < top) || (rect.top > bottom)) {
+				return;
+			};
+
+			const id = el.getAttribute('data-message-id');
+			const msg = id ? findMessage(sid, id) : null;
+			if (msg) {
+				ret.push(msg);
+			};
+		});
+
+		return ret;
+	}, [ isPopup, targetType, targetId, findMessage ]);
+
+	const readMessage = useCallback((id: string, orderId: string, lastStateId: string, type: I.ChatReadType) => {
+		const did = discussionIdRef.current;
+		const sid = U.Comment.getSubId(targetType, did || targetId);
+
+		if (type == I.ChatReadType.Message) {
+			S.Comment.setReadMessageStatus(sid, [ id ], true);
+		};
+		if (type == I.ChatReadType.Mention) {
+			S.Comment.setReadMentionStatus(sid, [ id ], true);
+		};
+
+		C.ChatReadMessages(did, orderId, orderId, lastStateId, type);
+	}, [ targetType, targetId ]);
+
+	const onReadStop = useCallback(() => {
+		if (!scrolledItems.current.size) {
+			return;
+		};
+
+		const did = discussionIdRef.current;
+		if (!did) {
+			scrolledItems.current.clear();
+			return;
+		};
+
+		const sid = U.Comment.getSubId(targetType, did);
+		const ids: string[] = [ ...scrolledItems.current ];
+		const first = findMessage(sid, ids[0]);
+		const last = findMessage(sid, ids[ids.length - 1]);
+		const chatPreviewSubId = S.Chat.getChatSubId(J.Constant.subId.chatPreview, S.Common.space, did);
+		const { lastStateId } = S.Chat.getState(chatPreviewSubId);
+
+		if (S.Common.windowIsFocused && first && last) {
+			C.ChatReadMessages(did, first.orderId, last.orderId, lastStateId, I.ChatReadType.Message);
+			C.ChatReadMessages(did, first.orderId, last.orderId, lastStateId, I.ChatReadType.Mention);
+
+			S.Comment.setReadMessageStatus(sid, ids, true);
+			S.Comment.setReadMentionStatus(sid, ids, true);
+		};
+
+		scrolledItems.current.clear();
+	}, [ targetType, findMessage ]);
+
+	const readVisibleMessages = useCallback(() => {
+		if (!discussionIdRef.current || !S.Common.windowIsFocused || !isSectionVisibleRef.current) {
+			return;
+		};
+
+		const did = discussionIdRef.current;
+		const chatPreviewSubId = S.Chat.getChatSubId(J.Constant.subId.chatPreview, S.Common.space, did);
+		const { lastStateId } = S.Chat.getState(chatPreviewSubId);
+		const visible = getVisibleMessages();
+
+		visible.forEach(msg => {
+			scrolledItems.current.add(msg.id);
+
+			if (!msg.isReadMessage) {
+				readMessage(msg.id, msg.orderId, lastStateId, I.ChatReadType.Message);
+			};
+			if (!msg.isReadMention) {
+				readMessage(msg.id, msg.orderId, lastStateId, I.ChatReadType.Mention);
+			};
+		});
+
+		window.clearTimeout(readStopTimerRef.current);
+		readStopTimerRef.current = window.setTimeout(() => onReadStop(), 300);
+	}, [ getVisibleMessages, readMessage, onReadStop ]);
+
 	useEffect(() => {
 		updateSocialVisibility();
 		resize();
 	}, [ isOpen, updateSocialVisibility, resize ]);
+
+	useEffect(() => {
+		readVisibleMessages();
+	}, [ postCount, readVisibleMessages ]);
 
 	useEffect(() => {
 		if (discussionId && (subscribedId.current != discussionId)) {
@@ -77,6 +196,8 @@ const CommentSection = (props: I.CommentSectionProps) => {
 
 			isBottom.current = (max - st) <= SCROLL_THRESHOLD;
 			lastScrollTopRef.current = st;
+
+			readVisibleMessages();
 
 			// Show at end of document if no comments
 			if (isBottom.current && !postCount) {
@@ -103,12 +224,13 @@ const CommentSection = (props: I.CommentSectionProps) => {
 				U.Dom.removeEvent(container, 'scroll', scrollHandler);
 			};
 			window.clearTimeout(scrollTimerRef.current);
+			window.clearTimeout(readStopTimerRef.current);
 
 			if (discussionId) {
 				unsubscribe(discussionId);
 			};
 		};
-	}, [ discussionId ]);
+	}, [ discussionId, readVisibleMessages ]);
 
 	useEffect(() => {
 		const onKeyDown = (e: KeyboardEvent) => {
@@ -158,11 +280,15 @@ const CommentSection = (props: I.CommentSectionProps) => {
 		const observer = new IntersectionObserver((entries) => {
 			isSectionVisibleRef.current = entries[0]?.isIntersecting || false;
 			updateSocialVisibility();
+
+			if (isSectionVisibleRef.current) {
+				readVisibleMessages();
+			};
 		}, { threshold: 0 });
 
 		observer.observe(el);
 		return () => observer.disconnect();
-	}, [ updateSocialVisibility ]);
+	}, [ updateSocialVisibility, readVisibleMessages ]);
 
 	const loadDeps = useCallback((messages: any[], callBack?: () => void) => {
 		const ids = U.Comment.getDepsIds(messages);

--- a/src/ts/component/menu/object.tsx
+++ b/src/ts/component/menu/object.tsx
@@ -144,7 +144,8 @@ const MenuObject = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			S.Block.isAllowed(type?.restrictions, [ I.RestrictionObject.Details ])
 		);
 		const allowedEditChat = canWrite && isChat;
-		const allowedNotification = isChat;
+		const hasDiscussion = !isChat && !!object.discussionId;
+		const allowedNotification = isChat || (canWrite && hasDiscussion);
 		const allowedCopyMedia = U.Object.isImageLayout(object.layout);
 		if (!allowedPageLink) {
 			pageLink = null;
@@ -172,7 +173,7 @@ const MenuObject = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		if (!allowedNotification) {
 			notification = null;
 		} else
-		if (spaceview.isOneToOne) {
+		if (isChat && spaceview.isOneToOne) {
 			const chatMode = U.Object.getChatNotificationMode(spaceview, object.id);
 			const isMuted = chatMode != I.NotificationMode.All;
 
@@ -367,10 +368,16 @@ const MenuObject = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			};
 
 			case 'notification': {
+				const isDiscussion = !isChat && !!object.discussionId;
+				const options = isDiscussion ? U.Menu.discussionNotificationModeOptions() : U.Menu.notificationModeOptions();
+				const currentMode = isDiscussion
+					? U.Object.getDiscussionNotificationMode(spaceview, object.id)
+					: U.Object.getChatNotificationMode(spaceview, object.id);
+
 				menuId = 'select';
 				menuParam.data = {
-					value: String(U.Object.getChatNotificationMode(spaceview, object.id) || ''),
-					options: U.Menu.notificationModeOptions(),
+					value: String(currentMode),
+					options,
 					onSelect: (e, option) => {
 						Action.setChatNotificationMode(space, [ object.id ], Number(option.id), analytics.route.menuObject);
 						close();

--- a/src/ts/component/page/main/settings/personal.tsx
+++ b/src/ts/component/page/main/settings/personal.tsx
@@ -9,7 +9,7 @@ enum ChatKey {
 
 const PageMainSettingsPersonal = forwardRef<I.PageRef, I.PageSettingsComponent>((props, ref) => {
 
-	const { config, linkStyle, fileStyle, fullscreenObject, hideSidebar, vaultMessages, gridTitleClick, notificationSound, hideFileObjectsInTree, unicodeReplace } = S.Common;
+	const { config, linkStyle, fileStyle, fullscreenObject, hideSidebar, gridTitleClick, notificationSound, hideFileObjectsInTree, unicodeReplace } = S.Common;
 	const { hideTray, showMenuBar, alwaysShowTabs, hardwareAcceleration } = config;
 	const { theme, chatCmdSend, commentCmdSend } = S.Common;
 	const cmd = keyboard.cmdSymbol();
@@ -33,11 +33,6 @@ const PageMainSettingsPersonal = forwardRef<I.PageRef, I.PageSettingsComponent>(
 		{ id: '', class: 'light', name: translate('pageSettingsColorModeButtonLight') },
 		{ id: 'dark', class: 'dark', name: translate('pageSettingsColorModeButtonDark') },
 		{ id: 'system', class: 'system', name: translate('pageSettingsColorModeButtonSystem') },
-	];
-
-	const vaultStyles: I.Option[] = [
-		{ id: 0, name: translate('popupSettingsVaultCompact') },
-		{ id: 1, name: translate('popupSettingsVaultWithMessages') },
 	];
 
 	const canHideMenu = U.Common.isPlatformWindows() || U.Common.isPlatformLinux();
@@ -126,24 +121,6 @@ const PageMainSettingsPersonal = forwardRef<I.PageRef, I.PageSettingsComponent>(
 			<Label className="section" text={translate('popupSettingsPersonalSectionInterface')} />
 
 			<div className="actionItems">
-				<div className="item">
-					<Label text={translate('popupSettingsPersonalVaultStyle')} />
-
-					<Select
-						id="vaultMessages"
-						value={String(Number(vaultMessages))}
-						options={vaultStyles}
-						onChange={v => {
-							const value = Boolean(Number(v));
-
-							S.Common.vaultMessagesSet(value);
-							analytics.event('VaultStyleChange', { type: value ? 'MessagePreview' : 'Compact' });
-						}}
-						arrowClassName="black"
-						menuParam={{ horizontal: I.MenuDirection.Right }}
-					/>
-				</div>
-
 				<div className="item">
 					<Label text={translate('popupSettingsPersonalAlwaysShowTabbar')} />
 					<Switch

--- a/src/ts/component/sidebar/page/vault.tsx
+++ b/src/ts/component/sidebar/page/vault.tsx
@@ -11,14 +11,13 @@ import Storage from 'Lib/storage';
 
 const LIMIT = 20;
 const HEIGHT_ITEM = 45;
-const HEIGHT_ITEM_MESSAGE = 73;
 const HEIGHT_DIV = 16;
 const VAULT_MINIMAL_OFFSET = 44;
 
 const SidebarPageVault = forwardRef<{}, I.SidebarPageComponent>((props, ref) => {
 
 	const { getId } = props;
-	const { space, vaultMessages, vaultIsMinimal } = S.Common;
+	const { space, vaultIsMinimal } = S.Common;
 	const [ filter, setFilter ] = useState('');
 	const checkKeyUp = useRef(false);
 	const closeSidebar = useRef(false);
@@ -34,11 +33,6 @@ const SidebarPageVault = forwardRef<{}, I.SidebarPageComponent>((props, ref) => 
 	const cnh = [ 'head' ];
 	const cnb = [ 'body' ];
 	const cnf = [ 'bottom' ];
-
-	if (vaultMessages) {
-		cnh.push('withMessages');
-		cnb.push('withMessages');
-	};
 
 	const keydownHandler = useRef<(e: any) => void>(null);
 	const keyupHandler = useRef<(e: any) => void>(null);
@@ -415,13 +409,8 @@ const SidebarPageVault = forwardRef<{}, I.SidebarPageComponent>((props, ref) => 
 			...item.style,
 		};
 		const cn = [ 'item', U.Data.spaceClass(item.spaceType) ];
-		const iconSize = vaultMessages && !vaultIsMinimal ? 48 : 32;
+		const iconSize = 32;
 		const counter = <ChatCounter spaceId={targetSpaceId} isMinimal={vaultIsMinimal} />;
-
-		let chatName = null;
-		let time = null;
-		let last = null;
-		
 		const icons = [];
 
 		if (targetSpaceId == space) {
@@ -449,11 +438,7 @@ const SidebarPageVault = forwardRef<{}, I.SidebarPageComponent>((props, ref) => 
 		const hasUnread = rawCounters && !!(rawCounters.messageCounter || rawCounters.mentionCounter || rawCounters.reactionCounter);
 
 		if (lastMessage) {
-			const { createdAt, creator, isSynced } = lastMessage;
-
-			time = <Label className="time" text={U.Date.timeAgo(createdAt)} />;
-			last = <Label className="lastMessage" text={S.Chat.getMessageSimpleText(targetSpaceId, lastMessage, !isOneToOne)} />;
-			chatName = <Label className="chatName" text={U.Object.name(item.chat)} />;
+			const { creator, isSynced } = lastMessage;
 
 			if ((creator == S.Auth.account.id) && !isSynced) {
 				cn.push('isSyncing');
@@ -462,59 +447,17 @@ const SidebarPageVault = forwardRef<{}, I.SidebarPageComponent>((props, ref) => 
 			cn.push('noMessages');
 		};
 
-		let info = null;
-		if (vaultMessages) {
-			let message = null;
+		const info = (
+			<div className="nameWrapper">
+				<ObjectName object={item} />
 
-			if (isOneToOne) {
-				message = (
-					<div className="messageWrapper">
-						{last}
-						<div className="icons">
-							{icons.map(icon => <Icon key={icon.className} name={icon.name} className={icon.className} />)}
-						</div>
-						{counter}
-					</div>
-				);
-			} else {
-				message = (
-					<>
-						<div className="chatWrapper">
-							{chatName}
-							<div className="icons">
-								{icons.map(icon => <Icon key={icon.className} name={icon.name} className={icon.className} />)}
-							</div>
-							{counter}
-						</div>
-						<div className="messageWrapper">
-							{last}
-						</div>
-					</>
-				);
-			};
-
-			info = (
-				<>
-					<div className="nameWrapper">
-						<ObjectName object={item} />
-						{time}
-					</div>
-					{message}
-				</>
-			);
-		} else {
-			info = (
-				<div className="nameWrapper">
-					<ObjectName object={item} />
-
-					<div className="icons">
-						{icons.map(icon => <Icon key={icon.className} name={icon.name} className={icon.className} />)}
-					</div>
-
-					{counter}
+				<div className="icons">
+					{icons.map(icon => <Icon key={icon.className} name={icon.name} className={icon.className} />)}
 				</div>
-			);
-		};
+
+				{counter}
+			</div>
+		);
 
 		const mergedRef = (node: any) => {
 			setNodeRef(node);
@@ -614,19 +557,11 @@ const SidebarPageVault = forwardRef<{}, I.SidebarPageComponent>((props, ref) => 
 		Action.createSpace(analytics.route.vault);
 	};
 
-	const onVaultContext = (e: any) => {
-		U.Menu.vaultStyle({
-			element: '#button-vault-toggle',
-			className: 'fixed',
-			classNameWrap: 'fromSidebar',
-		});
-	};
-
 	const getRowHeight = (item: any) => {
 		if (item.isDiv) {
 			return HEIGHT_DIV;
 		};
-		return vaultMessages && !vaultIsMinimal ? HEIGHT_ITEM_MESSAGE : HEIGHT_ITEM;
+		return HEIGHT_ITEM;
 	};
 
 	useEffect(() => {
@@ -689,14 +624,13 @@ const SidebarPageVault = forwardRef<{}, I.SidebarPageComponent>((props, ref) => 
 								name="widget/sidebarToggle"
 								className="toggle"
 								withBackground={true}
-								tooltipParam={{ 
-									text: translate('popupShortcutMainBasics15'), 
-									caption: keyboard.getCaption('toggleSidebar'), 
+								tooltipParam={{
+									text: translate('popupShortcutMainBasics15'),
+									caption: keyboard.getCaption('toggleSidebar'),
 									typeY: I.MenuDirection.Bottom,
 								}}
 								onClick={() => sidebar.leftPanelToggle(true, true)}
 								onMouseDown={e => e.stopPropagation()}
-								onContextMenu={onVaultContext}
 							/>
 						</>
 					) : ''}

--- a/src/ts/component/util/chatCounter.tsx
+++ b/src/ts/component/util/chatCounter.tsx
@@ -5,13 +5,14 @@ import * as I from 'Interface';
 interface Props {
 	spaceId?: string;
 	chatId?: string;
+	mode?: I.NotificationMode;
 	className?: string;
 	isMinimal?: boolean;
 };
 
 const ChatCounter = forwardRef<HTMLDivElement, Props>((props, ref) => {
 
-	const { spaceId = S.Common.space, chatId, className = '', isMinimal = false } = props;
+	const { spaceId = S.Common.space, chatId, mode, className = '', isMinimal = false } = props;
 	const spaceview = U.Space.getSpaceviewBySpaceId(spaceId);
 
 	let counters = { mentionCounter: 0, messageCounter: 0, reactionCounter: 0 };
@@ -22,7 +23,7 @@ const ChatCounter = forwardRef<HTMLDivElement, Props>((props, ref) => {
 	if (chatId) {
 		counters = S.Chat.getChatCounters(spaceId, chatId);
 		if (spaceview) {
-			const chatMode = U.Object.getChatNotificationMode(spaceview, chatId);
+			const chatMode = (mode !== undefined) ? mode : U.Object.getChatNotificationMode(spaceview, chatId);
 
 			modeMessage = chatMode;
 			modeMention = chatMode;

--- a/src/ts/component/widget/object.tsx
+++ b/src/ts/component/widget/object.tsx
@@ -246,6 +246,9 @@ const WidgetObject = forwardRef<{}, I.WidgetComponent>((props, ref) => {
 			transition,
 		};
 		const isChat = U.Object.isChatLayout(item.layout);
+		const hasDiscussion = !isChat && !!item.discussionId;
+		const counterTargetId = isChat ? item.id : (hasDiscussion ? item.discussionId : '');
+		const showCounter = !!counterTargetId && (!hasUnreadSection || isUnread);
 		const canAdd = canWrite && (realId == J.Constant.widgetId.type) && isAllowedObject(item);
 		const spaceview = U.Space.getSpaceview();
 		const itemCn = [ 'item' ];
@@ -284,7 +287,12 @@ const WidgetObject = forwardRef<{}, I.WidgetComponent>((props, ref) => {
 					<ObjectName object={item} withPlural={true} />
 				</div>
 				<div className="side right">
-					{isChat && (!hasUnreadSection || isUnread) ? <ChatCounter chatId={item.id} /> : ''}
+					{showCounter ? (
+						<ChatCounter
+							chatId={counterTargetId}
+							mode={hasDiscussion ? U.Object.getDiscussionNotificationMode(spaceview, item.id) : undefined}
+						/>
+					) : ''}
 					{canAdd ? (
 						<div className="buttons">
 							<Icon

--- a/src/ts/interface/block/comment.ts
+++ b/src/ts/interface/block/comment.ts
@@ -33,6 +33,8 @@ export interface CommentMessage {
 	attachments: I.ChatMessageAttachment[];
 	reactions: I.ChatMessageReaction[];
 	isSynced: boolean;
+	isReadMessage: boolean;
+	isReadMention: boolean;
 	replyCount: number;
 };
 

--- a/src/ts/lib/api/dispatcher.ts
+++ b/src/ts/lib/api/dispatcher.ts
@@ -1224,7 +1224,14 @@ class Dispatcher {
 
 				case 'ChatStateUpdate': {
 					mapped.subIds = S.Chat.checkVaultSubscriptionIds(mapped.subIds, spaceId, rootId);
-					mapped.subIds.forEach(subId => S.Chat.setState(subId, mapped.state));
+
+					if (mapped.subIds.some(id => id.startsWith('comment-'))) {
+						mapped.subIds.push(S.Chat.getChatSubId(J.Constant.subId.chatPreview, spaceId, rootId));
+					};
+
+					mapped.subIds
+						.filter(subId => !subId.startsWith('comment-'))
+						.forEach(subId => S.Chat.setState(subId, mapped.state));
 					break;
 				};
 

--- a/src/ts/lib/api/dispatcher.ts
+++ b/src/ts/lib/api/dispatcher.ts
@@ -1231,15 +1231,23 @@ class Dispatcher {
 				case 'ChatUpdateMessageReadStatus': {
 					mapped.subIds = S.Chat.checkVaultSubscriptionIds(mapped.subIds, spaceId, rootId);
 					mapped.subIds.forEach(subId => {
-						S.Chat.setReadMessageStatus(subId, mapped.ids, mapped.isRead);
+						if (subId.startsWith('comment-')) {
+							S.Comment.setReadMessageStatus(subId, mapped.ids, mapped.isRead);
+						} else {
+							S.Chat.setReadMessageStatus(subId, mapped.ids, mapped.isRead);
+						};
 					});
-					break;	
+					break;
 				};
 
 				case 'ChatUpdateMentionReadStatus': {
 					mapped.subIds = S.Chat.checkVaultSubscriptionIds(mapped.subIds, spaceId, rootId);
 					mapped.subIds.forEach(subId => {
-						S.Chat.setReadMentionStatus(subId, mapped.ids, mapped.isRead);
+						if (subId.startsWith('comment-')) {
+							S.Comment.setReadMentionStatus(subId, mapped.ids, mapped.isRead);
+						} else {
+							S.Chat.setReadMentionStatus(subId, mapped.ids, mapped.isRead);
+						};
 					});
 					break;
 				};
@@ -1247,7 +1255,11 @@ class Dispatcher {
 				case 'ChatUpdateMessageSyncStatus': {
 					mapped.subIds = S.Chat.checkVaultSubscriptionIds(mapped.subIds, spaceId, rootId);
 					mapped.subIds.forEach(subId => {
-						S.Chat.setSyncStatus(subId, mapped.ids, mapped.isSynced);
+						if (subId.startsWith('comment-')) {
+							S.Comment.setSyncStatus(subId, mapped.ids, mapped.isSynced);
+						} else {
+							S.Chat.setSyncStatus(subId, mapped.ids, mapped.isSynced);
+						};
 					});
 					break;
 				};

--- a/src/ts/lib/util/data.ts
+++ b/src/ts/lib/util/data.ts
@@ -1364,9 +1364,10 @@ class UtilData {
 
 	getWidgetChats(): any[] {
 		const spaceview = U.Space.getSpaceview();
+		const space = S.Common.space;
 
-		return S.Record.getRecords(U.Subscription.spaceSubId(J.Constant.subId.chat)).filter(it => {
-			const counters = S.Chat.getChatCounters(S.Common.space, it.id);
+		const chats = S.Record.getRecords(U.Subscription.spaceSubId(J.Constant.subId.chat)).filter(it => {
+			const counters = S.Chat.getChatCounters(space, it.id);
 			const mode = U.Object.getChatNotificationMode(spaceview, it.id);
 
 			if (mode == I.NotificationMode.Nothing) {
@@ -1374,6 +1375,16 @@ class UtilData {
 			};
 
 			return (counters.messageCounter > 0) || (counters.mentionCounter > 0) || (counters.reactionCounter > 0);
+		});
+
+		const parents = S.Record.getRecords(U.Subscription.spaceSubId(J.Constant.subId.discussion)).filter(it => {
+			return it.discussionId && U.Object.discussionHasUnread(space, it.discussionId, it.id);
+		});
+
+		return chats.concat(parents).sort((a, b) => {
+			const aDate = Number(a.lastMessageDate) || 0;
+			const bDate = Number(b.lastMessageDate) || 0;
+			return bDate - aDate;
 		});
 	};
 

--- a/src/ts/lib/util/menu.ts
+++ b/src/ts/lib/util/menu.ts
@@ -1701,33 +1701,6 @@ class UtilMenu {
 		this.menuContext = context;
 	};
 
-	vaultStyle (param: I.MenuParam) {
-		const { isClosed } = sidebar.getData(I.SidebarPanel.Left);
-		const { vaultMessages } = S.Common;
-		const options =[
-			{ id: 0, name: translate('popupSettingsVaultCompact'), checkbox: !vaultMessages, },
-			{ id: 1, name: translate('popupSettingsVaultWithMessages'), checkbox: vaultMessages, },
-		];
-
-		S.Menu.open('select', {
-			...param,
-			data: {
-				options,
-				noVirtualisation: true,
-				onSelect: (e: any, item: any) => {
-					const value = Boolean(Number(item.id));
-
-					S.Common.vaultMessagesSet(value);
-					if (isClosed) {
-						sidebar.open(I.SidebarPanel.Left, '', );
-					};
-
-					analytics.event('VaultStyleChange', { type: value ? 'MessagePreview' : 'Compact' });
-				},
-			},
-		});
-	};
-
 	spaceTypeOptions (): I.Option[] {
 		return [
 			{ id: I.SpaceType.Data },
@@ -1755,6 +1728,13 @@ class UtilMenu {
 		};
 
 		return ret;
+	};
+
+	discussionNotificationModeOptions (): I.Option[] {
+		return [
+			{ id: I.NotificationMode.All },
+			{ id: I.NotificationMode.Mentions },
+		].map(it => ({ ...it, name: translate(`notificationModeDiscussion${it.id}`) }));
 	};
 
 	recentModeOptions (): I.Option[] {

--- a/src/ts/lib/util/object.ts
+++ b/src/ts/lib/util/object.ts
@@ -1073,6 +1073,39 @@ class UtilObject {
 		return spaceview.notificationMode as I.NotificationMode;
 	};
 
+	getDiscussionNotificationMode (spaceview: any, objectId: string): I.NotificationMode {
+		if (!spaceview) {
+			return I.NotificationMode.Mentions;
+		};
+
+		const allIds = Relation.getArrayValue(spaceview.allIds);
+		const mentionIds = Relation.getArrayValue(spaceview.mentionIds);
+
+		if (allIds.includes(objectId)) {
+			return I.NotificationMode.All;
+		};
+		if (mentionIds.includes(objectId)) {
+			return I.NotificationMode.Mentions;
+		};
+
+		return I.NotificationMode.Mentions;
+	};
+
+	discussionHasUnread (spaceId: string, discussionId: string, parentObjectId: string): boolean {
+		if (!discussionId) {
+			return false;
+		};
+
+		const counters = S.Chat.getChatCounters(spaceId, discussionId);
+		const spaceview = U.Space.getSpaceviewBySpaceId(spaceId);
+		const mode = this.getDiscussionNotificationMode(spaceview, parentObjectId);
+
+		return (
+			((mode == I.NotificationMode.All) && !!(counters.messageCounter || counters.mentionCounter || counters.reactionCounter)) ||
+			((mode == I.NotificationMode.Mentions) && !!counters.mentionCounter)
+		);
+	};
+
 };
 
 export default new UtilObject();

--- a/src/ts/lib/util/subscription.ts
+++ b/src/ts/lib/util/subscription.ts
@@ -838,7 +838,7 @@ class UtilSubscription {
 	 * @returns {string[]} The list of relation keys.
 	 */
 	discussionRelationKeys () {
-		return J.Relation.default.concat([ 'snippet', 'lastMessageDate' ]);
+		return J.Relation.default.concat([ 'snippet', 'lastMessageDate', 'unreadMessageCount', 'unreadMentionCount', 'notificationSubscribers' ]);
 	};
 
 	getRecentSubId (): string {

--- a/src/ts/lib/util/subscription.ts
+++ b/src/ts/lib/util/subscription.ts
@@ -588,6 +588,11 @@ class UtilSubscription {
 					{ relationKey: 'name', type: I.SortType.Asc },
 				],
 				noDeps: true,
+				onSubscribe: message => {
+					(message.records || []).forEach(it => {
+						S.Chat.discussionParentMapSet(it.spaceId, it.id, it.discussionId);
+					});
+				},
 			},
 			{
 				subId: this.spaceSubId(J.Constant.subId.recentEditMe),

--- a/src/ts/lib/util/subscription.ts
+++ b/src/ts/lib/util/subscription.ts
@@ -578,6 +578,18 @@ class UtilSubscription {
 				noDeps: true,
 			},
 			{
+				subId: this.spaceSubId(J.Constant.subId.discussion),
+				keys: this.discussionRelationKeys(),
+				filters: [
+					{ relationKey: 'discussionId', condition: I.FilterCondition.NotEmpty, value: null },
+				],
+				sorts: [
+					{ relationKey: 'lastMessageDate', type: I.SortType.Desc, format: I.RelationType.Date, includeTime: true },
+					{ relationKey: 'name', type: I.SortType.Asc },
+				],
+				noDeps: true,
+			},
+			{
 				subId: this.spaceSubId(J.Constant.subId.recentEditMe),
 				filters: [
 					{ relationKey: 'resolvedLayout', condition: I.FilterCondition.NotIn, value: U.Object.getFileAndSystemLayouts().concat(I.ObjectLayout.Participant).filter(it => !U.Object.isTypeLayout(it)) },
@@ -819,6 +831,14 @@ class UtilSubscription {
 	 */
 	chatRelationKeys () {
 		return J.Relation.default.concat([ 'source', 'picture', 'widthInPixels', 'heightInPixels', 'syncStatus', 'syncError' ]);
+	};
+
+	/**
+	 * Returns the relation keys for the discussion-parent subscription.
+	 * @returns {string[]} The list of relation keys.
+	 */
+	discussionRelationKeys () {
+		return J.Relation.default.concat([ 'snippet', 'lastMessageDate' ]);
 	};
 
 	getRecentSubId (): string {

--- a/src/ts/model/commentMessage.ts
+++ b/src/ts/model/commentMessage.ts
@@ -41,6 +41,8 @@ class CommentMessage implements I.CommentMessage {
 	attachments: I.ChatMessageAttachment[] = [];
 	reactions: I.ChatMessageReaction[] = [];
 	isSynced = false;
+	isReadMessage = false;
+	isReadMention = false;
 	replyCount = 0;
 
 	constructor (props: I.CommentMessage) {
@@ -54,6 +56,8 @@ class CommentMessage implements I.CommentMessage {
 		this.attachments = Array.isArray(props.attachments) ? props.attachments : [];
 		this.reactions = props.reactions || [];
 		this.isSynced = Boolean(props.isSynced);
+		this.isReadMessage = Boolean(props.isReadMessage);
+		this.isReadMention = Boolean(props.isReadMention);
 		this.replyCount = Number(props.replyCount) || 0;
 
 		makeObservable(this, {
@@ -66,6 +70,8 @@ class CommentMessage implements I.CommentMessage {
 			attachments: observable,
 			reactions: observable,
 			isSynced: observable,
+			isReadMessage: observable,
+			isReadMention: observable,
 			replyCount: observable,
 		});
 

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -478,28 +478,30 @@ class ChatStore {
 		};
 
 		const chat = S.Detail.get(J.Constant.subId.chatGlobal, chatId, []);
-		let isArchived = !chat._empty_ && !!chat.isArchived;
 
-		if (chat._empty_) {
-			const parent = S.Record.getRecords(U.Subscription.spaceSubId(J.Constant.subId.discussion))
-				.find(it => it.discussionId == chatId);
-
-			if (parent) {
-				isArchived = !!parent.isArchived;
+		if (!chat._empty_) {
+			if (chat.isArchived) {
+				return ret;
 			};
-		};
 
-		if (isArchived) {
+			const state = this.stateMap.get(spaceId)?.get(chatId);
+			if (state) {
+				ret.mentionCounter = Number(state.mentionCounter) || 0;
+				ret.messageCounter = Number(state.messageCounter) || 0;
+				ret.reactionCounter = Number(state.reactionCounter) || 0;
+			};
 			return ret;
 		};
 
-		const state = this.stateMap.get(spaceId)?.get(chatId);
-		if (state) {
-			ret.mentionCounter = Number(state.mentionCounter) || 0;
-			ret.messageCounter = Number(state.messageCounter) || 0;
-			ret.reactionCounter = Number(state.reactionCounter) || 0;
+		const parent = S.Record.getRecords(U.Subscription.spaceSubId(J.Constant.subId.discussion))
+			.find(it => it.discussionId == chatId);
+
+		if (!parent || parent.isArchived) {
+			return ret;
 		};
 
+		ret.messageCounter = Number(parent.unreadMessageCount) || 0;
+		ret.mentionCounter = Number(parent.unreadMentionCount) || 0;
 		return ret;
 	};
 

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -472,9 +472,26 @@ class ChatStore {
 	 */
 	getChatCounters (spaceId: string, chatId: string): I.ChatCounter {
 		const ret = { mentionCounter: 0, messageCounter: 0, reactionCounter: 0 };
-		const chat = S.Detail.get(J.Constant.subId.chatGlobal, chatId, []);
 
-		if (!spaceId || !chatId || chat._empty_ || chat.isArchived) {
+		if (!spaceId || !chatId) {
+			return ret;
+		};
+
+		const chat = S.Detail.get(J.Constant.subId.chatGlobal, chatId, []);
+		const isChat = !chat._empty_;
+		let isArchived = isChat && !!chat.isArchived;
+
+		if (!isChat) {
+			const parents = S.Record.getRecords(U.Subscription.spaceSubId(J.Constant.subId.discussion));
+			const parent = parents.find(it => it.discussionId == chatId);
+
+			if (!parent) {
+				return ret;
+			};
+			isArchived = !!parent.isArchived;
+		};
+
+		if (isArchived) {
 			return ret;
 		};
 

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -10,6 +10,7 @@ class ChatStore {
 	public replyMap: Map<string, Map<string, I.ChatMessage>> = observable(new Map());
 	public stateMap: Map<string, Map<string, I.ChatStoreState>> = observable.map(new Map());
 	public attachmentsMap: Map<string, any[]> = observable(new Map());
+	public discussionParentMap: Map<string, Map<string, string>> = observable.map(new Map());
 	private badgeValue = '';
 
 	constructor () {
@@ -20,6 +21,8 @@ class ChatStore {
 			setReply: action,
 			setState: action,
 			setAttachments: action,
+			discussionParentMapSet: action,
+			discussionParentMapDelete: action,
 		});
 	};
 
@@ -313,6 +316,7 @@ class ChatStore {
 		this.replyMap.clear();
 		this.stateMap.clear();
 		this.attachmentsMap.clear();
+		this.discussionParentMap.clear();
 	};
 
 	/**
@@ -493,16 +497,49 @@ class ChatStore {
 			return ret;
 		};
 
-		const parent = S.Record.getRecords(U.Subscription.spaceSubId(J.Constant.subId.discussion))
-			.find(it => it.discussionId == chatId);
+		const parentId = this.discussionParentMap.get(spaceId)?.get(chatId);
+		if (!parentId) {
+			return ret;
+		};
 
-		if (!parent || parent.isArchived) {
+		const parent = S.Detail.get(U.Subscription.spaceSubId(J.Constant.subId.discussion, spaceId), parentId, [ 'unreadMessageCount', 'unreadMentionCount', 'isArchived' ]);
+		if (parent._empty_ || parent.isArchived) {
 			return ret;
 		};
 
 		ret.messageCounter = Number(parent.unreadMessageCount) || 0;
 		ret.mentionCounter = Number(parent.unreadMentionCount) || 0;
 		return ret;
+	};
+
+	/**
+	 * Add or update a discussion → parent-object mapping.
+	 */
+	discussionParentMapSet (spaceId: string, parentObjectId: string, discussionId: string) {
+		if (!spaceId || !discussionId || !parentObjectId) {
+			return;
+		};
+
+		let inner = this.discussionParentMap.get(spaceId);
+		if (!inner) {
+			inner = observable.map(new Map());
+			this.discussionParentMap.set(spaceId, inner);
+		};
+		inner.set(discussionId, parentObjectId);
+	};
+
+	/**
+	 * Remove a discussion → parent-object mapping.
+	 */
+	discussionParentMapDelete (spaceId: string, discussionId: string) {
+		this.discussionParentMap.get(spaceId)?.delete(discussionId);
+	};
+
+	/**
+	 * Returns the parent object id for a discussion, or '' if not mapped.
+	 */
+	getDiscussionParentId (spaceId: string, discussionId: string): string {
+		return this.discussionParentMap.get(spaceId)?.get(discussionId) || '';
 	};
 
 	/**

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -478,32 +478,26 @@ class ChatStore {
 		};
 
 		const chat = S.Detail.get(J.Constant.subId.chatGlobal, chatId, []);
-		const isChat = !chat._empty_;
-		let isArchived = isChat && !!chat.isArchived;
+		let isArchived = !chat._empty_ && !!chat.isArchived;
 
-		if (!isChat) {
-			const parents = S.Record.getRecords(U.Subscription.spaceSubId(J.Constant.subId.discussion));
-			const parent = parents.find(it => it.discussionId == chatId);
+		if (chat._empty_) {
+			const parent = S.Record.getRecords(U.Subscription.spaceSubId(J.Constant.subId.discussion))
+				.find(it => it.discussionId == chatId);
 
-			if (!parent) {
-				return ret;
+			if (parent) {
+				isArchived = !!parent.isArchived;
 			};
-			isArchived = !!parent.isArchived;
 		};
 
 		if (isArchived) {
 			return ret;
 		};
 
-		const spaceMap = this.stateMap.get(spaceId);
-
-		if (spaceMap) {
-			const state = spaceMap.get(chatId);
-			if (state) {
-				ret.mentionCounter = Number(state.mentionCounter) || 0;
-				ret.messageCounter = Number(state.messageCounter) || 0;
-				ret.reactionCounter = Number(state.reactionCounter) || 0;
-			};
+		const state = this.stateMap.get(spaceId)?.get(chatId);
+		if (state) {
+			ret.mentionCounter = Number(state.mentionCounter) || 0;
+			ret.messageCounter = Number(state.messageCounter) || 0;
+			ret.reactionCounter = Number(state.reactionCounter) || 0;
 		};
 
 		return ret;

--- a/src/ts/store/comment.ts
+++ b/src/ts/store/comment.ts
@@ -24,6 +24,9 @@ class CommentStore {
 			addReply: action,
 			updateReply: action,
 			deleteReply: action,
+			setReadMessageStatus: action,
+			setReadMentionStatus: action,
+			setSyncStatus: action,
 			setHasMorePosts: action,
 			setHasMoreReplies: action,
 			setHasOlderReplies: action,
@@ -138,6 +141,33 @@ class CommentStore {
 
 	deleteReply (parentId: string, id: string): void {
 		this.setReplies(parentId, this.getReplies(parentId).filter(it => it.id != id));
+	};
+
+	private updateInPostOrReply (subId: string, id: string, param: Partial<I.CommentMessage>): void {
+		const post = this.getPostById(subId, id);
+		if (post) {
+			set(post, param);
+			return;
+		};
+
+		this.replyMap.forEach((list, parentId) => {
+			const reply = list.find(it => it.id == id);
+			if (reply) {
+				set(reply, param);
+			};
+		});
+	};
+
+	setReadMessageStatus (subId: string, ids: string[], value: boolean): void {
+		(ids || []).forEach(id => this.updateInPostOrReply(subId, id, { isReadMessage: value }));
+	};
+
+	setReadMentionStatus (subId: string, ids: string[], value: boolean): void {
+		(ids || []).forEach(id => this.updateInPostOrReply(subId, id, { isReadMention: value }));
+	};
+
+	setSyncStatus (subId: string, ids: string[], value: boolean): void {
+		(ids || []).forEach(id => this.updateInPostOrReply(subId, id, { isSynced: value }));
 	};
 
 	getReplies (parentId: string): I.CommentMessage[] {

--- a/src/ts/store/common.ts
+++ b/src/ts/store/common.ts
@@ -46,7 +46,6 @@ class CommonStore {
 	public chatCmdSendValue = null;
 	public commentCmdSendValue = null;
 	public updateVersionValue = '';
-	public vaultMessagesValue = null;
 	public vaultIsMinimalValue = null;
 	public gridTitleClickValue = null;
 	public unicodeReplaceValue = null;
@@ -162,7 +161,6 @@ class CommonStore {
 			pinValue: observable,
 			firstDayValue: observable,
 			updateVersionValue: observable,
-			vaultMessagesValue: observable,
 			vaultIsMinimalValue: observable,
 			gridTitleClickValue: observable,
 			unicodeReplaceValue: observable,
@@ -187,7 +185,6 @@ class CommonStore {
 			timeFormat: computed,
 			pin: computed,
 			firstDay: computed,
-			vaultMessages: computed,
 			vaultIsMinimal: computed,
 			gridTitleClick: computed,
 			unicodeReplace: computed,
@@ -220,7 +217,6 @@ class CommonStore {
 			showRelativeDatesSet: action,
 			pinSet: action,
 			firstDaySet: action,
-			vaultMessagesSet: action,
 			vaultIsMinimalSet: action,
 			gridTitleClickSet: action,
 			unicodeReplaceSet: action,
@@ -471,10 +467,6 @@ class CommonStore {
 
 	get widgetSections (): I.WidgetSectionParam[] {
 		return this.widgetSectionsValue || [];
-	};
-
-	get vaultMessages (): any {
-		return this.boolGet('vaultMessages');
 	};
 
 	get vaultIsMinimal (): any {
@@ -1047,14 +1039,6 @@ class CommonStore {
 	firstDaySet (v: number) {
 		this.firstDayValue = Number(v) || 1;
 		Storage.set('firstDay', this.firstDayValue);
-	};
-
-	/**
-	 * Sets the vault messages value.
-	 * @param {boolean} v - The vault messages value.
-	 */
-	vaultMessagesSet (v: boolean) {
-		this.boolSet('vaultMessages', v);
 	};
 
 	/**

--- a/src/ts/store/detail.ts
+++ b/src/ts/store/detail.ts
@@ -187,6 +187,9 @@ class DetailStore {
 		if (U.Object.isSpaceViewLayout(item.details.layout)) {
 			S.Record.spaceMap.set(item.details.targetSpaceId, item.details.id);
 		};
+		if (item.details.discussionId) {
+			S.Chat.discussionParentMapSet(item.details.spaceId, item.details.id, item.details.discussionId);
+		};
 
 		if (createMap) {
 			this.map.set(rootId, map);


### PR DESCRIPTION
## Summary
- Add Notifications submenu (All New Replies / Mentions Only) to the object three-dot menu for objects with `discussionId`, gated on canWrite (Viewers excluded).
- Show a blue unread dot on the Comments button of the social block when the discussion has unread comments respecting the per-object notification mode.
- Add a space-scoped `discussion` subscription for objects with `discussionId` set; expose discussion-parent unreads in the sidebar Unread section and on object widgets.
- Extend `<ChatCounter>` and `S.Chat.getChatCounters` so they work for discussion ids; ChatCounter accepts an explicit `mode` override.
- Remove the vault-with-messages variant: drop `S.Common.vaultMessages*`, `U.Menu.vaultStyle`, the personal-settings select, the related i18n keys, and the conditional rendering in `vault.tsx`.

## Linear
[JS-9511](https://linear.app/anytype/issue/JS-9511/notification-preferences-and-unread-tracking-for-object-discussions)

Backend dependency: [GO-7168](https://linear.app/anytype/issue/GO-7168/notification-preferences-and-unread-tracking-for-object-discussions) (already shipped).

iOS reference: anyproto/anytype-swift#4881, anyproto/anytype-swift#4884

## Test plan
- [ ] On a non-creator account, open an editor object: three-dot menu shows Notifications submenu only after a discussion is created (`discussionId` non-empty); Viewers see no Notifications option.
- [ ] Toggle between All New Replies / Mentions Only; checkmark reflects the current mode.
- [ ] Have another user comment / @mention; verify the Comments button shows a blue dot when expected (respects the chosen mode).
- [ ] Pin the object as a widget: chat counter (blue / grey) renders next to the item; muting the discussion reflects in the counter.
- [ ] Sidebar Unread section lists discussion-parent objects interleaved with chats, sorted by `lastMessageDate`.
- [ ] Personal settings: vault style select is gone; vault renders compact only.
- [ ] No new console errors; typecheck and lint pass.