### PR TITLE
Increase editor bottom reserved space to 150px

### DIFF
--- a/src/json/size.ts
+++ b/src/json/size.ts
@@ -1,7 +1,7 @@
 export default {
 	editor: 704,
 	blockMenu: 48,
-	lastBlock: 80,
+	lastBlock: 150,
 	menuBorder: 10,
 	header: 52,
 

--- a/src/scss/component/editor.scss
+++ b/src/scss/component/editor.scss
@@ -35,7 +35,7 @@
 		}
 		.icon.buttonAdd.show { display: flex; }
 		
-		.blockLast { margin-left: -50px; height: 44px; }
+		.blockLast { margin-left: -50px; height: 150px; }
 
 		.tableOfContents { position: fixed; top: 50%; transform: translate3d(0px, -50%, 0px); padding: 16px; z-index: 10; }
 		.tableOfContents {


### PR DESCRIPTION
## Summary
- Increased `J.Size.lastBlock` from 80 to 150 in `src/json/size.ts` — this is the minimum height floor for the dynamically-calculated bottom spacer
- Updated the `.blockLast` CSS height from 44px to 150px in `src/scss/component/editor.scss` for consistency

## Test plan
- [ ] Open any object in the editor and verify there is more reserved space at the bottom
- [ ] Verify the "Start a discussion" button still appears correctly above the spacer

🤖 Generated with [Claude Code](https://claude.com/claude-code)