### PR TITLE
fix(list): water-fill layout engine + anchor relation menus to click position

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,16 +300,6 @@ Detailed documentation is available in `docs/` for deeper context on each module
 
 Run in browser without Electron: `bun run start:web` (starts anytypeHelper + Vite dev server). Use `ANYTYPE_USE_SIDE_SERVER=http://...` to skip helper start. See `docs/src/ts/lib/web/README.md` for details.
 
-## Pull Request Workflow
-
-After creating any pull request, always post the following comment on it:
-
-```
-I have read the CLA Document and I hereby sign the CLA.
-```
-
-Use `gh pr comment <number> --body "I have read the CLA Document and I hereby sign the CLA."`.
-
 ## Linear API Integration
 
 Use the `LINEAR_API_KEY` environment variable to fetch issue details from Linear.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,16 @@ Detailed documentation is available in `docs/` for deeper context on each module
 
 Run in browser without Electron: `bun run start:web` (starts anytypeHelper + Vite dev server). Use `ANYTYPE_USE_SIDE_SERVER=http://...` to skip helper start. See `docs/src/ts/lib/web/README.md` for details.
 
+## Pull Request Workflow
+
+After creating any pull request, always post the following comment on it:
+
+```
+I have read the CLA Document and I hereby sign the CLA.
+```
+
+Use `gh pr comment <number> --body "I have read the CLA Document and I hereby sign the CLA."`.
+
 ## Linear API Integration
 
 Use the `LINEAR_API_KEY` environment variable to fetch issue details from Linear.

--- a/src/scss/block/dataview/view/list.scss
+++ b/src/scss/block/dataview/view/list.scss
@@ -73,6 +73,18 @@
 			.sides {
 				.side { display: flex; flex-direction: row; align-items: center; overflow: hidden; }
 				.side.left { flex: 1 1 auto; min-width: 40%; }
+				.side.right { flex-shrink: 1; min-width: 0; }
+				.side.right {
+					> .cellWrapper:not(.isName) { min-width: 0; overflow: hidden; }
+					.cellContent:not(.isName) { width: 100%; }
+					.cellContent:not(.isName) {
+						.wrap { overflow: hidden; max-width: 100%; }
+						.over { overflow: hidden; max-width: 100%; }
+						.element { overflow: hidden; max-width: 100%; }
+						.tagItem { overflow: hidden; max-width: 100%; }
+					}
+					.element .iconObject { display: none; }
+				}
 				.side.left {
 					.cellWrapper { margin-right: 4px; }
 					.cellWrapper.isName { width: 100%; }

--- a/src/scss/block/dataview/view/list.scss
+++ b/src/scss/block/dataview/view/list.scss
@@ -45,7 +45,7 @@
 						.cellContent:not(.isEditing) { max-width: calc(100% - 26px); }
 					}
 					.sides {
-						.side.left.s50 {
+						.side.left.s60 {
 							.cellWrapper.isName {
 								.cellContent:not(.isEditing) { max-width: calc(100% - 46px); }
 							}
@@ -83,7 +83,6 @@
 						.element { overflow: hidden; max-width: 100%; }
 						.tagItem { overflow: hidden; max-width: 100%; }
 					}
-					.element .iconObject { display: none; }
 				}
 				.side.left {
 					.cellWrapper { margin-right: 4px; }

--- a/src/ts/component/block/dataview/view/list/row.tsx
+++ b/src/ts/component/block/dataview/view/list/row.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useRef, useState, useImperativeHandle, MouseEvent } from 'react';
+import React, { forwardRef, useEffect, useLayoutEffect, useRef, useState, useImperativeHandle, MouseEvent } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import { Cell, DropTarget, Icon, IconObject, SelectionTarget } from 'Component';
 import * as I from 'Interface';
@@ -15,6 +15,7 @@ const ListRow = forwardRef<I.RowRef, Props>((props, ref) => {
 	} = props;
 	const [ isEditing, setIsEditing ] = useState(false);
 	const nodeRef = useRef(null);
+	const resizeRef = useRef(null);
 	const view = getView();
 
 	const resize = () => {
@@ -45,28 +46,28 @@ const ListRow = forwardRef<I.RowRef, Props>((props, ref) => {
 			return;
 		};
 
-		// Clear any previous water-fill inline flex so the left side reports
-		// its true content width when we measure it below.
-		wrappers.forEach(el => { el.style.flex = ''; });
+		// Only clear previous water-fill flex when it was actually set.
+		// An unconditional clear changes layout and triggers a spurious second
+		// ResizeObserver callback on every tick.
+		if (wrappers.some(el => el.style.flex)) {
+			wrappers.forEach(el => { el.style.flex = ''; });
+		};
 
 		// Compute available space from the container, not from rightSide.offsetWidth.
 		// rightSide.offsetWidth is unreliable because inner elements have
 		// max-width:100% which creates a circular reference when the right side
 		// has no fixed width, causing it to collapse to near-zero.
 		const sidesEl = rightSide.parentElement as HTMLElement;
+		if (!sidesEl) {
+			return;
+		};
 		const leftSideEl = U.Dom.select('.side.left', sidesEl) as HTMLElement;
-		if (!sidesEl || !leftSideEl) {
+		if (!leftSideEl) {
 			return;
 		};
 
-		leftSideEl.style.flex = '0 0 auto';
-		const leftNatural = leftSideEl.offsetWidth;
-		leftSideEl.style.flex = '';
-
 		const sidesWidth = sidesEl.offsetWidth;
-		// Respect the CSS min-width:40% on the left side.
-		const effectiveLeft = Math.max(leftNatural, sidesWidth * 0.4);
-		const available = Math.max(0, sidesWidth - effectiveLeft - 12);
+		const available = Math.max(0, sidesWidth - leftSideEl.offsetWidth - 12);
 		if (!available) {
 			return;
 		};
@@ -97,9 +98,6 @@ const ListRow = forwardRef<I.RowRef, Props>((props, ref) => {
 			return;
 		};
 
-		// Cap each measured width at the CSS .name max-width (300px).
-		// Without this, text cells (description) measure at full text width and get
-		// assigned more space than they can display, creating an empty gap.
 		const naturalCapped = natural.map(w => Math.min(w, 300));
 		const total = naturalCapped.reduce((s, w) => s + w, 0);
 		if (total <= available) {
@@ -112,13 +110,13 @@ const ListRow = forwardRef<I.RowRef, Props>((props, ref) => {
 		let remaining = available;
 		let slots = wrappers.length;
 
-		const sorted = natural.map((_, i) => i).sort((a, b) => natural[a] - natural[b]);
+		const sorted = naturalCapped.map((_, i) => i).sort((a, b) => naturalCapped[a] - naturalCapped[b]);
 
 		for (const idx of sorted) {
 			const share = remaining / slots;
-			if (natural[idx] <= share) {
-				assigned[idx] = natural[idx];
-				remaining -= natural[idx];
+			if (naturalCapped[idx] <= share) {
+				assigned[idx] = naturalCapped[idx];
+				remaining -= naturalCapped[idx];
 				slots--;
 			} else {
 				break;
@@ -131,7 +129,20 @@ const ListRow = forwardRef<I.RowRef, Props>((props, ref) => {
 		});
 	};
 
-	useEffect(() => resize());
+	useLayoutEffect(() => {
+		resizeRef.current = resize;
+	});
+
+	useEffect(() => {
+		const node = nodeRef.current;
+		if (!node) {
+			return;
+		};
+		const target = (U.Dom.select('.sides', node) as HTMLElement) || node;
+		const ro = new ResizeObserver(() => resizeRef.current());
+		ro.observe(target);
+		return () => ro.disconnect();
+	}, []);
 
 	useImperativeHandle(ref, () => ({
 		setIsEditing,

--- a/src/ts/component/block/dataview/view/list/row.tsx
+++ b/src/ts/component/block/dataview/view/list/row.tsx
@@ -17,6 +17,7 @@ const ListRow = forwardRef<I.RowRef, Props>((props, ref) => {
 	const nodeRef = useRef(null);
 	const resizeRef = useRef(null);
 	const view = getView();
+	const record = getRecord(recordId);
 
 	const resize = () => {
 		const node = nodeRef.current;
@@ -139,10 +140,25 @@ const ListRow = forwardRef<I.RowRef, Props>((props, ref) => {
 			return;
 		};
 		const target = (U.Dom.select('.sides', node) as HTMLElement) || node;
-		const ro = new ResizeObserver(() => resizeRef.current());
+		const ro = new ResizeObserver(() => resizeRef.current?.());
 		ro.observe(target);
 		return () => ro.disconnect();
 	}, []);
+
+	// Re-run water-fill when right-side cell values change (e.g. after a
+	// relation value edit via popup). The ResizeObserver alone won't catch
+	// this because .sides width stays constant when only content changes.
+	const rightValueKey = view ? view.getVisibleRelations()
+		.filter(vr => vr.relationKey != 'name')
+		.map(vr => {
+			const v = record?.[vr.relationKey];
+			return Array.isArray(v) ? v.join(',') : String(v ?? '');
+		})
+		.join('|') : '';
+
+	useEffect(() => {
+		resizeRef.current?.();
+	}, [ rightValueKey ]);
 
 	useImperativeHandle(ref, () => ({
 		setIsEditing,
@@ -154,7 +170,6 @@ const ListRow = forwardRef<I.RowRef, Props>((props, ref) => {
 
 	const idPrefix = getIdPrefix();
 	const subId = S.Record.getSubId(rootId, block.id);
-	const record = getRecord(recordId);
 	const cn = [ 'row' ];
 	const relations = view.getVisibleRelations();
 	const nameIndex = relations.findIndex(it => it.relationKey == 'name');

--- a/src/ts/component/block/dataview/view/list/row.tsx
+++ b/src/ts/component/block/dataview/view/list/row.tsx
@@ -30,6 +30,105 @@ const ListRow = forwardRef<I.RowRef, Props>((props, ref) => {
 		if (first) {
 			U.Dom.addClass(first, 'first');
 		};
+
+		const rightSide = U.Dom.select('.side.right', node) as HTMLElement;
+		if (!rightSide) {
+			return;
+		};
+
+		const wrappers = Array.from(rightSide.children).filter(
+			el => (el as HTMLElement).classList.contains('cellWrapper') &&
+			      !(el as HTMLElement).classList.contains('isEmpty')
+		) as HTMLElement[];
+
+		if (wrappers.length < 2) {
+			return;
+		};
+
+		// Clear any previous water-fill inline flex so the left side reports
+		// its true content width when we measure it below.
+		wrappers.forEach(el => { el.style.flex = ''; });
+
+		// Compute available space from the container, not from rightSide.offsetWidth.
+		// rightSide.offsetWidth is unreliable because inner elements have
+		// max-width:100% which creates a circular reference when the right side
+		// has no fixed width, causing it to collapse to near-zero.
+		const sidesEl = rightSide.parentElement as HTMLElement;
+		const leftSideEl = U.Dom.select('.side.left', sidesEl) as HTMLElement;
+		if (!sidesEl || !leftSideEl) {
+			return;
+		};
+
+		leftSideEl.style.flex = '0 0 auto';
+		const leftNatural = leftSideEl.offsetWidth;
+		leftSideEl.style.flex = '';
+
+		const sidesWidth = sidesEl.offsetWidth;
+		// Respect the CSS min-width:40% on the left side.
+		const effectiveLeft = Math.max(leftNatural, sidesWidth * 0.4);
+		const available = Math.max(0, sidesWidth - effectiveLeft - 12);
+		if (!available) {
+			return;
+		};
+
+		// Measure natural widths using an off-screen clone so we never mutate live
+		// elements. Mutating live widths mid-render interferes with concurrent
+		// getBoundingClientRect calls from menu/popup positioning code.
+		// .name is intentionally left constrained to max-width:300px so text cells
+		// (description) measure at their visual cap and don't receive excess space.
+		const clone = rightSide.cloneNode(true) as HTMLElement;
+		clone.style.cssText = 'position:absolute;left:-9999px;top:-9999px;visibility:hidden;';
+		document.body.appendChild(clone);
+
+		const cloneWrappers = Array.from(clone.children).filter(
+			el => el.classList.contains('cellWrapper') && !el.classList.contains('isEmpty')
+		) as HTMLElement[];
+
+		cloneWrappers.forEach(el => { el.style.flex = 'none'; el.style.width = 'max-content'; el.style.maxWidth = 'none'; });
+		Array.from(clone.querySelectorAll<HTMLElement>('.cellContent, .tagItem, .element, .over, .wrap')).forEach(el => {
+			el.style.width = 'max-content';
+			el.style.maxWidth = 'none';
+		});
+
+		const natural = cloneWrappers.map(el => el.offsetWidth);
+		clone.remove();
+
+		if (natural.length !== wrappers.length) {
+			return;
+		};
+
+		// Cap each measured width at the CSS .name max-width (300px).
+		// Without this, text cells (description) measure at full text width and get
+		// assigned more space than they can display, creating an empty gap.
+		const naturalCapped = natural.map(w => Math.min(w, 300));
+		const total = naturalCapped.reduce((s, w) => s + w, 0);
+		if (total <= available) {
+			return;
+		};
+
+		// Water-fill: items that fit within their equal share keep their natural width;
+		// the remaining space is then split equally among items that need more.
+		const assigned: number[] = new Array(wrappers.length).fill(-1);
+		let remaining = available;
+		let slots = wrappers.length;
+
+		const sorted = natural.map((_, i) => i).sort((a, b) => natural[a] - natural[b]);
+
+		for (const idx of sorted) {
+			const share = remaining / slots;
+			if (natural[idx] <= share) {
+				assigned[idx] = natural[idx];
+				remaining -= natural[idx];
+				slots--;
+			} else {
+				break;
+			};
+		};
+
+		const equalShare = remaining / slots;
+		wrappers.forEach((el, i) => {
+			el.style.flex = `0 0 ${assigned[i] === -1 ? equalShare : assigned[i]}px`;
+		});
 	};
 
 	useEffect(() => resize());
@@ -174,8 +273,6 @@ const ListRow = forwardRef<I.RowRef, Props>((props, ref) => {
 		);
 	};
 
-	const lw = 50 + left.length * 5;
-
 	let content = null;
 
 	if (isRegular) {
@@ -218,7 +315,6 @@ const ListRow = forwardRef<I.RowRef, Props>((props, ref) => {
 			<div className="sides">
 				<div
 					className={[ 'side', 'left', (left.length > 1 ? 's60' : '') ].join(' ')}
-					style={{ width: `${lw}%` }}
 				>
 					{left.map(mapper)}
 				</div>

--- a/src/ts/component/cell/index.tsx
+++ b/src/ts/component/cell/index.tsx
@@ -196,6 +196,22 @@ const Cell = forwardRef<I.CellRef, Props>((props, ref) => {
 
 		if (noInplace) {
 			param.title = relation.name;
+
+			if (!isGrid) {
+				const clickX = e.clientX;
+				const clickY = e.clientY;
+
+				param.recalcRect = () => {
+					const el = U.Dom.get(cellId);
+					const rect = el?.getBoundingClientRect();
+					return {
+						x: clickX,
+						y: rect ? rect.top + window.scrollY : clickY,
+						width: 0,
+						height: rect ? rect.height : 0,
+					};
+				};
+			};
 		};
 
 		switch (relation.format) {

--- a/src/ts/component/cell/index.tsx
+++ b/src/ts/component/cell/index.tsx
@@ -205,8 +205,8 @@ const Cell = forwardRef<I.CellRef, Props>((props, ref) => {
 					const el = U.Dom.get(cellId);
 					const rect = el?.getBoundingClientRect();
 					return {
-						x: clickX,
-						y: rect ? rect.top + window.scrollY : clickY,
+						x: clickX + window.scrollX,
+						y: rect ? rect.top + window.scrollY : clickY + window.scrollY,
 						width: 0,
 						height: rect ? rect.height : 0,
 					};


### PR DESCRIPTION
## Summary

### Menu anchoring (JS-9573)
In list/gallery/board views, relation cells near the right edge of the row were computing the cell's left edge for menu placement (e.g. x=1394 for a Status cell), causing the popup to flip leftward ~400px away from the click. Added `recalcRect` for `noInplace` cells in non-grid views: horizontal placement uses the click x-coordinate, vertical uses the cell's bounding rect. Menu now opens near where the user clicked regardless of cell position in the flex layout.

Also fixed coordinate space inconsistency: `x`/`y` are now both document-relative (`clientX + scrollX`, `rect.top + scrollY`), consistent with the rest of the menu positioning code.

### Water-fill layout engine for List view right side
The right side of a List row can contain multiple relation cells (Status, Author, Tags, etc.) with no fixed widths. Without distribution, all cells were full-width and clipped or hidden by overflow. Added a water-fill algorithm that distributes the available right-side space proportionally:

- Measures each cell's natural content width using an off-screen clone (no live DOM mutation)
- Caps natural widths at 300px (matching CSS `.name { max-width: 300px }`)
- Cells whose natural width fits within their equal share keep their exact width; remaining space is split equally among cells that need more
- If everything fits naturally, no flex is assigned (fast path)
- Runs via `ResizeObserver` on the `.sides` container (fires on container width changes) and a separate `useEffect` keyed on right-side relation values (fires after in-place edits that change cell content but not container width)

### Performance and correctness fixes (post code-review)
- Use `leftSideEl.offsetWidth` directly instead of temporarily mutating `leftSideEl.style.flex` to measure (the mutation was also a TypeScript no-op: `flex` is not an `HTMLElement` property)
- Drive water-fill sort, fit-test, and assignment entirely from `naturalCapped` — previously `naturalCapped` was used only for the early-exit total check while the loop used uncapped values, over-allocating space to cells with a 300px visual cap
- Guard the `style.flex = ''` clear to only run when flex was previously set, preventing a spurious second ResizeObserver callback on every tick
- Attach `ResizeObserver` to `.sides` instead of the full row to avoid triggering on framer-motion animations, drag handle, and selection state changes
- Move `resizeRef` update into `useLayoutEffect` (post-commit, pre-paint) for React 18 concurrent mode safety
- Fix `sidesEl` null check to occur before it is passed to `U.Dom.select`
- Fix dead `.side.left.s50` hover selector → `.s60` (the `s50` class is never applied)
- Guard `resizeRef.current?.()` in observer callbacks

## Test plan

- [ ] Open a Set/Collection in **List view**
- [ ] Click a relation value on the right side of a row (Status, Author, Select) — menu should open near the click, not far to the left
- [ ] With multiple right-side relations visible, verify cells share space proportionally and don't overflow each other
- [ ] Edit a relation value (e.g. add a tag, change status) — water-fill should recompute to fit the new content
- [ ] Resize the window / panel — water-fill should recompute as container width changes
- [ ] Repeat for **Gallery view** and **Board view** relation menus
- [ ] Verify **Grid view** relation menus are unaffected (still center-aligned)
- [ ] Verify Name cell inline editing still works in List view

🤖 Generated with [Claude Code](https://claude.com/claude-code)