### PR TITLE
JS-9805: preferred-space-aware cold start

### DIFF
--- a/src/json/constant.ts
+++ b/src/json/constant.ts
@@ -97,6 +97,7 @@ export default {
 		highlight:  	 1000,
 		chatHistory:	 500,
 		chatMessage:	 200,
+		spacePreload:	 2000,
 	},
 
 	fileExtension: {

--- a/src/ts/app.tsx
+++ b/src/ts/app.tsx
@@ -391,9 +391,11 @@ const App: FC = () => {
 			const { dataPath } = S.Common;
 			const { networkConfig } = S.Auth;
 			const { mode, path: networkPath } = networkConfig;
+			const param = route ? U.Router.getParam(route) : {};
+			const spaceId = param.spaceId || data.spaceId || Storage.getAccountKey('spaceId', false, accountId) || '';
 
 			S.Auth.tokenSet(token);
-			C.AccountSelect(accountId, dataPath, mode, networkPath, (message: any) => {
+			C.AccountSelect(accountId, dataPath, mode, networkPath, spaceId, (message: any) => {
 				if (message.error.code) {
 					console.error('[App.onInit]:', message.error.description);
 					S.Common.redirectSet(route);
@@ -418,9 +420,6 @@ const App: FC = () => {
 				U.Data.onInfo(account.info);
 				S.Common.spaceSet('');
 				U.Data.onAuthOnce();
-
-				const param = route ? U.Router.getParam(route) : {};
-				const spaceId = param.spaceId || data.spaceId || Storage.get('spaceId');
 
 				if (spaceId) {
 					U.Router.switchSpace(spaceId, route, false, routeParam, true);

--- a/src/ts/component/page/auth/login.tsx
+++ b/src/ts/component/page/auth/login.tsx
@@ -70,7 +70,9 @@ const PageAuthLogin = forwardRef<I.PageRef, I.PageComponent>((props, ref: any) =
 		S.Auth.accountSet(account);
 		Renderer.send('keytarSet', account.id, getPhrase());
 
-		C.AccountSelect(account.id, S.Common.dataPath, mode, path, (message: any) => {
+		const preferredSpaceId = Storage.get('spaceId') || '';
+
+		C.AccountSelect(account.id, S.Common.dataPath, mode, path, preferredSpaceId, (message: any) => {
 			if (setErrorHandler(message.error.code, message.error.description) || !message.account) {
 				isSelecting.current = false;
 				return;

--- a/src/ts/component/page/auth/setup.tsx
+++ b/src/ts/component/page/auth/setup.tsx
@@ -49,10 +49,12 @@ const PageAuthSetup = forwardRef<I.PageRef, I.PageComponent>((props, ref) => {
 
 	const select = (accountId: string) => {
 		const { networkConfig } = S.Auth;
-		const { dataPath } = S.Common;
+		const { dataPath, redirect } = S.Common;
 		const { mode, path } = networkConfig;
+		const param = redirect ? U.Router.getParam(redirect) : {};
+		const preferredSpaceId = param.spaceId || Storage.getAccountKey('spaceId', false, accountId) || '';
 
-		C.AccountSelect(accountId, dataPath, mode, path, (message: any) => {
+		C.AccountSelect(accountId, dataPath, mode, path, preferredSpaceId, (message: any) => {
 			const { account } = message;
 
 			if (setErrorHandler(message.error) || !account) {

--- a/src/ts/lib/api/command.ts
+++ b/src/ts/lib/api/command.ts
@@ -152,7 +152,7 @@ export const AccountRecover = (callBack?: (message: any) => void) => {
 	dispatcher.request('AccountRecover', {}, callBack);
 };
 
-export const AccountSelect = (id: string, path: string, mode: I.NetworkMode, networkConfigPath: string, callBack?: (message: any) => void) => {
+export const AccountSelect = (id: string, path: string, mode: I.NetworkMode, networkConfigPath: string, preferredSpaceId: string, callBack?: (message: any) => void) => {
 	dispatcher.request('AccountSelect', {
 		id,
 		rootPath: path,
@@ -160,7 +160,12 @@ export const AccountSelect = (id: string, path: string, mode: I.NetworkMode, net
 		networkCustomConfigFilePath: networkConfigPath,
 		jsonApiListenAddr: J.Url.api,
 		enableMembershipV2: true,
+		preferredSpaceId,
 	}, callBack);
+};
+
+export const AccountPreloadRemainingSpaces = (callBack?: (message: any) => void) => {
+	dispatcher.request('AccountPreloadRemainingSpaces', {}, callBack);
 };
 
 export const AccountMigrate = (id: string, path: string, callBack?: (message: any) => void) => {

--- a/src/ts/lib/api/dispatcher.ts
+++ b/src/ts/lib/api/dispatcher.ts
@@ -26,7 +26,7 @@ const SORT_IDS = [
 ];
 
 const SKIP_IDS = [ 'BlockSetCarriage' ];
-const SKIP_ERRORS = [ 'LinkPreview', 'BlockTextSetText', 'FileSpaceUsage', 'SpaceInviteGetCurrent', 'ObjectClose' ];
+const SKIP_ERRORS = [ 'LinkPreview', 'BlockTextSetText', 'FileSpaceUsage', 'SpaceInviteGetCurrent', 'ObjectClose', 'AccountPreloadRemainingSpaces' ];
 
 /**
  * Dispatcher class handles all communication between the Electron frontend

--- a/src/ts/lib/storage.ts
+++ b/src/ts/lib/storage.ts
@@ -307,27 +307,29 @@ class Storage {
 	/**
 	 * Gets an account key value for the current account.
 	 * @param {string} key - The account key.
+	 * @param {string} [accountId] - The account ID (defaults to the current account).
 	 * @returns {any} The value for the account key.
 	 */
-	getAccountKey (key: string, isLocal: boolean) {
-		const accountId = this.getAccountId();
+	getAccountKey (key: string, isLocal: boolean, accountId?: string) {
+		accountId = accountId || this.getAccountId();
 		if (!accountId) {
 			return;
 		};
 
-		const obj = this.getAccount(isLocal);
+		const obj = this.getAccount(isLocal, accountId);
 
 		return obj[accountId]?.[key];
 	};
 
 	/**
 	 * Gets the account object from storage.
+	 * @param {string} [accountId] - The account ID (defaults to the current account).
 	 * @returns {any} The account object.
 	 */
-	getAccount (isLocal: boolean) {
+	getAccount (isLocal: boolean, accountId?: string) {
 		const obj = this.get('account', isLocal) || {};
-		const accountId = this.getAccountId();
 
+		accountId = accountId || this.getAccountId();
 		obj[accountId] = obj[accountId] || {};
 
 		return obj;

--- a/src/ts/lib/util/data.ts
+++ b/src/ts/lib/util/data.ts
@@ -46,6 +46,8 @@ export interface TreeNode {
  */
 class UtilData {
 
+	private spacesPreloaded = false;
+
 	/**
 	 * Returns the CSS class for a text block style.
 	 * @param {I.TextStyle} v - The text style.
@@ -321,6 +323,7 @@ class UtilData {
 		if (!widgets) {
 			console.error('[U.Data].onAuth No widgets defined');
 			U.Space.openDashboard(routeParam);
+			this.preloadRemainingSpaces();
 			callBack?.();
 			return;
 		};
@@ -350,10 +353,25 @@ class UtilData {
 					};
 
 					S.Common.redirectSet('');
+					this.preloadRemainingSpaces();
 					callBack?.();
 				});
 			});
 		});
+	};
+
+	/**
+	 * Tells the middleware the priority screen is up, so it can start loading the spaces
+	 * deferred by AccountSelect.preferredSpaceId. Fires once per process; errors are benign —
+	 * the middleware has its own timer fallback.
+	 */
+	preloadRemainingSpaces () {
+		if (this.spacesPreloaded) {
+			return;
+		};
+
+		this.spacesPreloaded = true;
+		window.setTimeout(() => C.AccountPreloadRemainingSpaces(), J.Constant.delay.spacePreload);
 	};
 
 	initPin (callBack?: () => void) {


### PR DESCRIPTION
## What

Wires up two middleware additions for faster cold start:

- `AccountSelect` now sends `preferredSpaceId` so heart eagerly loads only that space (+ tech space) and defers the rest.
- New `AccountPreloadRemainingSpaces` command is called once per process, 2s after the destination screen is reached, to load the deferred spaces. Errors are benign (heart has a 10s timer fallback), so the RPC is added to dispatcher `SKIP_ERRORS`.

## How

- Preferred space is picked **before** `AccountSelect` with priority: route/deeplink space id → electron tab `spaceId` → last-opened space → empty (empty = today's eager behavior; onboarding/new-account flows unaffected).
  - `app.tsx` — hoisted the existing space pick above the call, same values reused for navigation.
  - `auth/setup.tsx` — parses pending `S.Common.redirect` route, falls back to last-opened.
  - `auth/login.tsx` — last-opened space (empty on a fresh device).
- `Storage.getAccountKey`/`getAccount` accept an optional explicit `accountId`, since `spaceId` is account-scoped and `S.Auth.account` isn't set yet when `AccountSelect` runs.
- `U.Data.preloadRemainingSpaces()` one-shot is fired from `onSpaceSwitch` — the convergence point all cold-start space entries pass through. Paths that never reach it (void, workspace-open failure) intentionally rely on heart's timer.

No changes to space subscriptions or navigation behavior.