### PR TITLE
fix: socialBlock overlay no longer intercepts clicks on page content

### DIFF
--- a/src/scss/component/comment.scss
+++ b/src/scss/component/comment.scss
@@ -3,11 +3,12 @@
 .socialBlockWrap { position: sticky; bottom: 0; height: 0; z-index: 2; }
 
 .socialBlock {
-	position: absolute; bottom: 0px; width: 100%; height: 88px; display: flex; justify-content: center; 
-	align-items: flex-end; padding: 0px 0px 12px 0px; transition: opacity 0.15s ease;
+	position: absolute; bottom: 0px; width: 100%; height: 88px; display: flex; justify-content: center;
+	align-items: flex-end; padding: 0px 0px 12px 0px; transition: opacity 0.15s ease; pointer-events: none;
 }
 .socialBlock {
-	&.isHidden { opacity: 0; pointer-events: none; }
+	&.isHidden { opacity: 0; }
+	& > * { pointer-events: all; }
 
 	.commentCounter {
 		display: inline-flex; align-items: center; gap: 0px 4px; padding: 7px 10px 7px 8px; border-radius: 18px;


### PR DESCRIPTION
## Summary
- The `.socialBlock` element (88px absolutely-positioned overlay) was blocking pointer events on page content behind it (e.g. charts, images, text)
- Added `pointer-events: none` to the container so it no longer intercepts clicks
- Restored `pointer-events: all` on direct children so the "Start a discussion" button remains fully clickable
- Removed the redundant `pointer-events: none` from `.isHidden` (now inherited from parent)

## Test plan
- [ ] Open a page with a comment section — content behind the social block area should be clickable (links, images, etc.)
- [ ] The "Start a discussion" / comment counter button should still be clickable when visible
- [ ] Hiding/showing the social block (scroll triggers) should still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)