### PR TITLE
JS-2193: ignore stale ObjectOpen after workspace switch

### DIFF
--- a/src/ts/lib/util/router.ts
+++ b/src/ts/lib/util/router.ts
@@ -161,7 +161,12 @@ class UtilRouter {
 			sidebar.rightPanelClose(false, false);
 		};
 
-		if (routeParam.spaceId && (routeParam.spaceId != space) && ![ 'object', 'invite' ].includes(routeParam.action)) {
+		// If route explicitly targets another space, switch before navigating.
+		// NOTE: Universal object routes (`/object?objectId=...&spaceId=...`) are normalized to
+		// `{ page: 'main', action: 'object', id: objectId, spaceId }` in `getParam()`.
+		// They must also trigger a space switch; otherwise we try to open the object in the
+		// previous space (stale `S.Common.space`) when switching spaces quickly.
+		if (routeParam.spaceId && (routeParam.spaceId != space) && ![ 'invite' ].includes(routeParam.action)) {
 			this.switchSpace(routeParam.spaceId, newRoute, false, param, false);
 			return;
 		};


### PR DESCRIPTION
## Summary
Fixes [#2193](https://github.com/anyproto/anytype-ts/issues/2193): rapid workspace switching (e.g. Cmd+1 / Cmd+2) could surface **ObjectOpen** errors such as `build tree: tree does not exist` and the generic “problem while opening the object” popup even when the UI had already moved on.

## Root cause
`ObjectClose` from `pageClose` / space switch could finish before an in-flight `ObjectOpen` response returned. The middleware had already torn down the tree, so the late response was treated as a hard failure.

## Approach
- **`C.ObjectOpen`** (`command.ts`): optional `isSuperseded` callback; when true, skip `onObjectView` / last-opened storage so a superseded success cannot apply the wrong tree.
- **Object pages** (editor, set, media, chat, relation, date): per-mount **open sequence** + space snapshot; bump on each `open` / `close`; treat matching responses as stale and skip UI/error handling (loaders still clear).
- **Guard** empty `rootId` where we issue `ObjectOpen`.

## Testing
- [x] Switch spaces quickly with an object open (and while a page is still loading); confirm no spurious error popup.

---
I have read the CLA Document and I hereby sign the CLA
https://github.com/anyproto/.github/blob/main/docs/CLA.md

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed