### PR TITLE
JS-9678: fix P2pStatusUpdate event being dropped after event-type refactor

### DIFF
--- a/src/ts/lib/api/dispatcher.ts
+++ b/src/ts/lib/api/dispatcher.ts
@@ -1465,7 +1465,7 @@ class Dispatcher {
 				};
 
 				case 'SpaceSyncStatusUpdate':
-				case 'P2PStatusUpdate': {
+				case 'P2pStatusUpdate': {
 					S.Auth.syncStatusUpdate(mapped);
 					break;
 				};
@@ -1872,7 +1872,7 @@ class Dispatcher {
 		const { config } = S.Common;
 		const { event, sync, file, subscribe } = config.flagsMw;
 		const fileEvents = [ 'FileLocalUsage', 'FileSpaceUsage' ];
-		const syncEvents = [ 'SpaceSyncStatusUpdate', 'P2PStatusUpdate', 'ThreadStatus' ];
+		const syncEvents = [ 'SpaceSyncStatusUpdate', 'P2pStatusUpdate', 'ThreadStatus' ];
 		const subscribeEvents = [ 'SubscriptionAdd', 'SubscriptionRemove', 'SubscriptionCounters', 'SubscriptionPosition' ];
 
 		let check = false;

--- a/src/ts/lib/api/mapper.ts
+++ b/src/ts/lib/api/mapper.ts
@@ -1815,7 +1815,7 @@ export const Mapper = {
 			};
 		},
 
-		P2PStatusUpdate: (obj: any) => {
+		P2pStatusUpdate: (obj: any) => {
 			return {
 				id: obj.spaceId,
 				p2p: obj.status,


### PR DESCRIPTION
## Summary
- Fixes JS-9678 — `p2pStatusUpdate` events from middleware were silently dropped after the event-type derivation refactor (cd185f81dd), so the sync UI never updated and no log appeared in the dev console.
- The `eventType()` helper capitalizes only the first letter of the proto field name, so `p2pStatusUpdate` resolves to `P2pStatusUpdate`. The mapper key, dispatcher case, and `needEventLog` syncEvents list still used the old `P2PStatusUpdate` (uppercase middle `P`) preserved by the previous static map. The mapper lookup returned undefined, `mapped` came back null, and the event was dropped before reaching the switch.
- Renamed all three references to match the derived name.

## Test plan
- [ ] Run app against middleware emitting `p2pStatusUpdate` (peer connect/disconnect)
- [ ] Enable sync event logging in dev console, confirm `Event.P2pStatusUpdate` lines appear
- [ ] Confirm sync status icon updates as peers come/go