### PR TITLE
JS-9801: extend owner-only space checks to owner-or-admin

### DIFF
--- a/src/ts/component/header/main/archive.tsx
+++ b/src/ts/component/header/main/archive.tsx
@@ -5,12 +5,12 @@ import * as I from 'Interface';
 const HeaderMainArchive = forwardRef<{}, I.HeaderComponent>((props, ref) => {
 
 	const { renderLeftIcons, menuOpen, isPopup } = props;
-	const isOwner = U.Space.isMyOwner();
+	const canModerate = U.Space.canMyParticipantModerate();
 
 	const onMore = () => {
 		const options: any[] = [];
 
-		if (isOwner) {
+		if (canModerate) {
 			options.push({ id: 'emptyBin', name: translate('commonEmptyBin'), iconParam: { name: 'menu/action/remove' } });
 		};
 
@@ -41,7 +41,7 @@ const HeaderMainArchive = forwardRef<{}, I.HeaderComponent>((props, ref) => {
 			<div className="side left">{renderLeftIcons(true, true)}</div>
 			<div className="side center" />
 			<div className="side right">
-				{isOwner ? (
+				{canModerate ? (
 					<Icon
 						id="button-header-more"
 						tooltipParam={{ text: translate('commonMenu'), typeY: I.MenuDirection.Bottom }}

--- a/src/ts/component/header/main/settings.tsx
+++ b/src/ts/component/header/main/settings.tsx
@@ -11,7 +11,7 @@ const HeaderMainSettings = forwardRef<{}, I.HeaderComponent>((props, ref) => {
 	const participant = U.Space.getParticipant() || profile;
 	const globalName = Relation.getStringValue(participant?.globalName);
 	const space = U.Space.getSpaceview();
-	const isOwner = U.Space.isMyOwner();
+	const canModerate = U.Space.canMyParticipantModerate();
 	const showTransfer = (id == 'spaceShare') && U.Space.canTransferOwnership();
 
 	const init = () => {
@@ -99,7 +99,7 @@ const HeaderMainSettings = forwardRef<{}, I.HeaderComponent>((props, ref) => {
 
 	const renderMore = () => {
 		const hasLink = invite.cid && invite.key;
-		const spaceShareShowButton = hasLink || (isOwner && space.isShared);
+		const spaceShareShowButton = hasLink || (canModerate && space.isShared);
 
 		if (id == 'account') {
 			return <Icon id="button-share-one-to-one" name="header/oneToOne" withBackground={true} onClick={onOneToOne} />;

--- a/src/ts/component/menu/object.tsx
+++ b/src/ts/component/menu/object.tsx
@@ -122,7 +122,7 @@ const MenuObject = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		const allowedSearchText = !isFilePreview && !isInSet && !isChat;
 		const allowedHistory = !object.isArchived && !isInFileOrSystem && !isParticipant && !isDate && !isChat && !object.templateIsBundled;
 		const allowedLock = canWrite && !object.isArchived && S.Block.checkFlags(rootId, rootId, [ I.RestrictionObject.Details ]) && !isInFileOrSystem;
-		const allowedPinToChannel = canWrite && !isRelation && !isTemplate && !object.isArchived && U.Space.isMyOwner();
+		const allowedPinToChannel = canWrite && !isRelation && !isTemplate && !object.isArchived && U.Space.canMyParticipantModerate();
 		const allowedFavorite = canWrite && !isRelation && !isTemplate && !object.isArchived;
 		const allowedLinkTo = canWrite && !isRelation && !object.isArchived;
 		const allowedAddCollection = canWrite && !isRelation && !object.isArchived && !isTemplate;

--- a/src/ts/component/menu/object/context.tsx
+++ b/src/ts/component/menu/object/context.tsx
@@ -176,7 +176,7 @@ const MenuObjectContext = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			allowedEditChat = false;
 		};
 
-		if (!U.Space.isMyOwner()) {
+		if (!U.Space.canMyParticipantModerate()) {
 			allowedPin = false;
 		};
 

--- a/src/ts/component/menu/syncStatus.tsx
+++ b/src/ts/component/menu/syncStatus.tsx
@@ -19,7 +19,7 @@ const MenuSyncStatus = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	const keydownHandler = useRef(null);
 	const clickHandler = useRef(null);
 	const emptyText = U.Data.isLocalNetwork() ? translate('menuSyncStatusEmptyLocal') : translate('menuSyncStatusEmpty');
-	const isOwner = U.Space.isMyOwner();
+	const canModerate = U.Space.canMyParticipantModerate();
 
 	useEffect(() => {
 		load();
@@ -142,7 +142,7 @@ const MenuSyncStatus = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			{ relationKey: 'resolvedLayout', condition: I.FilterCondition.NotIn, value: U.Object.getSystemLayouts().concat(I.ObjectLayout.Participant) },
 		];
 
-		if (!isOwner) {
+		if (!canModerate) {
 			const participant = U.Space.getMyParticipant();
 			
 			filters.push({ relationKey: 'creator', condition: I.FilterCondition.Equal, value: participant?.id });

--- a/src/ts/component/menu/widget.tsx
+++ b/src/ts/component/menu/widget.tsx
@@ -48,7 +48,7 @@ const MenuWidget = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		const checked = checkState(layout, limit);
 		const hasLimit = ![ I.WidgetLayout.Link ].includes(checked.layout);
 		const canWrite = U.Space.canMyParticipantWrite();
-		const isOwner = U.Space.isMyOwner();
+		const canModerate = U.Space.canMyParticipantModerate();
 		const layoutOptions = U.Menu.getWidgetLayoutOptions(target?.id, target?.layout, isPreview);
 		const block = S.Block.getLeaf(widgets, blockId);
 		const isSystem = U.Menu.isSystemWidget(target?.id);
@@ -98,7 +98,7 @@ const MenuWidget = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			actionChildren.push({ id: 'pageLink', iconParam: { name: 'menu/action/pageLink' }, name: translate('commonCopyLink') });
 		};
 
-		if (isSystem && isPinned && canWrite && isOwner) {
+		if (isSystem && isPinned && canWrite && canModerate) {
 			actionChildren.push({
 				id: 'removeWidget',
 				iconParam: { name: 'menu/action/remove' },
@@ -117,7 +117,7 @@ const MenuWidget = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 				name: translate(isFavorite ? 'menuWidgetUnfavorite' : 'menuWidgetFavorite'),
 			});
 
-			if (isOwner) {
+			if (canModerate) {
 				actionChildren.push({
 					id: isPinned ? 'unpinFromChannel' : 'pinToChannel',
 					iconParam: { name: 'menu/action/pin' },

--- a/src/ts/component/page/elements/head/simple.tsx
+++ b/src/ts/component/page/elements/head/simple.tsx
@@ -50,7 +50,7 @@ const HeadSimple = forwardRef<PropsRef, Props>((props, ref) => {
 	const isRelation = U.Object.isRelationLayout(check.layout);
 	const cn = [ 'headSimple', check.className ];
 	const canEditIcon = allowDetails && !isRelation && !isType;
-	const isOwner = U.Space.isMyOwner();
+	const canModerate = U.Space.canMyParticipantModerate();
 	const total = S.Record.getMeta(SUB_ID_CHECK, '').total;
 	const placeholder = {
 		title: String(props.placeholder || ''),
@@ -310,7 +310,7 @@ const HeadSimple = forwardRef<PropsRef, Props>((props, ref) => {
 			const allowEdit = allowDetails && !isTemplate && !U.Object.isParticipantLayout(object.recommendedLayout);
 			const allowedReset = allowEdit && !U.Object.isChatLayout(object.recommendedLayout);
 
-			if (isOwner && total && allowedReset) {
+			if (canModerate && total && allowedReset) {
 				buttonLayout = (
 					<Button
 						id="button-layout"

--- a/src/ts/component/page/main/archive.tsx
+++ b/src/ts/component/page/main/archive.tsx
@@ -23,13 +23,13 @@ const PageMainArchive = forwardRef<I.PageRef, I.PageComponent>((props, ref) => {
 	const subId = J.Constant.subId.archive;
 	const spaceview = U.Space.getSpaceview();
 	const isShared = spaceview.isShared;
-	const isOwner = U.Space.isMyOwner();
+	const canModerate = U.Space.canMyParticipantModerate();
 	const participantId = U.Space.getCurrentParticipantId();
 	const canWrite = U.Space.canMyParticipantWrite();
 	const hasSelection = selectedIds.length > 0;
 
 	const canDeleteSelection = (): boolean => {
-		if (isOwner || !isShared) {
+		if (canModerate || !isShared) {
 			return true;
 		};
 

--- a/src/ts/component/page/main/settings/space/index.tsx
+++ b/src/ts/component/page/main/settings/space/index.tsx
@@ -16,7 +16,7 @@ const PageMainSettingsSpaceIndex = forwardRef<I.PageRef, I.PageSettingsComponent
 	const type = S.Record.getTypeById(S.Common.type);
 	const participant = U.Space.getParticipant();
 	const canWrite = U.Space.canMyParticipantWrite();
-	const isOwner = U.Space.isMyOwner();
+	const canModerate = U.Space.canMyParticipantModerate();
 	const members = U.Space.getParticipantsList([ I.ParticipantStatus.Active ]);
 	const otherParticipant = spaceview.isOneToOne ? U.Space.getOneToOneParticipant(spaceview) : null;
 	const cnh = [ 'spaceHeader' ];
@@ -336,7 +336,7 @@ const PageMainSettingsSpaceIndex = forwardRef<I.PageRef, I.PageSettingsComponent
 							<Label className="sub" text={translate(`popupSettingsSpaceIndexManageSpaceTitle`)} />
 
 							<div className="sectionContent">
-								{!spaceview.isOneToOne && isOwner ? (
+								{!spaceview.isOneToOne && canModerate ? (
 									<div className="item">
 										<div className="sides">
 											<Icon name="settings/home" />

--- a/src/ts/component/page/main/settings/space/share.tsx
+++ b/src/ts/component/page/main/settings/space/share.tsx
@@ -17,7 +17,7 @@ const PageMainSettingsSpaceShare = forwardRef<I.PageRef, I.PageSettingsComponent
 	const limitReached = sharedSpacesLimit && (mySharedSpaces.length >= sharedSpacesLimit);
 	const { isOnline } = S.Common;
 	const isLocalNetwork = U.Data.isLocalNetwork();
-	const canEdit = U.Space.isMyOwner() && (!limitReached || spaceview.isShared);
+	const canEdit = U.Space.canMyParticipantModerate() && (!limitReached || spaceview.isShared);
 
 	const init = () => {
 		if (spaceview.isShared && (!invite.cid || !invite.key)) {

--- a/src/ts/component/page/main/settings/space/share/members.tsx
+++ b/src/ts/component/page/main/settings/space/share/members.tsx
@@ -45,7 +45,7 @@ const Members = forwardRef<I.PageRef, I.PageSettingsComponent>((props, ref) => {
 	const getParticipantList = () => {
 		const statuses = [ I.ParticipantStatus.Active ];
 
-		if (isOwner) {
+		if (canModerate) {
 			statuses.push(I.ParticipantStatus.Joining);
 		};
 
@@ -75,13 +75,18 @@ const Members = forwardRef<I.PageRef, I.PageSettingsComponent>((props, ref) => {
 		const isWriterLimit = U.Space.getWriterLimit() <= 0;
 		const items: any[] = [];
 
-		// Only Owners can assign roles. Admins can only remove Editors and Viewers.
-		if (isOwner) {
-			[
-				{ id: I.ParticipantPermissions.Admin, disabled: isWriterLimit },
-				{ id: I.ParticipantPermissions.Writer, disabled: isWriterLimit },
-				{ id: I.ParticipantPermissions.Reader, disabled: isReaderLimit },
-			].forEach(it => {
+		// Moderators (owners/admins) can assign roles. Only Owners can assign the Admin role.
+		if (canModerate) {
+			const roles: any[] = [];
+
+			if (isOwner) {
+				roles.push({ id: I.ParticipantPermissions.Admin, disabled: isWriterLimit });
+			};
+
+			roles.push({ id: I.ParticipantPermissions.Writer, disabled: isWriterLimit });
+			roles.push({ id: I.ParticipantPermissions.Reader, disabled: isReaderLimit });
+
+			roles.forEach(it => {
 				items.push({ ...it, name: translate(`participantPermissions${it.id}`) });
 			});
 
@@ -200,7 +205,7 @@ const Members = forwardRef<I.PageRef, I.PageSettingsComponent>((props, ref) => {
 
 		// Owner approves join requests; moderators (owner/admin) can manage members they have authority over.
 		const canManage = !isCurrent && (
-			(isJoining && isOwner) ||
+			(isJoining && canModerate) ||
 			(isActive && U.Space.canManageParticipant(item))
 		);
 

--- a/src/ts/component/popup/invite/confirm.tsx
+++ b/src/ts/component/popup/invite/confirm.tsx
@@ -65,7 +65,7 @@ const PopupInviteConfirm = forwardRef<{}, I.Popup>((props, ref) => {
 			const records = (message.records || []).filter(it => it.isActive);
 
 			readerLimt.current = spaceview?.readersLimit - records.length;
-			writerLimit.current = spaceview?.writersLimit - records.filter(it => it.isWriter || it.isOwner).length;
+			writerLimit.current = spaceview?.writersLimit - records.filter(it => it.isWriter || it.isAdmin || it.isOwner).length;
 
 			setIsLoading(false);
 		});

--- a/src/ts/component/sidebar/page/widget.tsx
+++ b/src/ts/component/sidebar/page/widget.tsx
@@ -19,7 +19,7 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 	const cnb = [ 'body' ];
 	const spaceview = U.Space.getSpaceview();
 	const canWrite = U.Space.canMyParticipantWrite();
-	const isOwner = U.Space.isMyOwner();
+	const canModerate = U.Space.canMyParticipantModerate();
 	const bodyRef = useRef<HTMLDivElement>(null);
 	const dropTargetIdRef = useRef<string>('');
 	const positionRef = useRef<I.BlockPosition>(null);
@@ -642,7 +642,7 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 		const sections = getSections();
 		const members = U.Space.getParticipantsList([ I.ParticipantStatus.Active ]);
 		const hasMembers = members.length > 1;
-		const showMembers = !spaceview.isOneToOne && !spaceview.isPersonal && (hasMembers || isOwner);
+		const showMembers = !spaceview.isOneToOne && !spaceview.isPersonal && (hasMembers || canModerate);
 
 		head = (
 			<>

--- a/src/ts/component/sidebar/page/widgetManage.tsx
+++ b/src/ts/component/sidebar/page/widgetManage.tsx
@@ -120,9 +120,9 @@ const SidebarPageWidgetManage = forwardRef<{}, I.SidebarPageComponent>((props, r
 
 	const sectionOptions = U.Menu.widgetSections();
 	const members = U.Space.getParticipantsList([ I.ParticipantStatus.Active ]);
-	const isOwner = U.Space.isMyOwner();
+	const canModerate = U.Space.canMyParticipantModerate();
 	const hasMembers = members.length > 1;
-	const showMembers = !spaceview.isOneToOne && !spaceview.isPersonal && (hasMembers || isOwner);
+	const showMembers = !spaceview.isOneToOne && !spaceview.isPersonal && (hasMembers || canModerate);
 
 	useEffect(() => {
 		S.Common.widgetSectionsInit();

--- a/src/ts/component/util/upsell/index.tsx
+++ b/src/ts/component/util/upsell/index.tsx
@@ -52,7 +52,7 @@ const UpsellBanner = forwardRef<{}, Props>(({
 					return { isShown, isRed };
 				};
 
-				const editors = U.Space.getParticipantsList([ I.ParticipantStatus.Active ]).filter(it => it.isWriter || it.isOwner);
+				const editors = U.Space.getParticipantsList([ I.ParticipantStatus.Active ]).filter(it => it.isWriter || it.isAdmin || it.isOwner);
 				const limit = space.writersLimit;
 
 				isShown = editors.length >= Math.round(limit / 2);

--- a/src/ts/component/util/upsell/members.tsx
+++ b/src/ts/component/util/upsell/members.tsx
@@ -19,7 +19,7 @@ const UpsellMembers = forwardRef<{}, Props>(({
 		return null;
 	};
 
-	const editors = U.Space.getParticipantsList([ I.ParticipantStatus.Active ]).filter(it => it.isWriter || it.isOwner);
+	const editors = U.Space.getParticipantsList([ I.ParticipantStatus.Active ]).filter(it => it.isWriter || it.isAdmin || it.isOwner);
 	const limit = space.writersLimit;
 	const cn = [
 		'upsellBanner',

--- a/src/ts/lib/keyboard.ts
+++ b/src/ts/lib/keyboard.ts
@@ -260,7 +260,7 @@ class Keyboard {
 		const cmd = this.cmdKey();
 		const isMain = this.isMain();
 		const canWrite = U.Space.canMyParticipantWrite();
-		const isOwner = U.Space.isMyOwner();
+		const canModerate = U.Space.canMyParticipantModerate();
 		const selection = S.Common.getRef('selectionProvider');
 		const rootId = this.getRootId();
 		const object = S.Detail.get(rootId, rootId);
@@ -492,7 +492,7 @@ class Keyboard {
 				};
 
 				// Pin/Unpin
-				if (isOwner) {
+				if (canModerate) {
 					this.shortcut('pin', e, () => {
 						e.preventDefault();
 						Action.toggleWidgetsForObject(rootId, analytics.route.header);

--- a/src/ts/lib/util/menu.ts
+++ b/src/ts/lib/util/menu.ts
@@ -842,6 +842,7 @@ class UtilMenu {
 		const { isSharePage, noManage, noMembers, withPin, withDelete, withOpenNewTab, noShare, route } = param;
 		const isLoading = space.isAccountLoading || space.isLocalLoading;
 		const isOwner = U.Space.isMyOwner(targetSpaceId);
+		const canModerate = U.Space.canMyParticipantModerate(targetSpaceId);
 		const participants = U.Space.getParticipantsList([ I.ParticipantStatus.Active ]);
 		const oneToOneParticipant = space.isOneToOne ? U.Space.getOneToOneParticipant(space) : null;
 		const oneToOneGlobalName = oneToOneParticipant?.globalName || '';
@@ -994,7 +995,7 @@ class UtilMenu {
 					];
 				};
 
-				if (isOwner && space.isShared) {
+				if (canModerate && space.isShared) {
 					const isDisabled = participants.length > 1;
 					sections.actions.push({
 						id: 'stopSharing',
@@ -1866,7 +1867,7 @@ class UtilMenu {
 		if (sectionId == I.WidgetSection.Bin) {
 			options.push({ id: 'openBin', name: translate('commonOpen') });
 
-			if (U.Space.isMyOwner()) {
+			if (U.Space.canMyParticipantModerate()) {
 				options.push({ id: 'emptyBin', name: translate('commonEmptyBin') });
 			};
 


### PR DESCRIPTION
Follow-up to JS-8510 (Admin role + chat moderation, phase 1

Extends the remaining owner-only space-management gates to **owner or admin**, with one exception: an admin can never grant or revoke the Admin role.

## Approach
Reuse `U.Space.canMyParticipantModerate()` (owner || admin). Swap 20 `isMyOwner()` gates across 18 files; keep `isMyOwner()` for owner-exclusive actions.

## Now owner-or-admin
- Invite / manage invite links, share-button visibility
- Approve/decline join requests + assign Writer/Viewer roles
- Empty bin + delete others' archived objects
- Pin to channel + manage/remove space widgets (+ pin shortcut)
- Stop sharing (make space private)
- Set space homepage; reset type layout
- Sync-status scope (all objects, not just own)
- Seat-counting filters now include `isAdmin` (invite confirm + upsell)

## Exception (enforced)
In `members.tsx` the Admin role option renders only for owners; `canManageParticipant()` blocks an admin acting on another admin/owner.

## Kept owner-only
Delete space / leave-vs-delete, ownership transfer, storage/billing accounting, the Admin-role gate, `detail.ts` source-of-truth flag, cosmetic sorting.

## Verification
- `bun run typecheck` passes (0 errors); lint clean
- Completeness sweep: 46 owner-check sites, 20 converted, rest intentional keeps, no misses

## ⚠️ Check before ship
UI gating only. anytype-heart (Go/gRPC) must grant admins these capabilities or the UI offers actions that error out. Needs heart-side coordination.
