### PR TITLE
JS-9749: image loader fixes for chat attachments and editor image block

### DIFF
--- a/src/scss/block/chat/attachment.scss
+++ b/src/scss/block/chat/attachment.scss
@@ -106,8 +106,8 @@
 
 		&.isImage { width: 72px; height: 72px; min-width: unset; display: flex; align-items: center; justify-content: center; }
 		&.isImage {
-			.image,
-			.loaderWrapper { display: block; object-fit: cover; aspect-ratio: 1; width: 100%; height: 100%; }
+			.image { display: block; object-fit: cover; aspect-ratio: 1; width: 100%; height: 100%; }
+			.loaderWrapper { position: absolute; inset: 0; z-index: 1; width: auto; height: auto; margin: 0; }
 
 			.icon.syncStatus { width: 72px !important; height: 72px !important; }
 
@@ -174,7 +174,7 @@
 .attachments.withLayout {
 	.attachment { border-radius: 12px; height: auto; width: 100%; aspect-ratio: 1; flex-shrink: 0; min-width: unset; }
 	.attachment.isImage {
-		.image, .loaderWrapper { max-width: 100%; max-height: 360px; }
+		.image { max-width: 100%; max-height: 360px; }
 	}
 }
 

--- a/src/scss/block/media.scss
+++ b/src/scss/block/media.scss
@@ -48,6 +48,7 @@
 		.wrap { max-width: 100%; position: relative; display: inline-block; overflow: hidden; }
 		.wrap {
 			> .loader { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); z-index: 1; }
+			> .loaderWrapper { position: absolute; inset: 0; z-index: 1; width: auto; height: auto; margin: 0; background: var(--color-shape-highlight-light); border-radius: 8px; }
 		}
 		.mediaImage { width: 100%; display: block; cursor: zoom-in; }
 		.mediaVideo {

--- a/src/ts/component/block/chat/attachment/index.tsx
+++ b/src/ts/component/block/chat/attachment/index.tsx
@@ -1,5 +1,5 @@
-import React, { forwardRef, useRef, useImperativeHandle } from 'react';
-import { IconObject, Icon, ObjectName, ObjectDescription, ObjectType, MediaVideo, MediaAudio } from 'Component';
+import React, { forwardRef, useRef, useImperativeHandle, useState } from 'react';
+import { IconObject, Icon, ObjectName, ObjectDescription, ObjectType, MediaVideo, MediaAudio, Loader } from 'Component';
 import * as I from 'Interface';
 
 interface Props {
@@ -43,6 +43,7 @@ const ChatAttachment = forwardRef<RefProps, Props>((props, ref) => {
 	const nodeRef = useRef(null);
 	const syncIconName = (syncStatus != I.SyncStatusObject.Synced) ? `chat/syncStatus/${I.SyncStatusObject[syncStatus].toLowerCase()}` : '';
 	const src = useRef('');
+	const [ isImageLoaded, setIsImageLoaded ] = useState(false);
 
 	if (isDownloadingFile) {
 		cn.push('isDownloadingFile');
@@ -187,11 +188,13 @@ const ChatAttachment = forwardRef<RefProps, Props>((props, ref) => {
 		return (
 			<div className="mediaWrapper" onClick={onPreviewHandler}>
 				{blur}
+				{!isImageLoaded ? <Loader type={I.LoaderType.Loader} /> : ''}
 				<img
 					id="image"
 					className="image"
 					src={src.current}
 					onDragStart={e => e.preventDefault()}
+					onLoad={() => setIsImageLoaded(true)}
 					style={style}
 				/>
 

--- a/src/ts/component/block/media/image.tsx
+++ b/src/ts/component/block/media/image.tsx
@@ -177,6 +177,9 @@ const BlockImage = forwardRef<I.BlockRef, I.BlockComponent>((props, ref) => {
 
 	if (object.widthInPixels && object.heightInPixels) {
 		wrapCss.aspectRatio = `${object.widthInPixels} / ${object.heightInPixels}`;
+		if (!width) {
+			wrapCss.width = object.widthInPixels;
+		};
 	} else
 	if (!isLoaded) {
 		wrapCss.height = 80;


### PR DESCRIPTION
## Summary

- Chat image attachments now show the standard `<Loader>` while the gateway request is in flight, mirroring the editor image block pattern.
- Fixes a recently introduced regression in the editor image block (JS-9425) where the wrap collapsed to 0×0 during load on un-resized blocks: `display: inline-block` + only `aspect-ratio` (no width) cannot resolve dimensions, so the loader had no area to render in. Now the wrap is reserved with the natural `widthInPixels` (capped by `max-width: 100%`) when no user-set width is present.
- Loader overlay sits centered on a themed light-grey background (`--color-shape-highlight-light`) with rounded corners while loading, and vanishes the moment `onLoad` fires.

Retry/reload behavior on failed loads is intentionally out of scope and will land in a separate PR.

## Test plan

- [x] Send an image in chat — loader appears while gateway request is pending, image swaps in cleanly on load.
- [x] Open a page with a freshly inserted (un-resized) image block — wrap reserves correct aspect-ratio space immediately, loader is centered on the light-grey background, image fills the same box on load with no jump.
- [x] Open a page with a previously-resized image block — user width is preserved, no regression.
- [x] Verify in dark mode — loader background uses the dark theme variant (`rgba(255,255,255,0.03)`).
- [x] Verify chat multi-image grid layouts (2/3/4/5+ attachments) — loaders render correctly inside each cell.