### PR TITLE
fix(editor): code block Backspace/Delete after rich paste (#2196)

### DIFF
--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -169,6 +169,13 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 			text = '';
 		};
 
+		// Rich clipboard (e.g. AI "Copy response") can embed ZWJ / word joiner / BOM.
+		// Strip so the DOM stays clean; Editable also uses plainDomTextOffsets for code
+		// so stray U+200B cannot break caret via dom/model conversion (#2196).
+		if (block.isTextCode()) {
+			text = U.String.stripZeroWidthFormatChars(text);
+		};
+
 		textRef.current = text;
 		let html = text;
 
@@ -270,6 +277,10 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 		// innerText includes that phantom <br/> as a real \n, so strip it here.
 		if (phantomNewlineRef.current && value.endsWith('\n')) {
 			value = value.slice(0, -1);
+		};
+
+		if (block.isTextCode()) {
+			value = U.String.stripZeroWidthFormatChars(value);
 		};
 
 		return value;
@@ -643,35 +654,87 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 		};
 
 		keyboard.shortcut('backspace', e, () => {
-			if (range.to) {
-				const parsed = Mark.checkMarkOnBackspace(value, range, marksRef.current);
-
-				if (parsed.save) {
+			// Code blocks: native Backspace inside Prism/plain <br> markup is unreliable after
+			// rich paste (DOM vs model offsets). Apply deletion on the model string (#2196).
+			if (
+				block.isTextCode() &&
+				!menuOpenAdd &&
+				!menuOpenMention &&
+				!menuOpenEmoji &&
+				!menuOpenSmile
+			) {
+				if (range.from !== range.to) {
 					e.preventDefault();
 
-					value = parsed.text;
-					marksRef.current = parsed.marks;
+					const newValue = U.String.cut(value, range.from, range.to);
+					const newRange = { from: range.from, to: range.from };
+
+					focus.set(block.id, newRange);
+					U.Data.blockSetText(rootId, block.id, newValue, [], true, () => {
+						focus.apply();
+						setValue(newValue, newRange);
+					});
+					ret = true;
+				} else
+				if (range.from > 0) {
+					const del = U.String.utf16DeleteLengthBefore(value, range.from);
+
+					if (del > 0) {
+						e.preventDefault();
+
+						const newValue = U.String.cut(value, range.from - del, range.from);
+						const newRange = { from: range.from - del, to: range.from - del };
+
+						focus.set(block.id, newRange);
+						U.Data.blockSetText(rootId, block.id, newValue, [], true, () => {
+							focus.apply();
+							setValue(newValue, newRange);
+						});
+						ret = true;
+					};
+				};
+			} else {
+				// Use explicit offsets: `if (range.to)` is false when to===0 (caret at start),
+				// same as undefined/NaN from a bad range — that wrongly hit the mark-sync branch
+				// below and re-sent stale text + ret=true, skipping onKeyDown.
+				const hasNonZeroCaretOrSelection = (range.from > 0) || (range.from !== range.to);
+
+				if (hasNonZeroCaretOrSelection) {
+					const parsed = Mark.checkMarkOnBackspace(value, range, marksRef.current);
+
+					if (parsed.save) {
+						e.preventDefault();
+
+						value = parsed.text;
+						marksRef.current = parsed.marks;
+
+						U.Data.blockSetText(rootId, block.id, value, marksRef.current, true, () => {
+							focus.set(block.id, parsed.range);
+							focus.apply();
+
+							onKeyDown(e, value, marksRef.current, range, props);
+						});
+						ret = true;
+					};
+				} else
+				if (
+					!menuOpenAdd &&
+					!menuOpenMention &&
+					!menuOpenEmoji &&
+					(range.from === range.to) &&
+					(range.from === 0)
+				) {
+					if (block.canHaveMarks()) {
+						const parsed = getMarksFromHtml();
+
+						marksRef.current = parsed.marks;
+					};
 
 					U.Data.blockSetText(rootId, block.id, value, marksRef.current, true, () => {
-						focus.set(block.id, parsed.range);
-						focus.apply();
-
 						onKeyDown(e, value, marksRef.current, range, props);
 					});
 					ret = true;
 				};
-			} else 
-			if (!menuOpenAdd && !menuOpenMention && !menuOpenEmoji && !range.to) {
-				if (block.canHaveMarks()) {
-					const parsed = getMarksFromHtml();
-
-					marksRef.current = parsed.marks;
-				};
-
-				U.Data.blockSetText(rootId, block.id, value, marksRef.current, true, () => {
-					onKeyDown(e, value, marksRef.current, range, props);
-				});
-				ret = true;
 			};
 
 			if (menuOpenAdd && (oneSymbolBefore == '/')) {
@@ -688,6 +751,44 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 		});
 
 		keyboard.shortcut('delete', e, () => {
+			if (
+				block.isTextCode() &&
+				!menuOpenAdd &&
+				!menuOpenMention &&
+				!menuOpenEmoji &&
+				!menuOpenSmile
+			) {
+				if (range.from !== range.to) {
+					e.preventDefault();
+
+					const newValue = U.String.cut(value, range.from, range.to);
+					const newRange = { from: range.from, to: range.from };
+
+					focus.set(block.id, newRange);
+					U.Data.blockSetText(rootId, block.id, newValue, [], true, () => {
+						focus.apply();
+						setValue(newValue, newRange);
+					});
+					ret = true;
+				} else
+				if (range.from < value.length) {
+					const del = U.String.utf16DeleteLengthAfter(value, range.from);
+
+					if (del > 0) {
+						e.preventDefault();
+
+						const newValue = U.String.cut(value, range.from, range.from + del);
+						const newRange = { from: range.from, to: range.from };
+
+						focus.set(block.id, newRange);
+						U.Data.blockSetText(rootId, block.id, newValue, [], true, () => {
+							focus.apply();
+							setValue(newValue, newRange);
+						});
+						ret = true;
+					};
+				};
+			} else
 			if ((range.from == range.to) && (range.to == value.length)) {
 				U.Data.blockSetText(rootId, block.id, value, marksRef.current, true, () => {
 					onKeyDown(e, value, marksRef.current, range, props);
@@ -1263,7 +1364,7 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 					let to = selRange.collapsed ? from : U.Dom.getSelectionOffsetWithLatex(editable, selRange.endContainer, selRange.endOffset);
 
 					// Convert DOM offsets to model offsets (strip ZWS cursor anchors)
-					if (Mark.hasZws(editable)) {
+					if (Mark.hasZws(editable) && !block.isTextCode()) {
 						from = Mark.domToModel(from, editable);
 						to = Mark.domToModel(to, editable);
 					};
@@ -1726,6 +1827,7 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 				classNamePlaceholder={`c${id}`}
 				readonly={readonly}
 				spellcheck={spellcheck}
+				plainDomTextOffsets={block.isTextCode()}
 				placeholder={placeholder}
 				onKeyDown={onKeyDownHandler}
 				onKeyUp={onKeyUpHandler}

--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -1505,7 +1505,9 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 		const ids = selection?.get(I.SelectType.Block, true) || [];
 
 		if (block.isText()) {
-			if (!isDelete && !range.to) {
+			// Collapsed caret at text offset 0 only — `!range.to` is also true when to is
+			// undefined/NaN and would misfire merge-at-start (#2196).
+			if (!isDelete && (range.from === range.to) && (range.from === 0)) {
 				if (block.isTextToggleHeader() && !length) {
 					const map = {
 						[I.TextStyle.ToggleHeader1]: I.TextStyle.Header1,

--- a/src/ts/component/form/editable.tsx
+++ b/src/ts/component/form/editable.tsx
@@ -26,6 +26,12 @@ interface Props {
 	onCompositionStart?: (e: any) => void;
 	onCompositionEnd?: (e: any, value: string, range: I.TextRange) => void;
 	onBeforeInput?: (e: any) => void;
+	/**
+	 * When true, skip Mark ZWS dom/model offset conversion. Prism code fields never
+	 * use mark ZWS anchors; conversion breaks caret/backspace if U+200B appears in
+	 * pasted source (#2196).
+	 */
+	plainDomTextOffsets?: boolean;
 };
 
 interface EditableRefProps {
@@ -69,6 +75,7 @@ const Editable = forwardRef<EditableRefProps, Props>(({
 	onCompositionStart,
 	onCompositionEnd,
 	onBeforeInput,
+	plainDomTextOffsets = false,
 }, ref) => {
 
 	const nodeRef = useRef(null);
@@ -139,7 +146,7 @@ const Editable = forwardRef<EditableRefProps, Props>(({
 		};
 
 		// Convert DOM offsets (with ZWS) to model offsets (without ZWS)
-		if (Mark.hasZws(editableRef.current)) {
+		if (!plainDomTextOffsets && Mark.hasZws(editableRef.current)) {
 			return {
 				from: Mark.domToModel(range.start, editableRef.current),
 				to: Mark.domToModel(range.end, editableRef.current),
@@ -157,7 +164,7 @@ const Editable = forwardRef<EditableRefProps, Props>(({
 		editableRef.current.focus({ preventScroll: true });
 
 		// Convert model offsets (without ZWS) to DOM offsets (with ZWS)
-		if (Mark.hasZws(editableRef.current)) {
+		if (!plainDomTextOffsets && Mark.hasZws(editableRef.current)) {
 			const domFrom = Mark.modelToDom(range.from, editableRef.current);
 			const domTo = Mark.modelToDom(range.to, editableRef.current);
 
@@ -336,7 +343,7 @@ const Editable = forwardRef<EditableRefProps, Props>(({
 	}, []);
 
 	const isAtDomEnd = (): boolean => {
-		if (!editableRef.current || !Mark.hasZws(editableRef.current)) {
+		if (!editableRef.current || plainDomTextOffsets || !Mark.hasZws(editableRef.current)) {
 			return true;
 		};
 
@@ -349,7 +356,7 @@ const Editable = forwardRef<EditableRefProps, Props>(({
 	};
 
 	const isAtDomStart = (): boolean => {
-		if (!editableRef.current || !Mark.hasZws(editableRef.current)) {
+		if (!editableRef.current || plainDomTextOffsets || !Mark.hasZws(editableRef.current)) {
 			return true;
 		};
 

--- a/src/ts/lib/focus.ts
+++ b/src/ts/lib/focus.ts
@@ -148,8 +148,12 @@ class Focus {
 		if (U.Dom.hasClass(node, 'editable')) {
 			keyboard.setFocus(true);
 
+			// Code blocks (`.textCode`): never use Mark ZWS mapping — Prism/source may still
+			// contain stray U+200B from clipboard; mapping breaks caret (#2196).
+			const isCodeTextField = Boolean(node.closest('.textCode'));
+
 			// Convert model offsets to DOM offsets if ZWS cursor anchors are present
-			if (Mark.hasZws(node)) {
+			if (Mark.hasZws(node) && !isCodeTextField) {
 				const domFrom = Mark.modelToDom(range.from, node);
 				const domTo = Mark.modelToDom(range.to, node);
 

--- a/src/ts/lib/util/string.ts
+++ b/src/ts/lib/util/string.ts
@@ -433,6 +433,53 @@ class UtilString {
 	};
 
 	/**
+	 * Removes invisible Unicode often embedded by rich clipboard / AI copy flows.
+	 * In code blocks these make Mark.hasZws() treat content like mark-anchored text
+	 * and break dom/model range conversion (caret / backspace).
+	 */
+	stripZeroWidthFormatChars (s: string): string {
+		return String(s || '').replace(/[\u200B-\u200D\uFEFF\u2060]/g, '');
+	};
+
+	/**
+	 * UTF-16 code units to remove immediately before index (manual Backspace).
+	 */
+	utf16DeleteLengthBefore (s: string, index: number): number {
+		s = String(s || '');
+		index = Number(index) || 0;
+		if (index <= 0) {
+			return 0;
+		};
+		const low = s.charCodeAt(index - 1);
+		if ((low >= 0xDC00) && (low <= 0xDFFF) && (index >= 2)) {
+			const high = s.charCodeAt(index - 2);
+			if ((high >= 0xD800) && (high <= 0xDBFF)) {
+				return 2;
+			};
+		};
+		return 1;
+	};
+
+	/**
+	 * UTF-16 code units to remove at index going forward (manual Delete).
+	 */
+	utf16DeleteLengthAfter (s: string, index: number): number {
+		s = String(s || '');
+		index = Number(index) || 0;
+		if (index >= s.length) {
+			return 0;
+		};
+		const high = s.charCodeAt(index);
+		if ((high >= 0xD800) && (high <= 0xDBFF) && (index + 1 < s.length)) {
+			const low = s.charCodeAt(index + 1);
+			if ((low >= 0xDC00) && (low <= 0xDFFF)) {
+				return 2;
+			};
+		};
+		return 1;
+	};
+
+	/**
 	 * Escapes HTML special characters in a string.
 	 * @param {string} s - The string to escape.
 	 * @returns {string} The escaped string.


### PR DESCRIPTION
You can paste this into the PR description on GitHub:

Summary
Fixes [#2196](https://github.com/anyproto/anytype-ts/issues/2196) — after pasting content from rich sources (e.g. AI “Copy response”, Markdown-heavy snippets) into a code block, Backspace and Delete often did not remove characters, or editing felt “stuck” even though new typing still worked.

What was going wrong
Code blocks render as a contenteditable whose HTML is built from plain text (syntax highlighting with Prism, newlines as <br>). That stack is different from normal paragraph text with marks.

Several things could line up badly:

Invisible Unicode (zero-width spaces, BOM, word joiner, etc.) from the clipboard could end up in the stored text. That made Mark.hasZws() treat the field like mark-anchored rich text and turned on ZWS-aware DOM ↔ model range conversion — which is meant for mentions/emoji, not for source code. Caret and offsets could disagree with what you see.

Backspace handling used if (range.to) as a proxy for “not at the start of the block”. In JavaScript, 0 is falsy, so a collapsed caret at offset 0 was mixed with broken or missing range.to. That could run the wrong branch, re-save stale text, set ret = true, and skip the rest of the key handler — fighting the browser’s native delete.

Even after tightening ranges and ZWS behavior, native contenteditable deletion inside long pasted <br> / Prism trees could still disagree with the plain-text model the app persists. The reliable fix for code is to not depend on the browser for single-character Backspace/Delete there.

What we changed
1. Normalize pasted / stored code text
Added U.String.stripZeroWidthFormatChars() and call it when reading/writing code block text so invisible format characters do not accumulate in the model.
2. Correct selection mapping for code fields
Editable: new prop plainDomTextOffsets — for code blocks, selection offsets match selection-ranges directly (no Mark ZWS dom/model conversion).
focus.apply: if the focused node is inside .textCode, skip modelToDom ZWS conversion.
BlockText onFocus: skip domToModel for code when reading the selection from the DOM.
3. Safer Backspace conditions (all text, especially edge cases)
Replaced fragile if (range.to) / !range.to logic with explicit checks: non-empty caret or selection vs collapsed at offset 0.
onBackspaceBlock: merge-at-start-of-block now requires range.from === range.to === 0 instead of !range.to, so missing to does not look like “start of block”.
4. Programmatic Backspace / Delete inside code blocks
For code blocks only (menus closed): on Backspace / Delete, preventDefault and update the block using the current getTextValue() string:
Selection: remove the selected range.
Collapsed caret: remove one UTF-16 code unit or a full surrogate pair (emoji) before/after the caret via U.String.utf16DeleteLengthBefore / utf16DeleteLengthAfter.
Then blockSetText + setValue so the DOM and store stay aligned.
Caret at offset 0 is not intercepted here so merge with the previous block still works as before.
Scope / risk
Touched files (5): string.ts, block/text.tsx, form/editable.tsx, lib/focus.ts, editor/page.tsx.
Behavior change is scoped to code-style text blocks and Backspace/Delete (plus the small, targeted range and focus fixes above).
Non-code paragraphs, titles, lists, etc. keep their existing paths; mark-related Backspace logic stays in the non-code branch.
How to verify (manual)
Copy a long snippet from an AI assistant or any source that puts Markdown + emoji + fenced blocks in the clipboard.
Paste into a code block in the editor.
Place the caret inside the pasted text and use Backspace and Delete — each key should remove one visible character (or the selection), including around emoji.
Move the caret to the very start of the block and press Backspace — block merge / previous-block focus should still behave as today.
Smoke-test a normal paragraph (not code): Backspace, Delete, marks, and merge-at-start unchanged.
Checklist

 Fixes #2196 (code block editing after rich paste)

 Single logical change-set; no unrelated refactors

 Typecheck / lint clean on changed files

Short title for the PR:
fix(editor): code block Backspace/Delete after rich paste (#2196)

I have read the CLA Document and I hereby sign the CLA