### PR TITLE
fix: translation issues in Block action menu

### DIFF
--- a/src/ts/component/menu/block/action.tsx
+++ b/src/ts/component/menu/block/action.tsx
@@ -204,10 +204,10 @@ const MenuBlockAction = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 
 			const c1: any[] = [
 				hasLink ? { id: 'linkSettings', name: translate('commonView'), caption: translate(`menuBlockLinkSettingsStyle${I.LinkCardStyle[cardStyle]}`), arrow: true } : null,
-				hasTurnFile ? { id: 'turnStyle', name: translate('commonView'), caption: I.FileStyle[style], arrow: true, isBlockFile: true } : null,
+				hasTurnFile ? { id: 'turnStyle', name: translate('commonView'), caption: translate(`blockName${I.FileStyle[style]}`), arrow: true, isBlockFile: true } : null,
 				(hasTurnText && !isCardStyle) ? turnText : null,
 				hasTurnDiv ? { id: 'turnStyle', iconParam: { name: U.Data.styleIcon(I.BlockType.Div, style) }, name: translate('menuBlockActionsSectionsDividerStyle'), arrow: true, isBlockDiv: true } : null,
-				hasAlign ? { id: 'align', name: translate('commonAlign'), caption: I.BlockHAlign[hAlign], arrow: true } : null,
+				hasAlign ? { id: 'align', name: translate('commonAlign'), caption: translate(`commonHAlign${I.BlockHAlign[hAlign]}`), arrow: true } : null,
 				hasColor ? { id: 'color', name: translate('commonColor'), arrow: true, isTextColor: true, value: (color || 'default') } : null,
 				hasBg ? { id: 'background', name: translate('commonBackground'), arrow: true, isBgColor: true, value: (bgColor || 'default') } : null,
 				hasText ? { id: 'clear', name: translate('libMenuClearStyle') } : null,
@@ -217,8 +217,8 @@ const MenuBlockAction = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			if (hasAction) {
 				const cmd = keyboard.cmdSymbol();
 				const count = blockIds.length;
-				const copyName = `${translate('commonDuplicate')} ${U.Common.plural(count, translate('pluralLCBlock'))}`;
-				const deleteName = `${translate('commonDelete')} ${U.Common.plural(count, translate('pluralLCBlock'))}`;
+				const copyName = U.String.sprintf(translate('commonDuplicateBlocks'), U.Common.plural(count, translate('pluralLCBlock')));
+				const deleteName = U.String.sprintf(translate('commonDeleteBlocks'), U.Common.plural(count, translate('pluralLCBlock')));
 
 				const move = hasCommon ? { id: 'move', iconParam: { name: 'menu/action/move' }, name: translate('commonMoveTo'), arrow: true } : null;
 				const clipboardCopy = hasClipboard ? { id: 'clipboardCopy', iconParam: { name: 'menu/action/copy' }, name: translate('commonCopy'), caption: `${cmd} + C` } : null;


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

Hi Anytype dev team!

This PR fixes localization and translation mapping issues within the block action menu.

1. Fixed untranslated text: fixed untranslated text items under the "Align" and "View" sub-menus in the block action menu by properly applying translations.
2. Contextual translation (word order correction): replaced the generic `commonDuplicate` and `commonDelete` keys with `commonDuplicateBlocks` and `commonDeleteBlocks`. Although these context-specific keys were available, they were unused. This replacement resolves unnatural word order issues in languages with different grammatical structures, such as Japanese and Korean (e.g., correcting the literal and unnatural "削除 ブロック" to the linguistically appropriate "ブロックを削除").

Thank you for your continuous work on Anytype!

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
#### Before
<img width="553" height="660" alt="before" src="https://github.com/user-attachments/assets/480aa097-639b-43b9-b80f-350db575ec7e" />

#### After
<img width="541" height="665" alt="after" src="https://github.com/user-attachments/assets/231b0152-f516-4c79-bca6-3c21e7976745" />

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
