### PR TITLE
JS-9806: do not subscribe to space search results

### DIFF
--- a/src/json/constant.ts
+++ b/src/json/constant.ts
@@ -121,7 +121,6 @@ export default {
 	},
 
 	subId: {
-		search:			 		'search',
 		profile:		 		'profile',
 		deleted:		 		'deleted',
 		archived:		 		'archived',

--- a/src/ts/component/popup/search.tsx
+++ b/src/ts/component/popup/search.tsx
@@ -338,7 +338,7 @@ const PopupSearch = forwardRef<{}, I.Popup>((props, ref) => {
 			setIsLoading(true);
 		};
 
-		C.ObjectSearchWithMeta(space, filters, sorts, J.Relation.default.concat([ 'pluralName', 'links', 'backlinks', '_final_score' ]), filterValueRef.current, offsetRef.current, limit, (message) => {
+		C.ObjectSearchWithMeta(space, filters, sorts, J.Relation.default.concat([ 'pluralName', 'links', 'backlinks', 'creator', '_final_score' ]), filterValueRef.current, offsetRef.current, limit, (message) => {
 			if (message.error.code) {
 				setIsLoading(false);
 				return;
@@ -356,16 +356,6 @@ const PopupSearch = forwardRef<{}, I.Popup>((props, ref) => {
 			});
 
 			itemsRef.current = itemsRef.current.concat(records);
-
-			if (itemsRef.current.length) {
-				U.Subscription.destroyList([ J.Constant.subId.search ], true, () => {
-					U.Subscription.subscribeIds({
-						subId: J.Constant.subId.search,
-						ids: itemsRef.current.map(it => it.id),
-						noDeps: true,
-					});
-				});
-			};
 
 			if (clear) {
 				setIsLoading(false);
@@ -596,7 +586,7 @@ const PopupSearch = forwardRef<{}, I.Popup>((props, ref) => {
 			classNameWrap: 'fromPopup',
 			vertical: I.MenuDirection.Center,
 			data: {
-				subId: J.Constant.subId.search,
+				getObject: id => itemsRef.current.find(it => it.id == id),
 				route,
 				objectIds: [ item.id ],
 				allowedNewTab: true,
@@ -651,7 +641,6 @@ const PopupSearch = forwardRef<{}, I.Popup>((props, ref) => {
 
 		return () => {
 			unbind();
-			U.Subscription.destroyList([ J.Constant.subId.search ]);
 			window.clearTimeout(timeoutRef.current);
 			window.clearTimeout(rebindTimeoutRef.current);
 		};


### PR DESCRIPTION
## Summary

The global search popup ran a one-shot `C.ObjectSearchWithMeta` and then additionally subscribed to the returned IDs via `U.Subscription.subscribeIds` under `J.Constant.subId.search`. This subscription was unnecessary overhead: the visible rows render straight from the local `itemsRef.current` snapshot, not from the store. Its only real consumer was the `objectContext` menu, which read objects via `S.Detail.get(subId, id)`.

## Changes

- **`src/ts/component/popup/search.tsx`**
  - Removed the `destroyList`/`subscribeIds` block in the search callback and the `destroyList` call in the unmount cleanup.
  - The `objectContext` menu now receives `getObject: id => itemsRef.current.find(it => it.id == id)` instead of `subId` — the menu's `getObjectHandler` already supports this store-bypassing callback (same pattern as the graph provider).
  - Added `creator` to the keys requested by `C.ObjectSearchWithMeta` — the only context-menu key missing from `J.Relation.default`, used for the archive-permission check in one-to-one spaces.
- **`src/json/constant.ts`**
  - Removed the now-unused `search` entry from `subId` (verified no remaining references).

## Notes

- `Action.archiveCheckType(subId, ...)` never uses its first param — no change needed there.
- Records are already mapped through `S.Detail.mapper` in the search callback, so layout resolves correctly for the menu.
- Archive-from-menu row removal is handled by the `archiveObject` window event listener and does not depend on the subscription.

## Verification

- `bun run typecheck` — passes
- `bun run lint` — passes (2 pre-existing warnings in untouched files)