### PR TITLE
HTML Live Preview for Code Blocks

### DIFF
--- a/dist/embed/iframe.html
+++ b/dist/embed/iframe.html
@@ -129,6 +129,27 @@
 					};
 					// ──────────────────────────────────────────────────────────────
 
+					// ── Raw HTML Preview (Bypasses CSP) ──────────────────────────────
+					if (oe.data && oe.data.rawHtmlPreview !== undefined) {
+						body.css({ margin: 0, padding: 0 });
+
+						const blob = new Blob([oe.data.rawHtmlPreview], { type: 'text/html' });
+						const blobUrl = URL.createObjectURL(blob);
+
+						const iframe = document.createElement('iframe');
+						iframe.src = blobUrl;
+						iframe.sandbox = 'allow-scripts allow-same-origin allow-popups';
+
+						root.empty();
+						scripts.empty();
+						root.get(0).appendChild(iframe);
+
+						// Cleanup blob URL when iframe unloads
+						win.on('unload', () => URL.revokeObjectURL(blobUrl));
+						return;
+					};
+					// ──────────────────────────────────────────────────────────────
+
 					let { js, className, insertBeforeLoad, allowIframeResize, align } = oe.data;
 
 					html = String(oe.data.html || '');

--- a/electron/json/cors.json
+++ b/electron/json/cors.json
@@ -260,6 +260,9 @@
 	"frame-src": [
 		"chrome-extension://react-developer-tools",
 		"file://*",
+		"about:",
+		"data:",
+		"blob:",
 		"http://localhost:*/embed/iframe.html",
 		"https://*.youtube.com",
 		"https://*.youtube-nocookie.com",

--- a/electron/ts/main.ts
+++ b/electron/ts/main.ts
@@ -285,6 +285,12 @@ function createWindow () {
 
 app.on('ready', async () => {
 	session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+		// Skip CSP injection for iframe embeds which need to load external scripts
+		if (details.url.includes('/embed/iframe.html')) {
+			callback({ responseHeaders: details.responseHeaders });
+			return;
+		};
+
 		callback({
 			responseHeaders: {
 				...details.responseHeaders,

--- a/src/scss/block/text.scss
+++ b/src/scss/block/text.scss
@@ -299,6 +299,8 @@
 		#value { white-space: pre; overflow-x: scroll; }
 	}
 
+
+
 	/* DropTarget */
 
 	.block.blockText.textParagraph > .wrapContent > .dropTarget.targetBot.isOver.bottom,
@@ -321,4 +323,80 @@
 		.flex { gap: 0px 8px; }
 		.marker { width: 30px; height: 30px; margin: 0px; }
 	}
+}
+
+/* HTML Preview Panel — fixed right-side overlay rendered via Portal */
+.htmlPreviewPanel {
+	position: fixed;
+	top: 0;
+	right: 0;
+	width: 50%;
+	height: 100vh;
+	z-index: 10000;
+	display: flex;
+	flex-direction: column;
+	background-color: var(--color-bg-primary);
+	border-left: 1px solid var(--color-shape-secondary);
+	box-shadow: -4px 0 16px rgba(0, 0, 0, 0.2);
+	transition: width 0.2s ease;
+
+	&.isFullscreen {
+		width: 100%;
+		border-left: none;
+	}
+}
+
+.htmlPreviewPanel-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	height: 36px;
+	min-height: 36px;
+	padding: 0 8px 0 12px;
+	background-color: var(--color-bg-secondary);
+	border-bottom: 1px solid var(--color-shape-secondary);
+	user-select: none;
+}
+
+.htmlPreviewPanel-title {
+	font-size: 11px;
+	font-weight: 600;
+	color: var(--color-text-secondary);
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+}
+
+.htmlPreviewPanel-actions {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+}
+
+.htmlPreviewPanel-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	border-radius: 4px;
+	cursor: pointer;
+	transition: background-color 0.15s ease;
+
+	&:hover { background-color: var(--color-bg-tertiary); }
+
+	.icon {
+		width: 16px;
+		height: 16px;
+		opacity: 0.5;
+		transition: opacity 0.15s ease;
+	}
+
+	&:hover .icon { opacity: 0.8; }
+}
+
+.htmlPreviewPanel-iframe {
+	flex: 1;
+	width: 100%;
+	border: none;
+	display: block;
 }

--- a/src/scss/common.scss
+++ b/src/scss/common.scss
@@ -37,7 +37,9 @@ select:-webkit-autofill:focus { transition: background-color 5000s linear 0s; }
 input, textarea, select { font-family: 'Inter'; }
 
 #root { height: 100%; }
-#appContainer { display: flex; flex-direction: column; height: 100%; }
+#appContainer { display: flex; flex-direction: column; height: 100%; transition: width 0.2s ease; width: 100vw; }
+
+body.html-preview-split-active #appContainer { width: 50vw; }
 #selection { flex-grow: 1; overflow: hidden; }
 .swiper-navigation-icon { display: none !important; }
 

--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, useRef, useEffect } from 'react';
+import React, { forwardRef, useRef, useEffect, useMemo, useCallback, useState } from 'react';
+import ReactDOM from 'react-dom';
 import * as Prism from 'prismjs';
 
 import raf from 'raf';
@@ -57,6 +58,13 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 	const { id, content } = block;
 	const fields = block.fields || {};
 	const { text, marks, style, checked, color, iconEmoji, iconImage } = content;
+	const codeLang = fields.lang || J.Constant.default.codeLang;
+	const isHtml = block.isTextCode() && (
+		codeLang === 'html' || 
+		codeLang === 'htm' || 
+		codeLang === 'xhtml' || 
+		U.Prism.aliasMap[codeLang] === 'markup'
+	);
 	const { theme } = S.Common;
 	const root = S.Block.getLeaf(rootId, rootId);
 	const cn = [ 'flex' ];
@@ -1404,6 +1412,12 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 		]);
 	};
 
+	const onTogglePreview = () => {
+		C.BlockListSetFields(rootId, [
+			{ blockId: id, fields: { ...fields, showPreview: !fields.showPreview } },
+		]);
+	};
+
 	const onCopy = () => {
 		const length = block.getLength();
 
@@ -1692,6 +1706,13 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 					/>
 
 					<div className="buttons">
+						{isHtml && (
+							<div className="btn" onClick={onTogglePreview}>
+								<Icon name={fields.showPreview ? 'common/eye1' : 'common/eye0'} className="preview" />
+								<div className="txt">{fields.showPreview ? translate('blockTextHidePreview') : translate('blockTextShowPreview')}</div>
+							</div>
+						)}
+
 						<div className="btn" onClick={onToggleWrap}>
 							<Icon name="menu/action/wrap" className="codeWrap" />
 							<div className="txt">{fields.isUnwrapped ? translate('blockTextWrap') : translate('blockTextUnwrap')}</div>
@@ -1732,18 +1753,73 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 	};
 
-	return (
-		<div 
-			ref={nodeRef}
-			className={cn.join(' ')}
-		>
-			<div className="markers">
-				{marker ? <Marker {...marker} id={id} color={color} readonly={readonly} /> : ''}
-				{markerIcon}
+	const showPreview = block.isTextCode() && fields.showPreview && isHtml;
+	const iframeRef = useRef<HTMLIFrameElement>(null);
+	const [ isPreviewFullscreen, setIsPreviewFullscreen ] = useState(false);
+
+	const sendPreviewData = useCallback(() => {
+		if (!iframeRef.current || !iframeRef.current.contentWindow) return;
+		
+		const data = {
+			rawHtmlPreview: text,
+			blockId: id,
+		};
+		iframeRef.current.contentWindow.postMessage(data, '*');
+	}, [ text, id ]);
+
+	useEffect(() => {
+		if (showPreview) {
+			sendPreviewData();
+			document.body.classList.add('html-preview-split-active');
+		} else {
+			document.body.classList.remove('html-preview-split-active');
+		}
+
+		return () => document.body.classList.remove('html-preview-split-active');
+	}, [ showPreview, text, sendPreviewData ]);
+
+	const onHidePreview = (e: React.MouseEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		setIsPreviewFullscreen(false);
+		C.BlockListSetFields(rootId, [
+			{ blockId: id, fields: { ...fields, showPreview: false } },
+		]);
+	};
+
+	const onToggleFullscreen = (e: React.MouseEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		setIsPreviewFullscreen(!isPreviewFullscreen);
+	};
+
+	const previewPanel = showPreview ? ReactDOM.createPortal(
+		<div className={[ 'htmlPreviewPanel', isPreviewFullscreen ? 'isFullscreen' : '' ].join(' ')}>
+			<div className="htmlPreviewPanel-header">
+				<span className="htmlPreviewPanel-title">HTML Preview</span>
+				<div className="htmlPreviewPanel-actions">
+					<div className="htmlPreviewPanel-btn" onMouseDown={onToggleFullscreen} title={isPreviewFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}>
+						<Icon name="common/expand" />
+					</div>
+					<div className="htmlPreviewPanel-btn" onMouseDown={onHidePreview} title="Close Preview">
+						<Icon name="common/close" />
+					</div>
+				</div>
 			</div>
+			<iframe
+				ref={iframeRef}
+				title={`preview-${id}`}
+				sandbox="allow-scripts allow-same-origin allow-popups"
+				src={U.Common.fixAsarPath(`./embed/iframe.html?theme=${S.Common.getThemeClass()}`)}
+				className="htmlPreviewPanel-iframe"
+				onLoad={sendPreviewData}
+			/>
+		</div>,
+		document.body
+	) : null;
 
-			{additional ? <div className="additional">{additional}</div> : ''}
-
+	const editorContent = (
+		<>
 			<Editable 
 				ref={editableRef}
 				id="value"
@@ -1765,6 +1841,23 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 				onCompositionEnd={onCompositionEnd}
 				onBeforeInput={onBeforeInput}
 			/>
+			{previewPanel}
+		</>
+	);
+
+	return (
+		<div 
+			ref={nodeRef}
+			className={cn.join(' ')}
+		>
+			<div className="markers">
+				{marker ? <Marker {...marker} id={id} color={color} readonly={readonly} /> : ''}
+				{markerIcon}
+			</div>
+
+			{additional ? <div className="additional">{additional}</div> : ''}
+
+			{editorContent}
 		</div>
 	);
 


### PR DESCRIPTION
Adds a real-time HTML preview panel to code blocks when the language is set to HTML. The preview renders user HTML/CSS/JS in a sandboxed iframe using a CSP-bypassed embed proxy (dist/embed/iframe.html), supporting external CDN scripts (e.g. Tailwind CSS, Babel for React JSX).

Just like markdown, HTML format is becoming popular again for learning visually with the help of LLMs. I personally find myself making and storing lots of HTML in my anytype notes these days. We don't currently have preview HTML option inside the app itself so it's very frustrating to always download and open it in a separate web browser. I have integrated the preview support with this PR.

<img width="1918" height="226" alt="image" src="https://github.com/user-attachments/assets/71dbfd78-62ef-4912-ad9f-7bd50fa35b78" />

Clicking on "Show Preview" opens the side panel with the preview. Close and Full Screen option always visible to the user.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8bf8cdb0-7300-4d2a-b2b9-a4706882fa56" />



Closes #2281 
