### PR TITLE
Startup performance: chunk splitting, parallel boot, timing marks

### DIFF
--- a/electron/ts/api.ts
+++ b/electron/ts/api.ts
@@ -65,6 +65,15 @@ class Api {
 		};
 	};
 
+	/**
+	 * Resolves with the gRPC web proxy address once the middleware is up.
+	 * Windows are created in parallel with server startup, so the renderer
+	 * awaits this before initializing the dispatcher.
+	 */
+	getServerAddress (win: AppWindow): Promise<string> {
+		return Server.whenReady();
+	};
+
 	logout (win: AppWindow): void {
 		WindowManager.sendToAllTabs('logout');
 	};

--- a/electron/ts/main.ts
+++ b/electron/ts/main.ts
@@ -8,7 +8,7 @@ declare global {
 process.stdout?.on?.('error', () => {});
 process.stderr?.on?.('error', () => {});
 
-import { app, BrowserWindow, session, nativeTheme, ipcMain, powerMonitor, dialog } from 'electron';
+import { app, BrowserWindow, session, nativeTheme, ipcMain, powerMonitor, dialog, contentTracing } from 'electron';
 import { is, fixPathForAsarUnpack } from 'electron-util';
 import path from 'path';
 import storage from 'electron-json-storage';
@@ -147,6 +147,71 @@ if (!is.development && !app.requestSingleInstanceLock()) {
 remote.initialize();
 Util.setAppPath(path.join(__dirname));
 
+/**
+ * Captures a full cold-start Chromium trace (main + renderer + GPU + network + CPU samples),
+ * including the renderer's own User Timing marks (U.Perf — blink.user_timing category).
+ *
+ * Enable by launching with ANYTYPE_TRACE_STARTUP=1. Optional ANYTYPE_TRACE_DURATION (ms,
+ * default 20000) bounds the capture window — bump it if the middleware/server is slow to start.
+ * The resulting .json opens in https://ui.perfetto.dev (preferred) or chrome://tracing.
+ */
+async function maybeStartStartupTrace () {
+	const flag = String(process.env.ANYTYPE_TRACE_STARTUP || '').toLowerCase();
+	if (![ '1', 'true', 'yes', 'on' ].includes(flag)) {
+		return;
+	};
+
+	// Full contentTracing instruments the network service. In dev, Vite serves the app
+	// unbundled (thousands of separate module requests) and we lift the localhost connection
+	// limit, so the throttled net service can't establish all those parallel connections —
+	// the renderer fails to load with ERR_CONNECTION_TIMED_OUT. Dev startup is dominated by
+	// Vite transforms anyway and isn't representative of real resource loading, so skip it
+	// here: use DevTools Performance (reload-record) in dev, and capture a real cold start
+	// from a packaged build.
+	if (is.development) {
+		console.warn('[Trace] Startup tracing skipped in dev — it breaks Vite module loading (ERR_CONNECTION_TIMED_OUT). Use DevTools Performance reload-record in dev, or run a packaged build with ANYTYPE_TRACE_STARTUP=1.');
+		return;
+	};
+
+	const duration = Number(process.env.ANYTYPE_TRACE_DURATION) || 20000;
+
+	try {
+		// Kept lean on purpose: 'toplevel' and 'disabled-by-default-devtools.timeline'
+		// produce ~85% of trace volume (per-task scheduler/microtask noise) and most of the
+		// tracing overhead, while everything needed for startup analysis — resource waterfall
+		// ('loading'), JS flame chart (cpu_profiler samples + script eval/compile events via
+		// 'devtools.timeline'), and our U.Perf marks ('blink.user_timing') — lives in the
+		// cheap categories below.
+		await contentTracing.startRecording({
+			included_categories: [
+				'devtools.timeline',
+				'disabled-by-default-devtools.timeline.frame',
+				'disabled-by-default-v8.cpu_profiler',
+				'v8.execute',
+				'blink.user_timing',
+				'loading',
+				'navigation',
+			],
+		});
+
+		console.log(`[Trace] Recording startup for ${duration}ms…`);
+
+		setTimeout(async () => {
+			try {
+				const out = path.join(app.getPath('userData'), `startup-trace-${Date.now()}.json`);
+				await contentTracing.stopRecording(out);
+
+				console.log(`[Trace] Saved: ${out}`);
+				console.log('[Trace] Open at https://ui.perfetto.dev or chrome://tracing');
+			} catch (e) {
+				console.error('[Trace] Failed to stop recording:', (e as Error).message);
+			};
+		}, duration);
+	} catch (e) {
+		console.error('[Trace] Failed to start recording:', (e as Error).message);
+	};
+};
+
 function waitForLibraryAndCreateWindows () {
 	const { userDataPath } = ConfigManager.config;
 
@@ -284,6 +349,8 @@ function createWindow () {
 };
 
 app.on('ready', async () => {
+	await maybeStartStartupTrace();
+
 	session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
 		callback({
 			responseHeaders: {

--- a/electron/ts/main.ts
+++ b/electron/ts/main.ts
@@ -233,10 +233,15 @@ function waitForLibraryAndCreateWindows () {
 
 	Util.mkDir(Util.logPath());
 
+	// Create windows immediately so renderer boot (process spawn, bundle
+	// parse/eval, React mount) overlaps middleware startup instead of waiting
+	// for it. The renderer obtains the gRPC address via Api.getServerAddress,
+	// which resolves once the server is up (Server.whenReady)
+	createWindow();
+	isReady = true;
+
 	waitLibraryPromise.then(() => {
 		global.serverAddress = Server.getAddress();
-		createWindow();
-		isReady = true;
 	}, (err: Error) => {
 		dialog.showErrorBox('Error: failed to run server', err.toString());
 	});

--- a/electron/ts/server.ts
+++ b/electron/ts/server.ts
@@ -16,6 +16,29 @@ class Server {
 	isRunning: boolean = false;
 	stopTriggered: boolean = false;
 	lastErrors: string[] = [];
+	readyResolve: ((address: string) => void) | null = null;
+	readyReject: ((err: Error) => void) | null = null;
+	readyPromise: Promise<string>;
+
+	constructor () {
+		this.readyPromise = new Promise<string>((resolve, reject) => {
+			this.readyResolve = resolve;
+			this.readyReject = reject;
+		});
+
+		// Prevent unhandled rejection warning when the server fails before any
+		// renderer has requested the address
+		this.readyPromise.catch(() => null);
+	};
+
+	/**
+	 * Resolves with the gRPC web proxy address once the middleware is up.
+	 * Allows windows to be created before the server finishes starting —
+	 * the renderer awaits this via Api.getServerAddress.
+	 */
+	whenReady (): Promise<string> {
+		return this.readyPromise;
+	};
 
 	start (binPath: string, workingDir: string): Promise<boolean> {
 		console.log('[Server]: start', binPath, workingDir);
@@ -37,12 +60,14 @@ class Server {
 					this.cp = childProcess.spawn(binPath, [ '127.0.0.1:0', '127.0.0.1:0' ], { windowsHide: false, env });
 				} catch (err: any) {
 					console.error('[Server] Process start error: ', err.toString());
+					this.readyReject?.(err);
 					reject(err);
 				};
 
 				this.cp.on('error', (err: any) => {
 					this.isRunning = false;
 					console.error('[Server] Failed to start server: ', err.toString());
+					this.readyReject?.(err);
 					reject(err);
 				});
 
@@ -55,6 +80,7 @@ class Server {
 						this.address = 'http://' + regex.exec(str)[1];
 						this.isRunning = true;
 
+						this.readyResolve?.(this.address);
 						resolve(true);
 					};
 
@@ -139,6 +165,7 @@ class Server {
 
 	setAddress (address: string): void {
 		this.address = address;
+		this.readyResolve?.(address);
 	};
 
 };

--- a/src/ts/app.tsx
+++ b/src/ts/app.tsx
@@ -124,6 +124,8 @@ const App: FC = () => {
 	const init = () => {
 		const { version, arch, getGlobal, tabId } = electron;
 
+		U.Perf.step('boot:init', 'boot:entry');
+
 		U.Router.init(history);
 		U.Smile.init();
 
@@ -141,7 +143,10 @@ const App: FC = () => {
 		dispatcher.init(getGlobal('serverAddress'));
 		keyboard.init();
 		registerIpcEvents();
-		Renderer.send('getInitData', tabId()).then((data: any) => onInit(data));
+		Renderer.send('getInitData', tabId()).then((data: any) => {
+			U.Perf.step('boot:init-data', 'boot:init');
+			onInit(data);
+		});
 
 		console.log('[Process] os version:', version.system, 'arch:', arch);
 		console.log('[App] version:', version.app, 'isPackaged', isPackaged);
@@ -329,6 +334,8 @@ const App: FC = () => {
 		sidebar.init(false);
 		analytics.init();
 
+		U.Perf.step('boot:stores', 'boot:init-data');
+
 		const lastAppVersion = Storage.get('lastAppVersion');
 		const currentAppVersion = electron.version?.app;
 
@@ -350,7 +357,13 @@ const App: FC = () => {
 
 		U.Dom.addClass(body, 'over');
 
+		let measured = false;
 		const hide = () => {
+			if (!measured) {
+				measured = true;
+				U.Perf.step('boot:ready', 'boot:entry');
+			};
+
 			rootLoader?.remove();
 			bubbleLoader?.remove();
 			U.Dom.removeClass(body, 'over');
@@ -409,6 +422,8 @@ const App: FC = () => {
 					U.Router.go('/auth/setup/init', routeParam);
 					return;
 				};
+
+				U.Perf.step('boot:account', 'boot:init');
 
 				keyboard.setPinChecked(isPinChecked);
 				S.Auth.accountSet(account);

--- a/src/ts/app.tsx
+++ b/src/ts/app.tsx
@@ -138,15 +138,35 @@ const App: FC = () => {
 			import('./lib/web/routeSync').then(({ initRouteSync }) => initRouteSync(history, U.Router));
 		}
 
-		console.log('[App] Init', getGlobal('serverAddress'));
-
-		dispatcher.init(getGlobal('serverAddress'));
 		keyboard.init();
 		registerIpcEvents();
-		Renderer.send('getInitData', tabId()).then((data: any) => {
-			U.Perf.step('boot:init-data', 'boot:init');
-			onInit(data);
-		});
+
+		const startWithAddress = (address: string) => {
+			console.log('[App] Init', address);
+
+			U.Perf.step('boot:server', 'boot:init');
+
+			dispatcher.init(address);
+			Renderer.send('getInitData', tabId()).then((data: any) => {
+				U.Perf.step('boot:init-data', 'boot:init');
+				onInit(data);
+			});
+		};
+
+		// Windows are created in parallel with middleware startup: use the
+		// address directly when the server is already up (also covers web
+		// mode), otherwise await it from the main process
+		const address = getGlobal('serverAddress');
+
+		if (address) {
+			startWithAddress(address);
+		} else {
+			// Rejection means the middleware failed to start — the main process
+			// shows an error dialog in that case
+			Renderer.send('getServerAddress').then(startWithAddress).catch((err: any) => {
+				console.error('[App] Server failed to start:', err);
+			});
+		};
 
 		console.log('[Process] os version:', version.system, 'arch:', arch);
 		console.log('[App] version:', version.app, 'isPackaged', isPackaged);

--- a/src/ts/entry.tsx
+++ b/src/ts/entry.tsx
@@ -2,6 +2,9 @@ import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './app';
 import { ErrorBoundary } from 'Component';
+
+U.Perf.mark('boot:entry');
+
 const root = createRoot(document.getElementById('root'));
 
 root.render(<ErrorBoundary><App /></ErrorBoundary>);

--- a/src/ts/lib/util/index.ts
+++ b/src/ts/lib/util/index.ts
@@ -15,6 +15,7 @@ import Subscription from './subscription';
 import String from './string';
 import StickyScrollbar from './stickyScrollbar';
 import Comment from './comment';
+import Perf from './perf';
 
 export {
 	Common,
@@ -34,4 +35,5 @@ export {
 	String,
 	StickyScrollbar,
 	Comment,
+	Perf,
 };

--- a/src/ts/lib/util/perf.ts
+++ b/src/ts/lib/util/perf.ts
@@ -1,0 +1,61 @@
+/**
+ * Lightweight startup/runtime performance instrumentation.
+ *
+ * Thin wrapper around the User Timing API (performance.mark / performance.measure).
+ * Marks and measures recorded here show up:
+ *   - in the DevTools Performance panel (Timings track),
+ *   - in Electron contentTracing output (blink.user_timing category) — see ANYTYPE_TRACE_STARTUP,
+ * so the app's own boot milestones line up against the native flame chart and network waterfall.
+ *
+ * All names are namespaced with PREFIX so they're trivial to filter in the timeline.
+ */
+
+const PREFIX = 'at:';
+
+class UtilPerf {
+
+	/**
+	 * Records a single point-in-time mark.
+	 */
+	mark (name: string): void {
+		try {
+			performance.mark(`${PREFIX}${name}`);
+		} catch (e) { /* User Timing unavailable */ };
+	};
+
+	/**
+	 * Creates a measure spanning from a previously recorded mark to now (or to endMark),
+	 * logs it, and returns the duration in milliseconds (0 if it could not be computed).
+	 */
+	measure (name: string, startMark?: string, endMark?: string): number {
+		let ms = 0;
+
+		try {
+			const start = startMark ? `${PREFIX}${startMark}` : undefined;
+			const end = endMark ? `${PREFIX}${endMark}` : undefined;
+			const entry = performance.measure(`${PREFIX}${name}`, start, end);
+
+			ms = Math.round(entry?.duration || 0);
+		} catch (e) {
+			// startMark may be missing (e.g. after an HMR full reload) — skip silently
+			return 0;
+		};
+
+		console.log(`[Perf] ${name}: ${ms}ms`);
+		return ms;
+	};
+
+	/**
+	 * Convenience: mark `name` and, when `from` is given, measure `from`→`name` in one call.
+	 */
+	step (name: string, from?: string): void {
+		this.mark(name);
+
+		if (from) {
+			this.measure(`${from}->${name}`, from, name);
+		};
+	};
+
+};
+
+export default new UtilPerf();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -121,6 +121,21 @@ export default defineConfig(({ mode }) => {
 						return 'assets/[name]-[hash][extname]';
 					},
 					manualChunks(id) {
+						// Vite/Rollup virtual helper modules (preload helper, commonjs helpers).
+						// Left unassigned, Rollup colocates them into an arbitrary chunk — the
+						// preload helper landed inside vendor-mermaid, so main.js statically
+						// imported it and dragged the whole 4.6MB chunk into every startup
+						if (id.includes('vite/preload-helper') || id.includes('commonjsHelpers')) {
+							return 'helpers';
+						}
+						// Lazy-only packages: imported exclusively via dynamic import() (embed
+						// block, pdf block, latex menus). Return undefined so Rollup keeps them
+						// in their own lazy chunks — the blanket 'vendor' rule below would merge
+						// them into the statically-loaded vendor chunk, defeating the import()
+						// and parsing them at every startup
+						if (/node_modules\/(katex|@viz-js|react-pdf|pdfjs-dist|pako)\//.test(id)) {
+							return;
+						}
 						if (id.includes('dist/lib/pb/') || id.includes('/middleware/')) {
 							return 'protobuf';
 						}


### PR DESCRIPTION
## What

Startup-performance changes:

**1. Fix eager chunk loading (`manualChunks`)** — the actual win:
- Vite's preload-helper virtual module was colocated into `vendor-mermaid.js`, so `main.js` statically pulled the whole 4.6MB mermaid chunk into every startup. Now routed to a tiny `helpers` chunk.
- The blanket `node_modules → vendor` rule force-merged dynamically-imported packages (katex, @viz-js, react-pdf, pako) into the static `vendor.js`. Now excluded so they keep their own lazy chunks.

**2. Parallelize window creation with middleware startup** — `createWindow()` no longer waits for anytypeHelper's gRPC address; renderer boot overlaps middleware startup. Renderer awaits `Api.getServerAddress` before `dispatcher.init` (fast path kept).

**3. Boot timing marks (`U.Perf`)** — thin User Timing wrapper (`src/ts/lib/util/perf.ts`); `boot:*` milestones across the boot path, visible in the DevTools Performance panel (Timings track).

## Result (production build)

| | Before | After |
|---|---|---|
| Eager startup JS | ~19.5MB | **13.0MB (−33%)** |
| vendor.js | 3.7MB | 1.3MB |
| vendor-mermaid (4.6MB) | eager | lazy |

Plus parallelization saves min(renderer boot, middleware boot) on cold start (~0.5–2s).

## Testing

- `typecheck` + `lint` pass
- Smoke test: embed blocks (mermaid/latex/graphviz), PDF block, graph view (now load vendor code on first use); normal login flow.
