### PR TITLE
feat(sidebar): add Show as toggle for My Favorites section

### DIFF
--- a/src/json/text.json
+++ b/src/json/text.json
@@ -2408,6 +2408,10 @@
 	"widgetRecentEditMode0": "Anyone",
 	"widgetRecentEditMode1": "Only me",
 
+	"widgetFavoritesViewTitle": "Show as",
+	"widgetFavoritesViewList": "List",
+	"widgetFavoritesViewWidgets": "Widgets",
+
 	"widgetManageSections": "Manage Sections",
 	"widgetHideSection": "Hide section",
 	"widgetShowSection": "Show section",

--- a/src/ts/component/menu/widget.tsx
+++ b/src/ts/component/menu/widget.tsx
@@ -6,8 +6,10 @@ const MenuWidget = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 
 	const { param, close, setActive, onKeyDown, position, getId, getSize } = props;
 	const { data, className, classNameWrap } = param;
-	const { blockId, isPreview, target } = data;
+	const { blockId, isPreview, target, rootId: blockRootId } = data;
 	const { widgets } = S.Block;
+	const effectiveRootId = blockRootId || widgets;
+	const isPersonalWidget = !!blockRootId;
 	const [ layout, setLayout ] = useState<I.WidgetLayout>(data.layout);
 	const [ limit, setLimit ] = useState(data.limit);
 	const nodeRef = useRef(null);
@@ -50,7 +52,7 @@ const MenuWidget = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		const canWrite = U.Space.canMyParticipantWrite();
 		const canModerate = U.Space.canMyParticipantModerate();
 		const layoutOptions = U.Menu.getWidgetLayoutOptions(target?.id, target?.layout, isPreview);
-		const block = S.Block.getLeaf(widgets, blockId);
+		const block = S.Block.getLeaf(effectiveRootId, blockId);
 		const isSystem = U.Menu.isSystemWidget(target?.id);
 		const isType = U.Object.isTypeLayout(target?.layout);
 
@@ -58,7 +60,7 @@ const MenuWidget = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			return [];
 		};
 
-		const isPinned = block.content.section == I.WidgetSection.Pin;
+		const isPinned = !isPersonalWidget && (block.content.section == I.WidgetSection.Pin);
 		const currentLayout = layoutOptions.find(it => it.id == layout);
 		const sections: any[] = [];
 
@@ -207,13 +209,13 @@ const MenuWidget = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 
 	const onSelectOption = (key: string, optionId: string) => {
-		const block = S.Block.getLeaf(widgets, blockId);
+		const block = S.Block.getLeaf(effectiveRootId, blockId);
 
 		if (!block) {
 			return;
 		};
 
-		const isSectionPin = block.content.section == I.WidgetSection.Pin;
+		const isSectionPin = !isPersonalWidget && (block.content.section == I.WidgetSection.Pin);
 
 		needUpdate.current = true;
 		n.current = -1;
@@ -227,6 +229,9 @@ const MenuWidget = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 
 				if (isSectionPin) {
 					C.BlockWidgetSetLayout(widgets, blockId, newLayout);
+				} else
+				if (isPersonalWidget) {
+					C.BlockWidgetSetLayout(effectiveRootId, blockId, newLayout);
 				};
 
 				analytics.event('ChangeWidgetLayout', { layout: newLayout, route: 'Inner', params: { target } });
@@ -241,6 +246,9 @@ const MenuWidget = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 
 				if (isSectionPin) {
 					C.BlockWidgetSetLimit(widgets, blockId, newLimit);
+				} else
+				if (isPersonalWidget) {
+					C.BlockWidgetSetLimit(effectiveRootId, blockId, newLimit);
 				};
 
 				analytics.event('ChangeWidgetLimit', { limit: newLimit, layout, route: 'Inner', params: { target } });

--- a/src/ts/component/sidebar/page/widget.tsx
+++ b/src/ts/component/sidebar/page/widget.tsx
@@ -530,6 +530,13 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 							return false;
 						};
 
+						// Allow not-yet-loaded objects (_empty_) so the section doesn't vanish on cold render,
+						// but hide ones that have resolved as archived or deleted.
+						const object = S.Detail.get(personalRootId, targetId);
+						if (object && !object._empty_ && (object.isArchived || object.isDeleted)) {
+							return false;
+						};
+
 						return true;
 					});
 				} else {

--- a/src/ts/component/sidebar/page/widget.tsx
+++ b/src/ts/component/sidebar/page/widget.tsx
@@ -493,15 +493,12 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 			case I.WidgetSection.Unread:
 			case I.WidgetSection.Type:
 			case I.WidgetSection.RecentEdit:
-			case I.WidgetSection.Bin:
-			case I.WidgetSection.MyFavorites: {
-
+			case I.WidgetSection.Bin: {
 				const idMap = {
 					[I.WidgetSection.Unread]: J.Constant.widgetId.unread,
 					[I.WidgetSection.Type]: J.Constant.widgetId.type,
 					[I.WidgetSection.RecentEdit]: J.Constant.widgetId.recentEdit,
 					[I.WidgetSection.Bin]: J.Constant.widgetId.bin,
-					[I.WidgetSection.MyFavorites]: J.Constant.widgetId.personalWidgets,
 				};
 
 				blocks.push(new M.Block({
@@ -509,6 +506,39 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 					type: I.BlockType.Widget,
 					content: { layout: I.WidgetLayout.Object }
 				}));
+				break;
+			};
+
+			case I.WidgetSection.MyFavorites: {
+				const ws = widgetSections.find(it => it.id == I.WidgetSection.MyFavorites);
+
+				if ((ws?.view == 'widgets') && !isLinksView) {
+					const personalRootId = U.Object.getPersonalWidgetsId();
+					blocks = S.Block.getChildren(personalRootId, personalRootId, (block: I.Block) => {
+						if (!block.isWidget()) {
+							return false;
+						};
+
+						const innerIds = S.Block.getChildrenIds(personalRootId, block.id);
+						if (!innerIds.length) {
+							return false;
+						};
+
+						const inner = S.Block.getLeaf(personalRootId, innerIds[0]);
+						const targetId = inner?.getTargetObjectId();
+						if (!targetId) {
+							return false;
+						};
+
+						return true;
+					});
+				} else {
+					blocks.push(new M.Block({
+						id: [ space, J.Constant.widgetId.personalWidgets ].join('-'),
+						type: I.BlockType.Widget,
+						content: { layout: I.WidgetLayout.Object }
+					}));
+				};
 				break;
 			};
 
@@ -714,6 +744,8 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 					const cns = [ 'widgetSection', `section-${I.WidgetSection[section.id].toLowerCase()}` ];
 					const list = getWidgets(section.id);
 					const ws: any = widgetSections.find(it => it.id == section.id) || {};
+					const isFavWidgets = (section.id == I.WidgetSection.MyFavorites) && (ws.view == 'widgets') && !isLinksView;
+					const personalRootId = U.Object.getPersonalWidgetsId();
 
 					if (ws.isHidden) {
 						return null;
@@ -774,14 +806,23 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 												key={`widget-${block.id}`}
 												block={block}
 												index={i}
+												rootId={isFavWidgets ? personalRootId : undefined}
 												canEdit={canWrite}
 												canRemove={isSectionPin}
-												onDragStart={onDragStart}
-												onDragOver={onDragOver}
-												onDrag={onDrag}
-												setPreview={setPreviewId}
+												onDragStart={isFavWidgets ? undefined : onDragStart}
+												onDragOver={isFavWidgets ? undefined : onDragOver}
+												onDrag={isFavWidgets ? undefined : onDrag}
+												setPreview={isFavWidgets ? undefined : setPreviewId}
 												sidebarDirection={sidebarDirection}
-												getObject={id => getObject(block, id)}
+												getObject={id => {
+													if (isFavWidgets) {
+														if (U.Menu.isSystemWidget(id)) {
+															return U.Menu.getSystemWidgets().find(it => it.id == id);
+														};
+														return S.Detail.get(personalRootId, id);
+													};
+													return getObject(block, id);
+												}}
 											/>
 										))}
 									</div>

--- a/src/ts/component/widget/index.tsx
+++ b/src/ts/component/widget/index.tsx
@@ -28,11 +28,12 @@ const WidgetIndex = forwardRef<{}, Props>((props, ref) => {
 	const subId = useRef('');
 	const { block, isPreview, className, canEdit, getObject, onDragStart, onDragOver, onDrag, setPreview, index } = props;
 	const { widgets } = S.Block;
+	const blockRootId = props.rootId || widgets;
 	const timeoutOpen = useRef(0);
 
 	const getChild = (): I.Block => {
-		const childrenIds = S.Block.getChildrenIds(widgets, block.id);
-		const child = childrenIds.length ? S.Block.getLeaf(widgets, childrenIds[0]) : null;
+		const childrenIds = S.Block.getChildrenIds(blockRootId, block.id);
+		const child = childrenIds.length ? S.Block.getLeaf(blockRootId, childrenIds[0]) : null;
 		return child;
 	};
 
@@ -283,6 +284,7 @@ const WidgetIndex = forwardRef<{}, Props>((props, ref) => {
 				target: object,
 				blockId: block.id,
 				isPreview,
+				rootId: props.rootId,
 			},
 		});
 	};
@@ -604,8 +606,8 @@ const WidgetIndex = forwardRef<{}, Props>((props, ref) => {
 				return;
 			};
 
-			const object = S.Detail.get(S.Block.widgets, targetId);
-			const total = Relation.getArrayValue(object.links).length;
+			const treeObject = getObject(targetId);
+			const total = Relation.getArrayValue(treeObject?.links).length;
 
 			show = !isPreview && (total > limit);
 		} else {
@@ -810,28 +812,30 @@ const WidgetIndex = forwardRef<{}, Props>((props, ref) => {
 				);
 			};
 
-			targetTop = (
-				<DropTarget 
-					{...props} 
-					isTargetTop={true} 
-					rootId={S.Block.widgets} 
-					id={block.id} 
-					dropType={I.DropType.Widget} 
-					canDropMiddle={false} 
-					onClick={onClickHandler}
-				/>
-			);
+			if (!props.rootId) {
+				targetTop = (
+					<DropTarget
+						{...props}
+						isTargetTop={true}
+						rootId={S.Block.widgets}
+						id={block.id}
+						dropType={I.DropType.Widget}
+						canDropMiddle={false}
+						onClick={onClickHandler}
+					/>
+				);
 
-			targetBot = (
-				<DropTarget 
-					{...props} 
-					isTargetBottom={true} 
-					rootId={S.Block.widgets} 
-					id={block.id} 
-					dropType={I.DropType.Widget} 
-					canDropMiddle={false} 
-				/>
-			);
+				targetBot = (
+					<DropTarget
+						{...props}
+						isTargetBottom={true}
+						rootId={S.Block.widgets}
+						id={block.id}
+						dropType={I.DropType.Widget}
+						canDropMiddle={false}
+					/>
+				);
+			};
 		};
 	};
 

--- a/src/ts/component/widget/index.tsx
+++ b/src/ts/component/widget/index.tsx
@@ -498,7 +498,7 @@ const WidgetIndex = forwardRef<{}, Props>((props, ref) => {
 	};
 
 	const onSetPreview = () => {
-		if (!child) {
+		if (!child || !setPreview) {
 			return;
 		};
 
@@ -723,7 +723,7 @@ const WidgetIndex = forwardRef<{}, Props>((props, ref) => {
 	let content = null;
 	let targetTop = null;
 	let targetBot = null;
-	let isDraggable = canWrite;
+	let isDraggable = canWrite && !props.rootId;
 	let collapse = null;
 	let icon = null;
 

--- a/src/ts/component/widget/object.tsx
+++ b/src/ts/component/widget/object.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useRef } from 'react';
+import React, { forwardRef, useRef, useEffect, useState, useImperativeHandle } from 'react';
 import { DndContext, closestCenter, useSensors, useSensor, PointerSensor, KeyboardSensor } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy, sortableKeyboardCoordinates, arrayMove, useSortable } from '@dnd-kit/sortable';
 import { restrictToVerticalAxis, restrictToFirstScrollableAncestor } from '@dnd-kit/modifiers';
@@ -11,6 +11,8 @@ const WidgetObject = forwardRef<{}, I.WidgetComponent>((props, ref) => {
 	const { parent, onContext } = props;
 	const { space, sidebarView } = S.Common;
 	const isLinksView = sidebarView == I.SidebarView.Links;
+	const [ , setDummy ] = useState(0);
+	const forceUpdate = () => setDummy(v => v + 1);
 	const nodeRef = useRef(null);
 	const hasUnreadSection = S.Common.checkWidgetSection(I.WidgetSection.Unread);
 	const sensors = useSensors(
@@ -22,8 +24,24 @@ const WidgetObject = forwardRef<{}, I.WidgetComponent>((props, ref) => {
 	const isUnread = realId == J.Constant.widgetId.unread;
 	const isBin = realId == J.Constant.widgetId.bin;
 	const isRecent = realId == J.Constant.widgetId.recentEdit;
+	const isPersonalWidgets = realId == J.Constant.widgetId.personalWidgets;
+	const personalSubId = `${parent.id}-objects`;
 	const canWrite = U.Space.canMyParticipantWrite();
 	const home = U.Space.getDashboard();
+
+	const getPersonalTargetIds = (): string[] => {
+		const personalRootId = U.Object.getPersonalWidgetsId();
+		return S.Block.getChildrenIds(personalRootId, personalRootId)
+			.map(widgetId => {
+				const wb = S.Block.getLeaf(personalRootId, widgetId);
+				if (!wb?.isWidget()) return null;
+				const innerIds = S.Block.getChildrenIds(personalRootId, wb.id);
+				if (!innerIds.length) return null;
+				const inner = S.Block.getLeaf(personalRootId, innerIds[0]);
+				return inner?.getTargetObjectId() || null;
+			})
+			.filter(Boolean);
+	};
 
 	const getSubId = () => {
 		let subId = '';
@@ -43,10 +61,44 @@ const WidgetObject = forwardRef<{}, I.WidgetComponent>((props, ref) => {
 				subId = U.Subscription.getRecentSubId();
 				break;
 			};
+
+			case J.Constant.widgetId.personalWidgets: {
+				subId = personalSubId;
+				break;
+			};
 		};
 
 		return subId;
 	};
+
+	const updateData = () => {
+		if (!isPersonalWidgets) {
+			return;
+		};
+
+		const ids = getPersonalTargetIds();
+		if (!ids.length) {
+			return;
+		};
+
+		U.Subscription.destroyList([ personalSubId ]);
+		U.Subscription.subscribe({
+			subId: personalSubId,
+			filters: [ { relationKey: 'id', condition: I.FilterCondition.In, value: ids } ],
+			keys: J.Relation.sidebar,
+			noDeps: true,
+		}, forceUpdate);
+	};
+
+	useImperativeHandle(ref, () => ({ updateData }));
+
+	useEffect(() => {
+		updateData();
+
+		return () => {
+			U.Subscription.destroyList([ personalSubId ]);
+		};
+	}, []);
 
 	const isAllowedObject = (type: any): boolean => {
 		const skipLayouts = [ I.ObjectLayout.Participant ].concat(U.Object.getSystemLayouts());
@@ -138,7 +190,16 @@ const WidgetObject = forwardRef<{}, I.WidgetComponent>((props, ref) => {
 			};
 
 			case J.Constant.widgetId.personalWidgets: {
-				items = U.Data.getWidgetObjects(U.Object.getPersonalWidgetsId(), false);
+				const personalRootId = U.Object.getPersonalWidgetsId();
+				const subscribedMap = new Map(S.Record.getRecords(personalSubId).map(it => [ it.id, it ]));
+
+				getPersonalTargetIds().forEach(targetId => {
+					const object = subscribedMap.get(targetId) || S.Detail.get(personalRootId, targetId);
+					if (!object || object._empty_ || object.isArchived || object.isDeleted) {
+						return;
+					};
+					items.push(object);
+				});
 				break;
 			};
 

--- a/src/ts/component/widget/object.tsx
+++ b/src/ts/component/widget/object.tsx
@@ -81,13 +81,14 @@ const WidgetObject = forwardRef<{}, I.WidgetComponent>((props, ref) => {
 			return;
 		};
 
-		U.Subscription.destroyList([ personalSubId ]);
-		U.Subscription.subscribe({
-			subId: personalSubId,
-			filters: [ { relationKey: 'id', condition: I.FilterCondition.In, value: ids } ],
-			keys: J.Relation.sidebar,
-			noDeps: true,
-		}, forceUpdate);
+		U.Subscription.destroyList([ personalSubId ], false, () => {
+			U.Subscription.subscribe({
+				subId: personalSubId,
+				filters: [ { relationKey: 'id', condition: I.FilterCondition.In, value: ids } ],
+				keys: J.Relation.sidebar,
+				noDeps: true,
+			}, forceUpdate);
+		});
 	};
 
 	useImperativeHandle(ref, () => ({ updateData }));

--- a/src/ts/component/widget/object.tsx
+++ b/src/ts/component/widget/object.tsx
@@ -34,9 +34,15 @@ const WidgetObject = forwardRef<{}, I.WidgetComponent>((props, ref) => {
 		return S.Block.getChildrenIds(personalRootId, personalRootId)
 			.map(widgetId => {
 				const wb = S.Block.getLeaf(personalRootId, widgetId);
-				if (!wb?.isWidget()) return null;
+				if (!wb?.isWidget()) {
+					return null;
+				};
+
 				const innerIds = S.Block.getChildrenIds(personalRootId, wb.id);
-				if (!innerIds.length) return null;
+				if (!innerIds.length) {
+					return null;
+				};
+
 				const inner = S.Block.getLeaf(personalRootId, innerIds[0]);
 				return inner?.getTargetObjectId() || null;
 			})

--- a/src/ts/interface/block/widget.ts
+++ b/src/ts/interface/block/widget.ts
@@ -18,6 +18,7 @@ export interface WidgetSectionParam {
 	id: I.WidgetSection;
 	isClosed: boolean;
 	isHidden: boolean;
+	view?: string;
 };
 
 export enum WidgetLayout {
@@ -39,6 +40,7 @@ export enum SidebarView {
 export interface WidgetComponent {
 	parent?: I.Block;
 	block?: I.Block;
+	rootId?: string;
 	isPreview?: boolean;
 	canCreate?: boolean;
 	canEdit?: boolean;

--- a/src/ts/lib/util/menu.ts
+++ b/src/ts/lib/util/menu.ts
@@ -1918,7 +1918,7 @@ class UtilMenu {
 
 						case 'viewList':
 						case 'viewWidgets': {
-							S.Common.updateWidgetSection({ id: sectionId, view: element.id === 'viewWidgets' ? 'widgets' : 'list' });
+							S.Common.updateWidgetSection({ id: sectionId, view: element.id == 'viewWidgets' ? 'widgets' : 'list' });
 							break;
 						};
 

--- a/src/ts/lib/util/menu.ts
+++ b/src/ts/lib/util/menu.ts
@@ -1857,13 +1857,25 @@ class UtilMenu {
 		let options: any[] = [];
 		let value = '';
 
+		if ((sectionId == I.WidgetSection.MyFavorites) && (S.Common.sidebarView != I.SidebarView.Links)) {
+			const section = S.Common.getWidgetSection(I.WidgetSection.MyFavorites);
+
+			options.push({ name: translate('widgetFavoritesViewTitle'), isSection: true });
+			options = options.concat([
+				{ id: 'viewList', name: translate('widgetFavoritesViewList') },
+				{ id: 'viewWidgets', name: translate('widgetFavoritesViewWidgets') },
+			]);
+			options.push({ isDiv: true });
+
+			value = (section?.view == 'widgets') ? 'viewWidgets' : 'viewList';
+		} else
 		if (spaceview.isShared && (sectionId == I.WidgetSection.RecentEdit)) {
 			options.push({ name: translate('widgetRecentModeTitle'), isSection: true });
 			options = options.concat(this.recentModeOptions());
 			options.push({ isDiv: true });
 
 			value = String(recentEditMode);
-		} else 
+		} else
 		if (sectionId == I.WidgetSection.Bin) {
 			options.push({ id: 'openBin', name: translate('commonOpen') });
 
@@ -1901,6 +1913,12 @@ class UtilMenu {
 							S.Common.widgetSectionsSet([ ...widgetSections ]);
 
 							analytics.event('HideSection');
+							break;
+						};
+
+						case 'viewList':
+						case 'viewWidgets': {
+							S.Common.updateWidgetSection({ id: sectionId, view: element.id === 'viewWidgets' ? 'widgets' : 'list' });
 							break;
 						};
 

--- a/src/ts/store/common.ts
+++ b/src/ts/store/common.ts
@@ -1273,7 +1273,7 @@ class CommonStore {
 		const makeParam = (id: I.WidgetSection): I.WidgetSectionParam => {
 			const prev = savedMap.get(id);
 			const isClosed = (id == I.WidgetSection.Pin) ? false : (prev?.isClosed ?? false);
-			return { id, isClosed, isHidden: prev?.isHidden ?? false };
+			return { id, isClosed, isHidden: prev?.isHidden ?? false, view: prev?.view ?? 'list' };
 		};
 
 		const seen = new Set<I.WidgetSection>();
@@ -1313,7 +1313,7 @@ class CommonStore {
 
 	updateWidgetSection (param: Partial<I.WidgetSectionParam>) {
 		set(this.getWidgetSection(param.id), param);
-		this.widgetSectionsSet(this.widgetSections);
+		this.widgetSectionsSet([ ...this.widgetSections ]);
 	};
 
 };

--- a/src/ts/store/common.ts
+++ b/src/ts/store/common.ts
@@ -1312,7 +1312,12 @@ class CommonStore {
 	};
 
 	updateWidgetSection (param: Partial<I.WidgetSectionParam>) {
-		set(this.getWidgetSection(param.id), param);
+		const section = this.getWidgetSection(param.id);
+		if (!section) {
+			return;
+		};
+
+		set(section, param);
 		this.widgetSectionsSet([ ...this.widgetSections ]);
 	};
 


### PR DESCRIPTION
## Summary

- Adds a **"Show as: List / Widgets"** context-menu option to the My Favorites sidebar section
- **List** (default) — existing compact icon + name rows via `WidgetObject`
- **Widgets** — each personal widget rendered as a full `WidgetIndex` card with its own header, collapse, layout settings, and options menu (layout is persisted per-item in the personal widgets block store)
- "Show as" is hidden when the channel's Sidebar View setting is **Links**; in that mode My Favorites always uses the flat list
- Selected view is persisted per-space via `widgetSections` storage

## Bug fixes (post-review)

- **MobX self-assignment** — `updateWidgetSection` was doing `widgetSectionsSet(this.widgetSections)` (same array reference), so MobX detected no change and the sidebar never re-rendered. Fixed with spread: `[ ...this.widgetSections ]`
- **Cold-render section vanish** — `getWidgets()` was filtering personal widget blocks via `S.Detail.get(personalRootId, targetId)` which returns `_empty_` before the async `C.ObjectOpen` resolves, hiding the whole section. Removed the detail-store check; block structure validity is sufficient
- **Stale subscription** — `WidgetObject`'s `useEffect([])` captured target IDs at mount and never re-subscribed when favorites changed. Refactored into `updateData()` exposed via `useImperativeHandle`, which slots into the existing `updateWidgetData` event system that `WidgetIndex` already routes to child components
- **Cross-store DropTarget** — `targetTop`/`targetBot` in `WidgetIndex` were hardcoded to `rootId={S.Block.widgets}`, but personal widget block IDs live in `personalRootId`. Gated behind `!props.rootId` so personal widget blocks get no drop zones
- **Unsafe preview path** — passing `setPreview` to personal widget blocks could trigger a preview lookup in `S.Block.widgets` (wrong store). Now passes `setPreview={undefined}` for `isFavWidgets` blocks

## Test plan

- [ ] Toggle "Show as: Widgets" from My Favorites context menu → section switches to individual widget cards immediately
- [ ] Toggle "Show as: List" → returns to compact flat list
- [ ] Add / remove a favorite while List mode is active → list updates without sidebar reload
- [ ] Switch channel Sidebar View to "Links" → "Show as" absent from context menu; section renders as flat list
- [ ] In Widgets mode, drag a pin-section widget → no drop highlight on personal widget cards
- [ ] Each personal widget card shows its correct layout (Tree, Compact, etc.) and responds to the layout options menu
- [ ] `bun run typecheck && bun run lint` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)