### PR TITLE
JS-2195: align Excalidraw fullscreen top menu flush left on macOS

### DIFF
--- a/src/scss/block/embed.scss
+++ b/src/scss/block/embed.scss
@@ -168,7 +168,7 @@
 
 html.platformMac {
 	.blocks .block.blockEmbed.isExcalidraw .wrap.isFullScreen {
-		.App-menu_top { padding-left: 84px; }
+		.App-menu_top { padding-left: 0px; }
 		.App-menu_left { padding-top: 52px; }
 	}
 }


### PR DESCRIPTION
## Summary
Fixes misalignment of the Excalidraw main menu (top-left) when the embed is in block fullscreen on macOS ([#2195](https://github.com/anyproto/anytype-ts/issues/2195)).

## Cause
`embed.scss` applied `padding-left: 84px` on `.App-menu_top` to mirror the main app chrome (traffic lights). The fullscreen embed uses `position: fixed; inset: 0`, so that padding only shifted Excalidraw’s top bar to the right without matching real window chrome inside the overlay.

## Change
Set `padding-left: 0px` for `.App-menu_top` under `html.platformMac` + `.wrap.isFullScreen`. Left sidebar `padding-top: 52px` on `.App-menu_left` is unchanged.

## Testing
- [x] macOS: open Excalidraw embed → fullscreen → confirm top-left menu aligns with the left edge

---

I have read the CLA Document and I hereby sign the CLA
https://github.com/anyproto/.github/blob/main/docs/CLA.md

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

