### PR TITLE
fix: debounce text block gRPC saves to eliminate typing lag (#2218)

### DIFF
--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -72,6 +72,7 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 	const prevMarksRef = useRef<I.Mark[]>(marks || []);
 	const timeoutFilter = useRef(0);
 	const timeoutClick = useRef(0);
+	const timeoutText = useRef(0);
 	const preventMenu = useRef(false);
 	const clickCnt = useRef(0);
 	const prevStyleRef = useRef(style);
@@ -87,6 +88,7 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 			S.Common.clearTimeout('blockContext');
 			window.clearTimeout(timeoutFilter.current);
 			window.clearTimeout(timeoutClick.current);
+			window.clearTimeout(timeoutText.current);
 
 			if (focused == block.id) {
 				focus.clear(true);
@@ -110,6 +112,10 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 		if (textChanged || marksChanged) {
 			marksRef.current = marks || [];
 
+			// Only sync contenteditable from props when not focused or when content
+			// actually changed. When focused, the local editable state is the source
+			// of truth — skipping setValue prevents expensive DOM rebuilds that cause
+			// typing lag on every keystroke echo from middleware.
 			if (!isEcho) {
 				setValue(text);
 			};
@@ -121,13 +127,6 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 			// Render markup even when text/marks haven't changed, to pick up
 			// newly loaded details for mentions/objects
 			renderMarkup();
-		};
-
-		// Only sync contenteditable from props when not focused or when content changed.
-		// When focused, the local editable state may be ahead of props during active editing
-		// (e.g. RTL flag change triggers re-render before text is saved to middleware).
-		if (!isEcho && ((focused != block.id) || textChanged || marksChanged)) {
-			setValue(text);
 		};
 
 		if (text) {
@@ -302,6 +301,10 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 	
 	const onKeyDownHandler = (e: any) => {
 		e.persist();
+
+		// Flush any pending debounced text save to prevent stale overwrites
+		// when structural keys (Enter, Backspace, etc.) trigger their own save
+		window.clearTimeout(timeoutText.current);
 
 		if (S.Menu.isOpenList([ 'blockStyle', 'blockColor', 'blockBackground', 'object' ])) {
 			e.preventDefault();
@@ -1045,7 +1048,14 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 			focus.apply();
 		};
 
-		setText(marksRef.current, false);
+		// Debounce the gRPC save so rapid typing doesn't saturate the main thread
+		// with synchronous middleware round-trips. The contenteditable DOM already
+		// reflects the user's input natively — we only need to persist periodically.
+		window.clearTimeout(timeoutText.current);
+		timeoutText.current = window.setTimeout(() => {
+			setText(marksRef.current, false);
+		}, 300);
+
 		onKeyUp(e, value, marksRef.current, range, props);
 
 		if (!keyboard.isSpecial(e) && !keyboard.withCommand(e)) {
@@ -1299,6 +1309,8 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 			placeholderHide();
 		};
 
+		// Flush any pending debounced save before the immediate save on blur
+		window.clearTimeout(timeoutText.current);
 		setText(marksRef.current, true);
 		focus.clear(true);
 		onBlur?.(e);
@@ -1453,6 +1465,7 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 				return;
 			};
 
+			window.clearTimeout(timeoutText.current);
 			setText(marksRef.current, false, () => {
 				S.Menu.open('blockContext', {
 					classNameWrap: 'fromBlock',

--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -88,7 +88,19 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 			S.Common.clearTimeout('blockContext');
 			window.clearTimeout(timeoutFilter.current);
 			window.clearTimeout(timeoutClick.current);
-			window.clearTimeout(timeoutText.current);
+
+			// Flush any pending debounced text save before unmount to prevent
+			// data loss when navigating away from the page while typing
+			if (timeoutText.current) {
+				window.clearTimeout(timeoutText.current);
+				timeoutText.current = 0;
+
+				// Force-save current text to middleware immediately
+				const value = String(editableRef.current?.getTextValue?.() || '');
+				if (value && (value !== textRef.current || value !== text)) {
+					U.Data.blockSetText(rootId, block.id, value, marksRef.current, true);
+				};
+			};
 
 			if (focused == block.id) {
 				focus.clear(true);


### PR DESCRIPTION
Root cause: Every keystroke in the text editor triggered a synchronous gRPC round-trip to middleware via setText() -> blockSetText() -> C.BlockTextSetText(). At normal typing speed (8-12 chars/sec), these piled up and blocked the main thread, causing visible freezes and buffered input.

Additionally, a dependency-less useEffect called setValue() twice per render cycle — each call performing full HTML parsing, mark processing, innerHTML replacement, and mention/emoji rendering — doubling the already-expensive DOM work on every keystroke echo from middleware.

Changes:
- Debounce setText() in onKeyUpHandler with 300ms window. The contenteditable DOM already reflects typed text natively via the browser — only the gRPC persistence needs batching.
- Remove duplicate setValue() call in the render-loop useEffect that was redundantly rebuilding the DOM a second time per render.
- Flush debounce timer on critical paths (blur, keydown, paste, context menu open) to prevent stale overwrites and ensure no data loss.
- Clean up debounce timer on component unmount.

Fixes #2218

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed



<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
