### PR TITLE
JS-9673: clean S.Detail on SubscriptionRemove

### DIFF
--- a/src/ts/lib/api/dispatcher.ts
+++ b/src/ts/lib/api/dispatcher.ts
@@ -1025,6 +1025,7 @@ class Dispatcher {
 
 					if (!dep) {
 						S.Record.recordDelete(subId, '', id);
+						S.Detail.delete(subId, id);
 					};
 					break;
 				};


### PR DESCRIPTION
## Summary

After the cross-space refactor, archiving an object dropped it from `chatGlobal` / `discussionGlobal` subscriptions, but the `SubscriptionRemove` handler in dispatcher only cleaned `S.Record` and left `S.Detail` untouched. As a result, `S.Detail.get(subId, id)` kept returning stale data with `isArchived=false`, so the `_empty_ || isArchived` guard added in 3ed77c5d37 (`chat.ts`) could never catch the archived state — counters kept summing into the vault total and the dock badge.

## Fix

Mirror the existing `S.Record.recordDelete(subId, '', id)` with a `S.Detail.delete(subId, id)` on the same subId. After this, `S.Detail.get(...)._empty_` correctly means "no longer in this subscription" and the existing chat.ts guards work as intended — both for chat-layout objects (via `chatGlobal`) and pages with discussions (via `discussionGlobal` / per-space `discussion`).

Single-line change, no logic moved between layers.

## Test plan

- [x] Local repro: chat-layout object with unread → Move to Bin → counter disappears from Vault card and dock badge
- [x] Local repro: page with discussion + unread → Move to Bin → same result
- [x] `tsc --noEmit` clean
- [x] biome + eslint pass via lint-staged
- [ ] Verify nothing regresses around components that read `S.Detail.get(subId, id)` for items just removed from a sub (most call sites already guard with `_empty_`; `vault.tsx:212` writes `it.chat` but it's currently unread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)