### PR TITLE
fix(cell): URL/Email/Phone menu actions always use the underlying record value

### DIFF
--- a/src/ts/component/cell/index.tsx
+++ b/src/ts/component/cell/index.tsx
@@ -328,7 +328,13 @@ const Cell = forwardRef<I.CellRef, Props>((props, ref) => {
 				};
 
 				const onSelect = (event: any, item: any) => {
-					const value = childRef.current.getValue();
+					// Always read from the underlying record value, never from a child
+					// cell that may expose a display-only (truncated) representation.
+					// Fixes #2163: when the featured-relations header renders a URL
+					// with `shortUrl`/`textLimit`, the visible string can be a form
+					// like "github.com/an...issues"; the Open/Copy/Reload actions
+					// must operate on the full target URL stored on the record.
+					const value = String(record[relation.relationKey] || '');
 					if (!value) {
 						return;
 					};


### PR DESCRIPTION
## Summary

The URL relation menu (and its Email / Phone twins) has three actions: **Go**, **Copy**, **Reload**. All three were reading the value to operate on from `childRef.current.getValue()`, which returns whatever the child cell has chosen to expose.

In the featured-relations header path the child is rendered with `shortUrl={true}` and `textLimit={150}` (see `src/ts/component/block/featured.tsx`), so the visible string can be a truncated form like `github.com/an...issues`. The underlying record value, however, is the full `https://github.com/anyproto/anytype-ts/issues`.

Even where the current text-cell implementation does not propagate the visual truncation back through `getValue()`, the data-flow contract leaves the door open: any future change to the text-cell render layer or to `getValue` could quietly surface the displayed string into the actions, and the menu would then copy or open the truncated URL.

Switch the actions to read `record[relation.relationKey]` directly — the record value is authoritative for URL / Email / Phone targets; the child cell is purely a display surface for them.

## Diff

```diff
 const onSelect = (event: any, item: any) => {
-    const value = childRef.current.getValue();
+    // Always read from the underlying record value, never from a child
+    // cell that may expose a display-only (truncated) representation.
+    // Fixes #2163: when the featured-relations header renders a URL
+    // with `shortUrl`/`textLimit`, the visible string can be a form
+    // like "github.com/an...issues"; the Open/Copy/Reload actions
+    // must operate on the full target URL stored on the record.
+    const value = String(record[relation.relationKey] || '');
     if (!value) {
         return;
     };
     ...
 };
```

+7 / -1 LOC, one file touched.

## Closes

- Closes #2163

## Test plan

- [x] `tsc --noEmit -p tsconfig.json` — no new errors from this patch (3 pre-existing errors in `dispatcher.ts` / `relation.ts` due to ungenerated proto files in a non-built tree, unrelated)
- [x] `biome lint src/ts/component/cell/index.tsx` — clean
- [ ] Manual on a desktop build:
  - Create or open an object with a custom URL relation
  - Set the value to a long URL such as `https://github.com/anyproto/anytype-ts/issues`
  - Confirm the featured-relations header shows the truncated form
  - Right-click the relation → choose **Open in browser** → the browser opens the full URL
  - Right-click → **Copy** → the clipboard contains the full URL

No unit test added — `src/ts/component/cell/index.tsx` has no `.test.ts` companion and the project's vitest coverage for components is e2e-style; the convention is to verify component fixes manually on a desktop build.