### PR TITLE
JS-9803: Multi text block range selection

### DIFF
--- a/docs/src/ts/component/editor/README.md
+++ b/docs/src/ts/component/editor/README.md
@@ -27,6 +27,8 @@ Functional component using `forwardRef` with hooks (`useRef`, `useEffect`, `useS
 - `onPaste` - Multi-format paste (HTML/text/files/URLs)
 - `onBackspace` / `onDelete` - Block merging logic
 - `onEnter` - Block splitting / new block creation
+- `deleteTextSelection` - Removes a cross-block text selection: trims the edge blocks, deletes the blocks in between, merges the kept head/tail (optionally inserting typed text); used by Backspace/Delete, typing replacement and paste-over-selection
+- `onCopy` - Copies/cuts block selection or cross-block text selection (`Action.copyTextSelection`; the middleware trims/cuts the edge blocks via `selectedTextRange` + `selectedTextRangeLastBlock`)
 
 ## Integration
 

--- a/docs/src/ts/component/selection/README.md
+++ b/docs/src/ts/component/selection/README.md
@@ -18,6 +18,9 @@ Imperative ref API (`SelectionRefProps`):
 - `isSelecting()` / `setIsSelecting(v)` - Track active drag-select state
 - `rebind()` - Re-attach mouse/keyboard event listeners
 - `setContextMenuHandler(handler)` - Register context menu callback
+- `getTextSelection()` - Cross-block text selection state (`{ from, to }` endpoints with per-block `I.TextRange`), or `null`
+- `clearTextSelection()` - Dissolve the cross-block text selection and restore the blocks wrapper
+- `isCrossSelecting()` - Whether a cross-block text drag is in progress
 
 ## Features
 
@@ -26,6 +29,17 @@ Imperative ref API (`SelectionRefProps`):
 - Node caching via `cacheNodeMap` and `cacheChildrenMap` refs
 - Integrates with focus management system (`Lib/focus`)
 - Popup-aware: rebinds listeners when popup list changes
+
+## Cross-Block Text Selection
+
+A drag that starts inside a text block's editable and leaves the block produces a native text selection spanning blocks (instead of whole-block selection):
+
+- On crossing, the `.blocks` wrapper temporarily becomes `contenteditable` so all blocks form a single editing host (Chromium confines drag selection to one host otherwise)
+- The native drag re-bases its anchor after the host change, so the selection is re-applied from the saved anchor on every mousemove (rAF-scheduled, after the native update)
+- On mouseup, the DOM range is mapped to per-block model ranges (`getCrossCoverage`): partial ranges for the edge blocks, full coverage in between; a selection inside one block converts back to the standard `focus` flow
+- While the selection persists, the wrapper stays editable (reverting clamps the native selection); `beforeinput`/`cut`/`dragstart` are prevented, and a `selectionchange` listener remaps state on native extension (Shift+Arrow / Shift+Click)
+- Editor page consumes the state for copy/cut (`Action.copyTextSelection` → `Block.Copy`/`Block.Cut` with `selectedTextRange` + `selectedTextRangeLastBlock`, edge blocks trimmed by the middleware), delete/typing replacement (`deleteTextSelection`), and caret collapse on arrows
+- Right click on the selection opens a minimal context menu (Copy / Cut / Quote in discussion) handled in `component/block/index.tsx`
 
 ## SelectionTarget
 

--- a/src/ts/component/block/index.tsx
+++ b/src/ts/component/block/index.tsx
@@ -157,6 +157,15 @@ const Block = forwardRef<Ref, Props>((props, ref) => {
 			return;
 		};
 
+		// Cross-block text selection gets its own minimal context menu
+		if (selection?.getTextSelection()) {
+			e.preventDefault();
+			e.stopPropagation();
+
+			onContextMenuTextSelection();
+			return;
+		};
+
 		// Allow native context menu (spellcheck) when clicking on links
 		if ((e.target as HTMLElement)?.closest('.markupLink')) {
 			return;
@@ -200,6 +209,111 @@ const Block = forwardRef<Ref, Props>((props, ref) => {
 				data: { range: U.Common.objectCopy(range) },
 			});
 		});
+	};
+
+	// Minimal context menu for a cross-block text selection: copy / cut / quote in discussion
+	const onContextMenuTextSelection = () => {
+		const selection = S.Common.getRef('selectionProvider');
+		const textSel = selection?.getTextSelection();
+
+		if (!textSel) {
+			return;
+		};
+
+		const object = S.Detail.get(rootId, rootId, [ 'type' ], true);
+		const canQuote = !U.Object.isTemplateType(object?.type);
+		const cmd = keyboard.cmdSymbol();
+		const options: any[] = [
+			{ id: 'copy', iconParam: { name: 'menu/action/copy' }, name: translate('commonCopy'), caption: `${cmd} + C` },
+			(!readonly ? { id: 'cut', iconParam: { name: 'menu/action/cut' }, name: translate('commonCut'), caption: `${cmd} + X` } : null),
+			(canQuote ? { id: 'quote', iconParam: { name: 'menu/action/quote' }, name: translate('commonQuoteInComment') } : null),
+		].filter(it => it);
+
+		S.Menu.closeAll([], () => {
+			S.Menu.open('select', {
+				rect: { x: keyboard.mouse.page.x, y: keyboard.mouse.page.y, width: 0, height: 0 },
+				classNameWrap: 'fromBlock',
+				data: {
+					options,
+					onSelect: (e: any, item: any) => {
+						switch (item.id) {
+							case 'copy': {
+								Action.copyTextSelection(rootId, I.ClipboardMode.Copy);
+								break;
+							};
+
+							case 'cut': {
+								Action.copyTextSelection(rootId, I.ClipboardMode.Cut);
+								break;
+							};
+
+							case 'quote': {
+								quoteTextSelection(textSel);
+								break;
+							};
+						};
+					},
+				},
+			});
+		});
+	};
+
+	// Sends the selected text (with marks) to the discussion composer as a quote
+	const quoteTextSelection = (textSel: any) => {
+		const selection = S.Common.getRef('selectionProvider');
+		const ids = selection?.getTextSelectionIds() || [];
+		const parts = [];
+
+		ids.forEach((id: string) => {
+			const b = S.Block.getLeaf(rootId, id);
+			if (!b || !b.isText()) {
+				return;
+			};
+
+			const bt = String(b.content.text || '');
+			const r = { from: 0, to: bt.length };
+
+			if (id == textSel.from.id) {
+				r.from = Math.min(textSel.from.range.from, bt.length);
+			};
+			if (id == textSel.to.id) {
+				r.to = Math.min(textSel.to.range.to, bt.length);
+			};
+
+			parts.push({
+				text: bt.slice(r.from, r.to),
+				marks: Mark.cutRange(b.content.marks || [], r.from, r.to),
+			});
+		});
+
+		if (!parts.length) {
+			return;
+		};
+
+		let text = '';
+		let marks: I.Mark[] = [];
+
+		parts.forEach((it, i) => {
+			if (i) {
+				text += '\n';
+			};
+
+			marks = marks.concat(Mark.adjust(it.marks, 0, text.length));
+			text += it.text;
+		});
+
+		const part: I.CommentContentPart = {
+			style: I.TextStyle.Quote,
+			type: I.BlockType.Text,
+			text,
+			marks,
+			editorQuote: { blockId: textSel.from.id },
+		};
+
+		// Defer dispatch so the menu close stack unwinds before the section reacts
+		window.setTimeout(() => {
+			window.dispatchEvent(new CustomEvent(`commentQuote.${rootId}`, { detail: part }));
+		}, 0);
 	};
 
 	const menuOpen = (param?: Partial<I.MenuParam>) => {

--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -1407,7 +1407,7 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 	const onCopy = () => {
 		const length = block.getLength();
 
-		C.BlockCopy(rootId, [ block ], { from: 0, to: length }, (message: any) => {
+		C.BlockCopy(rootId, [ block ], { from: 0, to: length }, null, (message: any) => {
 			const text = String(message.textSlot || '').replace(/\n+$/, '');
 
 			U.Common.clipboardCopy({
@@ -1429,6 +1429,12 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 		};
 
 		const selection = S.Common.getRef('selectionProvider');
+
+		// Cross-block text selection is handled by the selection provider
+		if (selection?.isCrossSelecting() || selection?.getTextSelection()) {
+			return;
+		};
+
 		const ids = selection?.getForClick('', false, true) || [];
 		const range = getRange();
 		const value = getTextValue();

--- a/src/ts/component/comment/post.tsx
+++ b/src/ts/component/comment/post.tsx
@@ -519,7 +519,7 @@ const CommentPost = (props: Props) => {
 	const onCopyText = useCallback(() => {
 		const blocks = U.Comment.partsToBlocks(parts);
 
-		C.BlockCopy(rootId, blocks, { from: 0, to: 0 }, (message: any) => {
+		C.BlockCopy(rootId, blocks, { from: 0, to: 0 }, null, (message: any) => {
 			if (message.error.code) {
 				return;
 			};

--- a/src/ts/component/comment/reply.tsx
+++ b/src/ts/component/comment/reply.tsx
@@ -322,7 +322,7 @@ const CommentReply = (props: Props) => {
 	const onCopyText = useCallback(() => {
 		const blocks = U.Comment.partsToBlocks(parts);
 
-		C.BlockCopy(rootId, blocks, { from: 0, to: 0 }, (message: any) => {
+		C.BlockCopy(rootId, blocks, { from: 0, to: 0 }, null, (message: any) => {
 			if (message.error.code) {
 				return;
 			};

--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -273,6 +273,24 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 			if ((e.target as HTMLElement)?.closest?.('.commentSection')) {
 				return;
 			};
+
+			// Paste replaces the cross-block text selection
+			const textSel = selection?.getTextSelection();
+			if (textSel) {
+				if (isReadonly()) {
+					return;
+				};
+
+				const data = getClipboardData(e);
+				if (!data.text && !data.html) {
+					return;
+				};
+
+				e.preventDefault();
+				deleteTextSelection('', () => onPaste(data));
+				return;
+			};
+
 			onPasteEvent(e, props);
 		});
 
@@ -282,7 +300,7 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 			const ids = selection?.get(I.SelectType.Block, true) || [];
 			const top = Storage.getScroll('editor', rootId, isPopup);
 
-			if (!ids.length && !menuOpen && !popupOpen) {
+			if (!ids.length && !menuOpen && !popupOpen && !selection?.getTextSelection()) {
 				focus.restore();
 				raf(() => focus.apply());
 			};
@@ -509,6 +527,75 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 		const styleParam = getStyleParam();
 
 		let ret = false;
+
+		// Cross-block text selection
+		const textSel = selection.getTextSelection();
+		if (textSel) {
+			let handled = false;
+
+			keyboard.shortcut(`${cmd}+c, ${cmd}+x`, e, (pressed: string) => {
+				onCopy(e, pressed.match('x') ? I.ClipboardMode.Cut : I.ClipboardMode.Copy);
+				handled = true;
+			});
+
+			keyboard.shortcut('escape', e, () => {
+				if (!menuOpen) {
+					selection.clear();
+				};
+				handled = true;
+			});
+
+			keyboard.shortcut('backspace, delete', e, () => {
+				if (!readonly) {
+					e.preventDefault();
+					deleteTextSelection();
+				};
+				handled = true;
+			});
+
+			keyboard.shortcut('arrowleft, arrowup', e, () => {
+				e.preventDefault();
+				selection.clear();
+				focusSet(textSel.from.id, textSel.from.range.from, textSel.from.range.from, true);
+				handled = true;
+			});
+
+			keyboard.shortcut('arrowright, arrowdown', e, () => {
+				e.preventDefault();
+				selection.clear();
+				focusSet(textSel.to.id, textSel.to.range.to, textSel.to.range.to, true);
+				handled = true;
+			});
+
+			// Shift+Arrow extends the native selection, state is remapped on selectionchange
+			keyboard.shortcut('shift+arrowleft, shift+arrowright, shift+arrowup, shift+arrowdown', e, () => {
+				handled = true;
+			});
+
+			keyboard.shortcut('enter', e, () => {
+				if (!menuOpen && !popupOpen && !readonly) {
+					e.preventDefault();
+					deleteTextSelection();
+				};
+				handled = true;
+			});
+
+			// Clear the text selection and let the default handling run
+			keyboard.shortcut('selectAll, undo, redo, history', e, () => {
+				selection.clearTextSelection();
+			});
+
+			// Typing replaces the selection
+			if (!handled && !readonly && !keyboard.isSpecial(e) && !e.metaKey && !e.ctrlKey && !e.altKey && (e.key.length == 1)) {
+				e.preventDefault();
+				deleteTextSelection(e.key);
+				handled = true;
+			};
+
+			if (handled) {
+				return;
+			};
+		};
 
 		// Select all
 		keyboard.shortcut('selectAll', e, () => {
@@ -1995,6 +2082,13 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 			return;
 		};
 
+		// Cross-block text selection: the middleware trims/cuts the partially selected edge blocks
+		if (selection?.getTextSelection()) {
+			e.preventDefault();
+			Action.copyTextSelection(rootId, mode);
+			return;
+		};
+
 		let ids = selection?.get(I.SelectType.Block, true) || [];
 
 		if (root.isLocked() && !ids.length) {
@@ -2604,6 +2698,102 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 		});
 	};
 	
+	// Removes the content covered by a cross-block text selection, merging the edge blocks like a native editor
+	const deleteTextSelection = (insert?: string, callBack?: () => void) => {
+		const selection = S.Common.getRef('selectionProvider');
+		const textSel = selection?.getTextSelection();
+
+		if (!textSel || isReadonly()) {
+			return;
+		};
+
+		const list = selection.getTextSelectionIds();
+		if (!list.length) {
+			selection?.clearTextSelection();
+			return;
+		};
+
+		const first = S.Block.getLeaf(rootId, textSel.from.id);
+		const last = S.Block.getLeaf(rootId, textSel.to.id);
+
+		if (!first || !last) {
+			selection?.clearTextSelection();
+			return;
+		};
+
+		insert = String(insert || '');
+
+		const sameBlock = first.id == last.id;
+
+		let deleteIds = [];
+		let text = insert;
+		let marks: I.Mark[] = [];
+		let focusId = '';
+		let caret = 0;
+
+		if (first.isText()) {
+			const ft = String(first.content.text || '');
+
+			text = ft.slice(0, textSel.from.range.from) + insert;
+			marks = Mark.cutRange(first.content.marks || [], 0, textSel.from.range.from);
+			focusId = first.id;
+			caret = text.length;
+			deleteIds = list.filter(id => id != first.id);
+
+			const tailSource = sameBlock ? first : (last.isText() ? last : null);
+			if (tailSource) {
+				const lt = String(tailSource.content.text || '');
+				const tailMarks = Mark.cutRange(tailSource.content.marks || [], textSel.to.range.to, lt.length);
+
+				text += lt.slice(textSel.to.range.to);
+				marks = marks.concat(Mark.adjust(tailMarks, 0, caret));
+			};
+		} else
+		if (last.isText() && !sameBlock) {
+			// The first block is removed entirely, the tail of the last text block is kept
+			const lt = String(last.content.text || '');
+
+			text = insert + lt.slice(textSel.to.range.to);
+			marks = Mark.adjust(Mark.cutRange(last.content.marks || [], textSel.to.range.to, lt.length), 0, insert.length);
+			focusId = last.id;
+			caret = insert.length;
+			deleteIds = list.filter(id => id != last.id);
+		} else {
+			deleteIds = [ ...list ];
+		};
+
+		deleteIds = deleteIds.filter(id => {
+			const block = S.Block.getLeaf(rootId, id);
+			return block && block.isDeletable();
+		});
+
+		selection?.clear();
+		S.Menu.closeAll();
+
+		const done = () => {
+			if (focusId) {
+				focusSet(focusId, caret, caret, true);
+			};
+			callBack?.();
+		};
+
+		const remove = () => {
+			if (deleteIds.length) {
+				C.BlockListDelete(rootId, deleteIds, () => done());
+			} else {
+				done();
+			};
+		};
+
+		if (focusId) {
+			U.Data.blockSetText(rootId, focusId, text, marks, true, () => remove());
+		} else {
+			remove();
+		};
+
+		analytics.event('DeleteBlock', { count: deleteIds.length });
+	};
+
 	const onLastClick = (e: any) => {
 		const readonly = isReadonly();
 

--- a/src/ts/component/selection/provider.tsx
+++ b/src/ts/component/selection/provider.tsx
@@ -11,6 +11,16 @@ interface Props {
 
 type ContextMenuHandler = (e: MouseEvent, ids: string[]) => void;
 
+interface TextSelectionEnd {
+	id: string;
+	range: I.TextRange;
+};
+
+interface TextSelectionState {
+	from: TextSelectionEnd;
+	to: TextSelectionEnd;
+};
+
 interface SelectionRefProps {
 	get(type: I.SelectType): string[];
 	getForClick(id: string, withChildren: boolean, save: boolean): string[];
@@ -23,6 +33,10 @@ interface SelectionRefProps {
 	hide(): void;
 	rebind(): void;
 	setContextMenuHandler(handler: ContextMenuHandler | null): void;
+	getTextSelection(): TextSelectionState | null;
+	getTextSelectionIds(): string[];
+	clearTextSelection(): void;
+	isCrossSelecting(): boolean;
 };
 
 const THRESHOLD = 20;
@@ -55,6 +69,16 @@ const SelectionProvider = forwardRef<SelectionRefProps, Props>((props, ref) => {
 	const mouseEvents = useRef<[string, EventListener][]>([]);
 	const scrollContainer = useRef<EventTarget | null>(null);
 	const scrollEvent = useRef<[string, EventListener][]>([]);
+
+	const textAnchorId = useRef('');
+	const crossSelecting = useRef(false);
+	const crossState = useRef<TextSelectionState | null>(null);
+	const crossContainer = useRef<HTMLElement | null>(null);
+	const crossEvents = useRef<[string, EventListener][]>([]);
+	const crossTimeout = useRef(0);
+	const crossAnchor = useRef<{ node: Node; offset: number; id: string; model: number } | null>(null);
+	const crossFrame = useRef(0);
+	const selectionChangeHandler = useRef<(() => void) | null>(null);
 
 	const rebind = () => {
 		unbind();
@@ -123,7 +147,20 @@ const SelectionProvider = forwardRef<SelectionRefProps, Props>((props, ref) => {
 			hide();
 			return;
 		};
-		
+
+		if (crossState.current) {
+			// Shift+click extends the native cross-block selection, state is remapped on selectionchange
+			if (e.shiftKey) {
+				return;
+			};
+			clearTextSelection();
+		};
+
+		const targetValue = (e.target as HTMLElement).closest('.value');
+		const targetBlock = targetValue?.closest('.block');
+
+		textAnchorId.current = (targetBlock && targetValue?.closest('.blocks')) ? String(targetBlock.getAttribute('data-id') || '') : '';
+
 		const isPopup = keyboard.isPopup();
 		const { focused } = focus.state;
 		const container = U.Dom.getScrollContainer(isPopup);
@@ -203,6 +240,14 @@ const SelectionProvider = forwardRef<SelectionRefProps, Props>((props, ref) => {
 			return;
 		};
 
+		// Native painting and autoscroll are used during cross-block text selection, but the native drag
+		// re-bases its anchor after the editing host change, so the selection is re-applied each frame
+		if (crossSelecting.current) {
+			hasMoved.current = true;
+			scheduleCrossUpdate(e.clientX, e.clientY);
+			return;
+		};
+
 		const isPopup = keyboard.isPopup();
 		const { x: x1, y: y1 } = recalcCoords(e.pageX, e.pageY);
 		const rect = getRect(x.current, y.current, x1, y1);
@@ -220,6 +265,13 @@ const SelectionProvider = forwardRef<SelectionRefProps, Props>((props, ref) => {
 	};
 
 	const onScroll = (e: any) => {
+		if (crossSelecting.current) {
+			if (isSelecting.current && hasMoved.current) {
+				scheduleCrossUpdate(keyboard.mouse.client.x, keyboard.mouse.client.y);
+			};
+			return;
+		};
+
 		if (!isSelecting.current || !hasMoved.current || keyboard.isSelectionDisabled) {
 			return;
 		};
@@ -252,6 +304,10 @@ const SelectionProvider = forwardRef<SelectionRefProps, Props>((props, ref) => {
 	};
 	
 	const onMouseUp = (e: any) => {
+		if (crossSelecting.current) {
+			finalizeCrossSelect();
+		};
+
 		if (!hasMoved.current) {
 			if (!e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey) {
 				if (!keyboard.isSelectionClearDisabled) {
@@ -488,12 +544,22 @@ const SelectionProvider = forwardRef<SelectionRefProps, Props>((props, ref) => {
 				};
 			};
 		} else {
+			if (!crossSelecting.current && canCrossSelect(e)) {
+				startCrossSelect(e);
+			};
+
+			if (crossSelecting.current) {
+				initIds();
+				renderSelection();
+				return;
+			};
+
 			const { focused, range: fr } = focus.state;
 
 			if (focused && fr.to) {
 				focus.clear(false);
 			};
-			
+
 			keyboard.setFocus(false);
 			window.getSelection().empty();
 			window.focus();
@@ -501,7 +567,7 @@ const SelectionProvider = forwardRef<SelectionRefProps, Props>((props, ref) => {
 			allowRect.current = true;
 		};
 
-		renderSelection();		
+		renderSelection();
 	};
 
 	const hide = () => {
@@ -510,8 +576,352 @@ const SelectionProvider = forwardRef<SelectionRefProps, Props>((props, ref) => {
 		};
 		unbindMouse();
 	};
-	
+
+	const caretFromPoint = (x: number, y: number): { node: Node; offset: number } | null => {
+		const doc = document as any;
+
+		if (doc.caretRangeFromPoint) {
+			const r = doc.caretRangeFromPoint(x, y);
+			return r ? { node: r.startContainer, offset: r.startOffset } : null;
+		};
+
+		if (doc.caretPositionFromPoint) {
+			const p = doc.caretPositionFromPoint(x, y);
+			return p ? { node: p.offsetNode, offset: p.offset } : null;
+		};
+
+		return null;
+	};
+
+	const canCrossSelect = (e: any): boolean => {
+		if (!textAnchorId.current || keyboard.isCmd(e) || e.altKey || e.shiftKey) {
+			return false;
+		};
+
+		const block = S.Block.getLeaf(keyboard.getRootId(), textAnchorId.current);
+		if (!block || !block.isText()) {
+			return false;
+		};
+
+		const sel = window.getSelection();
+		if (!sel || !sel.rangeCount || !sel.anchorNode) {
+			return false;
+		};
+
+		// The drag must still be anchored inside the block where it started
+		const el = (sel.anchorNode.nodeType == Node.ELEMENT_NODE) ? sel.anchorNode as HTMLElement : sel.anchorNode.parentElement;
+		const blockEl = el?.closest('.block');
+
+		return blockEl?.getAttribute('data-id') == textAnchorId.current;
+	};
+
+	const startCrossSelect = (e: any) => {
+		const sel = window.getSelection();
+		const { anchorNode, anchorOffset } = sel;
+		const el = (anchorNode.nodeType == Node.ELEMENT_NODE) ? anchorNode as HTMLElement : anchorNode.parentElement;
+		const wrapper = el?.closest('.blocks') as HTMLElement;
+		const value = el?.closest('.value') as HTMLElement;
+
+		if (!wrapper || !value) {
+			return;
+		};
+
+		// Merging blocks into a single editing host lets the native drag selection cross block boundaries
+		crossContainer.current = wrapper;
+		wrapper.setAttribute('contenteditable', 'true');
+		wrapper.setAttribute('spellcheck', 'false');
+
+		crossEvents.current = [
+			[ 'beforeinput', e => crossGuard(e) ],
+			[ 'cut', e => crossGuard(e) ],
+			[ 'dragstart', e => crossGuard(e) ],
+		];
+		U.Dom.addEvents(wrapper, crossEvents.current);
+
+		crossAnchor.current = {
+			node: anchorNode,
+			offset: anchorOffset,
+			id: textAnchorId.current,
+			model: getCrossOffset(value, anchorNode, anchorOffset),
+		};
+
+		crossSelecting.current = true;
+		allowRect.current = false;
+
+		// Changing the editing host re-bases the native drag anchor, so the selection is driven programmatically
+		const x = (undefined === e.clientX) ? keyboard.mouse.client.x : e.clientX;
+		const y = (undefined === e.clientY) ? keyboard.mouse.client.y : e.clientY;
+
+		applyCrossUpdate(x, y);
+
+		focus.clear(false);
+		keyboard.setFocus(false);
+
+		S.Common.clearTimeout('blockContext');
+		S.Menu.close('blockContext');
+
+		if (rectRef.current) {
+			U.Dom.css(rectRef.current, { display: 'none' });
+		};
+	};
+
+	const scheduleCrossUpdate = (x: number, y: number) => {
+		raf.cancel(crossFrame.current);
+		crossFrame.current = raf(() => applyCrossUpdate(x, y));
+	};
+
+	// Re-applies the selection from the saved anchor to the pointer, overriding the re-based native drag update
+	const applyCrossUpdate = (x: number, y: number) => {
+		if (!crossSelecting.current || !crossAnchor.current) {
+			return;
+		};
+
+		const pos = caretFromPoint(x, y);
+		if (!pos || !crossContainer.current?.contains(pos.node)) {
+			return;
+		};
+
+		let { node, offset } = crossAnchor.current;
+
+		// The anchor block can re-render on blur: recover the anchor from the model offset
+		if (!node || !node.isConnected) {
+			const value = U.Dom.select(`#block-${U.Common.esc(crossAnchor.current.id)} .value`) as HTMLElement;
+			const restored = value ? nodeFromOffset(value, crossAnchor.current.model) : null;
+
+			if (!restored) {
+				return;
+			};
+
+			crossAnchor.current.node = node = restored.node;
+			crossAnchor.current.offset = offset = restored.offset;
+		};
+
+		try {
+			window.getSelection().setBaseAndExtent(node, offset, pos.node, pos.offset);
+		} catch (e) { /**/ };
+	};
+
+	// DOM position of a model text offset within a block value (ZWS anchors excluded)
+	const nodeFromOffset = (el: HTMLElement, model: number): { node: Node; offset: number } | null => {
+		const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+
+		let rest = model;
+		let last = null;
+
+		while (walker.nextNode()) {
+			const node = walker.currentNode;
+			const text = String(node.textContent || '');
+
+			last = node;
+
+			for (let i = 0; i < text.length; i++) {
+				if (text[i] == '\u200B') {
+					continue;
+				};
+
+				if (!rest) {
+					return { node, offset: i };
+				};
+				rest--;
+			};
+
+			if (!rest) {
+				return { node, offset: text.length };
+			};
+		};
+
+		return last ? { node: last, offset: String(last.textContent || '').length } : null;
+	};
+
+	const crossGuard = (e: Event) => {
+		if (crossSelecting.current || crossState.current) {
+			e.preventDefault();
+		};
+	};
+
+	const finalizeCrossSelect = () => {
+		// The native drag can re-base the selection after the last scheduled update, re-apply before reading it
+		raf.cancel(crossFrame.current);
+		applyCrossUpdate(keyboard.mouse.client.x, keyboard.mouse.client.y);
+
+		crossSelecting.current = false;
+
+		const coverage = getCrossCoverage();
+
+		if (!coverage.length) {
+			clearTextSelection();
+			return;
+		};
+
+		// Selection shrank back into a single block: restore the standard focus flow
+		if (coverage.length == 1) {
+			const { id, range } = coverage[0];
+
+			clearTextSelection();
+			focus.set(id, range);
+			focus.apply();
+			return;
+		};
+
+		crossState.current = { from: coverage[0], to: coverage[coverage.length - 1] };
+		bindSelectionChange();
+	};
+
+	const getCrossCoverage = (): TextSelectionEnd[] => {
+		const ret: TextSelectionEnd[] = [];
+		const sel = window.getSelection();
+
+		if (!sel || !sel.rangeCount || sel.isCollapsed || !crossContainer.current) {
+			return ret;
+		};
+
+		const rootId = keyboard.getRootId();
+		const r = sel.getRangeAt(0);
+		const values = U.Dom.selectAll('.value.focusable', crossContainer.current);
+
+		values.forEach((el: HTMLElement) => {
+			const id = el.closest('.block')?.getAttribute('data-id');
+			const block = id ? S.Block.getLeaf(rootId, id) : null;
+
+			if (!block || !block.isText() || !r.intersectsNode(el)) {
+				return;
+			};
+
+			const full = document.createRange();
+			full.selectNodeContents(el);
+
+			const length = block.getLength();
+			const from = (full.compareBoundaryPoints(Range.START_TO_START, r) >= 0) ? 0 : getCrossOffset(el, r.startContainer, r.startOffset);
+			const to = (full.compareBoundaryPoints(Range.END_TO_END, r) <= 0) ? length : getCrossOffset(el, r.endContainer, r.endOffset);
+
+			if (to > from) {
+				ret.push({ id, range: { from, to } });
+			};
+		});
+
+		return ret;
+	};
+
+	// Model text offset of a selection boundary within a block value (ZWS anchors excluded, see Mark.domToModel)
+	const getCrossOffset = (el: HTMLElement, node: Node, offset: number): number => {
+		const prefix = document.createRange();
+
+		prefix.selectNodeContents(el);
+
+		try {
+			prefix.setEnd(node, offset);
+		} catch (e) {
+			return 0;
+		};
+
+		return prefix.toString().replace(/\u200B/g, '').length;
+	};
+
+	const bindSelectionChange = () => {
+		unbindSelectionChange();
+		selectionChangeHandler.current = () => onSelectionChange();
+		document.addEventListener('selectionchange', selectionChangeHandler.current);
+	};
+
+	const unbindSelectionChange = () => {
+		window.clearTimeout(crossTimeout.current);
+
+		if (selectionChangeHandler.current) {
+			document.removeEventListener('selectionchange', selectionChangeHandler.current);
+			selectionChangeHandler.current = null;
+		};
+	};
+
+	const onSelectionChange = () => {
+		if (crossSelecting.current || !crossState.current) {
+			return;
+		};
+
+		window.clearTimeout(crossTimeout.current);
+		crossTimeout.current = window.setTimeout(() => remapCrossSelect(), 150);
+	};
+
+	// Keeps state in sync when the native selection is extended (Shift+Arrow, Shift+Click) or dissolved
+	const remapCrossSelect = () => {
+		if (!crossState.current) {
+			return;
+		};
+
+		const sel = window.getSelection();
+
+		if (!sel || !sel.rangeCount || sel.isCollapsed) {
+			clearTextSelection();
+			return;
+		};
+
+		const coverage = getCrossCoverage();
+
+		if (!coverage.length) {
+			clearTextSelection();
+			return;
+		};
+
+		if (coverage.length == 1) {
+			const { id, range } = coverage[0];
+
+			clearTextSelection();
+			focus.set(id, range);
+			focus.apply();
+			return;
+		};
+
+		crossState.current = { from: coverage[0], to: coverage[coverage.length - 1] };
+	};
+
+	const clearTextSelection = () => {
+		if (!crossState.current && !crossSelecting.current && !crossContainer.current) {
+			return;
+		};
+
+		unbindSelectionChange();
+
+		if (crossContainer.current) {
+			if (crossEvents.current.length) {
+				U.Dom.removeEvents(crossContainer.current, crossEvents.current);
+				crossEvents.current = [];
+			};
+
+			crossContainer.current.removeAttribute('contenteditable');
+			crossContainer.current.removeAttribute('spellcheck');
+			crossContainer.current = null;
+		};
+
+		crossState.current = null;
+		crossSelecting.current = false;
+
+		window.getSelection()?.removeAllRanges();
+	};
+
+	const getTextSelection = (): TextSelectionState | null => {
+		return crossState.current ? U.Common.objectCopy(crossState.current) : null;
+	};
+
+	// Ordered document slice of block ids covered by the cross-block text selection
+	const getTextSelectionIds = (): string[] => {
+		if (!crossState.current) {
+			return [];
+		};
+
+		const { from, to } = crossState.current;
+		const rootId = keyboard.getRootId();
+		const list = S.Block.unwrapTree(S.Block.getTree(rootId, S.Block.getBlocks(rootId)));
+		const idxStart = list.findIndex(it => it.id == from.id);
+		const idxEnd = list.findIndex(it => it.id == to.id);
+
+		if ((idxStart < 0) || (idxEnd < 0)) {
+			return [];
+		};
+
+		return list.slice(Math.min(idxStart, idxEnd), Math.max(idxStart, idxEnd) + 1).map(it => it.id);
+	};
+
 	const clear = () => {
+		clearTextSelection();
 		initIds();
 		renderSelection();
 		clearState();
@@ -525,6 +935,7 @@ const SelectionProvider = forwardRef<SelectionRefProps, Props>((props, ref) => {
 		setIsSelecting(false);
 		cacheNodeMap.current.clear();
 		focusedId.current = '';
+		textAnchorId.current = '';
 		nodes.current = [];
 		range.current = null;
 		containerOffset.current = null;
@@ -725,7 +1136,10 @@ const SelectionProvider = forwardRef<SelectionRefProps, Props>((props, ref) => {
 
 	useEffect(() => {
 		rebind();
-		return () => unbind();
+		return () => {
+			clearTextSelection();
+			unbind();
+		};
 	}, []);
 
 	useImperativeHandle(ref, () => ({
@@ -740,6 +1154,10 @@ const SelectionProvider = forwardRef<SelectionRefProps, Props>((props, ref) => {
 		hide,
 		rebind,
 		setContextMenuHandler,
+		getTextSelection,
+		getTextSelectionIds,
+		clearTextSelection,
+		isCrossSelecting: () => crossSelecting.current,
 	}));
 
 	return (

--- a/src/ts/lib/action.ts
+++ b/src/ts/lib/action.ts
@@ -617,8 +617,9 @@ class Action {
 	 * @param {string} rootId - The root object ID.
 	 * @param {string[]} ids - The block IDs to copy or cut.
 	 * @param {I.ClipboardMode} mode - Whether to copy or cut.
+	 * @param {Map<string, I.TextRange>} ranges - Per-block partial text ranges (cross-block text selection); the middleware applies them to the first and last block of the request.
 	 */
-	copyBlocks (rootId: string, ids: string[], mode: I.ClipboardMode) {
+	copyBlocks (rootId: string, ids: string[], mode: I.ClipboardMode, ranges?: Map<string, I.TextRange>) {
 		const root = S.Block.getLeaf(rootId, rootId);
 		if (!root) {
 			return;
@@ -630,7 +631,7 @@ class Action {
 			return;
 		};
 
-		const range = U.Common.objectCopy(focus.state.range);
+		const range = ranges ? { from: 0, to: 0 } : U.Common.objectCopy(focus.state.range);
 		const isCut = mode == I.ClipboardMode.Cut;
 		const cmd = isCut ? 'BlockCut' : 'BlockCopy';
 		const tree = S.Block.wrapTree(rootId, rootId);
@@ -660,7 +661,7 @@ class Action {
 			return it;
 		}).filter(it => it);
 
-		if (isCut && (blocks.length > 1)) {
+		if (isCut && !ranges && (blocks.length > 1)) {
 			next = S.Block.getNextBlock(rootId, blocks[0].id, -1, it => it.isFocusable());
 		};
 
@@ -668,7 +669,20 @@ class Action {
 			return;
 		};
 
-		C[cmd](rootId, blocks, range, (message: any) => {
+		// The middleware applies rangeFirst/rangeLast positionally to the first/last block of the request
+		let rangeFirst = range;
+		let rangeLast = null;
+
+		if (ranges && blocks.length) {
+			rangeFirst = ranges.get(blocks[0].id) || { from: 0, to: 0 };
+			rangeLast = ranges.get(blocks[blocks.length - 1].id) || { from: 0, to: 0 };
+		};
+
+		C[cmd](rootId, blocks, rangeFirst, rangeLast, (message: any) => {
+			if (message.error.code) {
+				return;
+			};
+
 			U.Common.clipboardCopy({
 				text: message.textSlot,
 				html: message.htmlSlot,
@@ -681,18 +695,69 @@ class Action {
 			if (isCut) {
 				S.Menu.closeAll([ 'blockContext', 'blockAction' ]);
 
-				if (next) {
-					const l = next.getLength();
-					focus.set(next.id, { from: l, to: l });
+				if (ranges) {
+					// Partially cut edge blocks keep the unselected part of their text: collapse the caret there
+					const first = blocks[0];
+					const last = blocks[blocks.length - 1];
+
+					if (first.isText() && rangeFirst.from > 0) {
+						focus.set(first.id, { from: rangeFirst.from, to: rangeFirst.from });
+					} else
+					if (last.isText() && rangeLast && (rangeLast.to > 0) && (rangeLast.to < last.getLength())) {
+						focus.set(last.id, { from: 0, to: 0 });
+					} else {
+						const prev = S.Block.getNextBlock(rootId, first.id, -1, it => it.isFocusable());
+						if (prev) {
+							const l = prev.getLength();
+							focus.set(prev.id, { from: l, to: l });
+						};
+					};
+
+					focus.apply();
 				} else {
-					focus.set(focused, { from: range.from, to: range.from });
+					if (next) {
+						const l = next.getLength();
+						focus.set(next.id, { from: l, to: l });
+					} else {
+						focus.set(focused, { from: range.from, to: range.from });
+					};
+
+					focus.apply();
 				};
-				
-				focus.apply();
 			};
 		});
 
 		analytics.event(isCut ? 'CutBlock' : 'CopyBlock', { count: blocks.length });
+	};
+
+	/**
+	 * Copies or cuts the current cross-block text selection to the clipboard.
+	 * @param {string} rootId - The root object ID.
+	 * @param {I.ClipboardMode} mode - Whether to copy or cut.
+	 */
+	copyTextSelection (rootId: string, mode: I.ClipboardMode) {
+		const selection = S.Common.getRef('selectionProvider');
+		const textSel = selection?.getTextSelection();
+
+		if (!textSel) {
+			return;
+		};
+
+		const ids = selection.getTextSelectionIds();
+		if (!ids.length) {
+			return;
+		};
+
+		const ranges = new Map([
+			[ textSel.from.id, textSel.from.range ],
+			[ textSel.to.id, textSel.to.range ],
+		]);
+
+		this.copyBlocks(rootId, ids, mode, ranges);
+
+		if (mode == I.ClipboardMode.Cut) {
+			selection.clear();
+		};
 	};
 
 	/**

--- a/src/ts/lib/api/command.ts
+++ b/src/ts/lib/api/command.ts
@@ -457,23 +457,25 @@ export const BlockUpload = (contextId: string, blockId: string, url: string, pat
 	}, callBack);
 };
 
-export const BlockCopy = (contextId: string, blocks: I.Block[], range: I.TextRange, callBack?: (message: any) => void) => {
+export const BlockCopy = (contextId: string, blocks: I.Block[], range: I.TextRange, rangeLastBlock?: I.TextRange, callBack?: (message: any) => void) => {
 	blocks = U.Common.objectCopy(blocks);
 
 	dispatcher.request('BlockCopy', {
 		contextId,
 		blocks: blocks.map(Mapper.To.Block),
 		selectedTextRange: Mapper.To.Range(range),
+		selectedTextRangeLastBlock: rangeLastBlock ? Mapper.To.Range(rangeLastBlock) : undefined,
 	}, callBack);
 };
 
-export const BlockCut = (contextId: string, blocks: I.Block[], range: I.TextRange, callBack?: (message: any) => void) => {
+export const BlockCut = (contextId: string, blocks: I.Block[], range: I.TextRange, rangeLastBlock?: I.TextRange, callBack?: (message: any) => void) => {
 	blocks = U.Common.objectCopy(blocks);
 
 	dispatcher.request('BlockCut', {
 		contextId,
 		blocks: blocks.map(Mapper.To.Block),
 		selectedTextRange: Mapper.To.Range(range),
+		selectedTextRangeLastBlock: rangeLastBlock ? Mapper.To.Range(rangeLastBlock) : undefined,
 	}, callBack);
 };
 

--- a/src/ts/lib/mark.ts
+++ b/src/ts/lib/mark.ts
@@ -345,6 +345,30 @@ class Mark {
 	};
 
 	/**
+	 * Extracts marks for a text slice, clamped to the slice and rebased to zero.
+	 * @param {I.Mark[]} marks - The list of marks.
+	 * @param {number} from - The start of the slice.
+	 * @param {number} to - The end of the slice.
+	 * @returns {I.Mark[]} The marks of the extracted slice.
+	 */
+	cutRange(marks: I.Mark[], from: number, to: number): I.Mark[] {
+		const ret: I.Mark[] = [];
+
+		for (const mark of (marks || [])) {
+			const mf = Math.max(mark.range.from, from);
+			const mt = Math.min(mark.range.to, to);
+
+			if (mf >= mt) {
+				continue;
+			};
+
+			ret.push({ ...mark, range: { from: mf - from, to: mt - from } });
+		};
+
+		return ret;
+	};
+
+	/**
 	 * Converts text and marks to HTML.
 	 * @param {string} text - The text content.
 	 * @param {I.Mark[]} marks - The list of marks.


### PR DESCRIPTION
## What

Cross-block text selection: dragging from inside a text block across block boundaries now produces a native continuous text selection (partial first block, full middle blocks, partial last block) instead of switching to whole-block selection. Whole-block selection still works when dragging from the empty canvas, via Esc, or with Cmd/Alt modifiers.

Supported operations on the selection:
- **Copy / Cut** (Cmd+C / Cmd+X and context menu) — via `Block.Copy` / `Block.Cut` with the new `selectedTextRangeLastBlock` field, so the middleware trims/cuts the partially selected edge blocks and the cut is a single undo step
- **Backspace / Delete / typing / paste** — replaces the selection client-side, merging the edge blocks like a native editor
- **Right click** — a minimal context menu with Copy / Cut / Quote in discussion (instead of the classical multi-block action menu); quote sends the selected text with marks to the discussion composer
- **Shift+Arrow / Shift+Click** — extends the selection natively, state is remapped on `selectionchange`

## How

Chromium confines a drag selection to the `contenteditable` editing host it started in. On crossing the block boundary, the `.blocks` wrapper temporarily becomes `contenteditable`, merging all blocks into a single editing host so the native drag can span blocks (native painting and autoscroll for free). The native drag re-bases its anchor after the host change, so the selection is re-applied from the saved anchor on each mousemove (rAF-scheduled after the native update). On mouseup the DOM range is mapped to per-block model ranges; the wrapper stays editable while the selection is displayed (reverting clamps the native selection), guarded by `beforeinput`/`cut`/`dragstart` listeners.

## Dependencies

- Requires anytype-heart `GO-7311` (`selectedTextRangeLastBlock` in `Rpc.Block.Copy/Cut.Request`). With an older middleware the new field is ignored and copy/cut degrade to whole edge blocks; selection/delete/typing behavior is unaffected.

## Testing

- 7 Playwright E2E tests in anytype-desktop-suite (`tests/editor/cross-block-selection.spec.ts`): drag selection, single-block fallback, backspace merge, typing replacement, copy/paste roundtrip, cut remainders + paste roundtrip, context menu + quote in discussion — all green against the rebuilt middleware
- Regression runs of clipboard/delete/editor-blocks suites: all failures reproduce identically on clean develop (pre-existing flakes)
- `bun run typecheck` and `bun run lint` clean