### PR TITLE
chat: use 1:1 OG image and top-align in wide bookmark layout

### DIFF
--- a/src/scss/block/chat/attachment.scss
+++ b/src/scss/block/chat/attachment.scss
@@ -77,7 +77,7 @@
 
 			&.isWide { max-width: 100%; overflow: hidden; }
 			&.isWide {
-				.inner { flex-direction: row; padding: 0px; align-items: stretch; overflow: hidden; }
+				.inner { flex-direction: row; padding: 0px; align-items: flex-start; overflow: hidden; }
 				.inner.withImage {
 					.side.left { padding-right: 0px; }
 				}
@@ -85,7 +85,7 @@
 				.side.left { flex-grow: 1; padding: 16px; justify-content: center; min-width: 0; }
 				.side.right {
 					padding: 16px; width: 28%; min-height: 90px; display: flex; justify-content: center; align-items: center; position: relative;
-					overflow: hidden; aspect-ratio: 7 / 3;
+					overflow: hidden; aspect-ratio: 1;
 				}
 				.side.right {
 					.img { border-radius: 4px; }


### PR DESCRIPTION
## Summary
- Changes wide bookmark attachment OG image aspect ratio from `7/3` to `1:1`
- Aligns the image container to the top of the card (`align-items: flex-start` on `.inner`)

## Test plan
- [ ] Open a chat with a wide bookmark attachment and confirm the OG image is square
- [ ] Confirm the image is top-aligned within the card
- [ ] Check that narrow/default bookmark layout is unaffected