### PR TITLE
JS-9807: markdown styling going past its format limit

### DIFF
--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -1058,6 +1058,14 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 			focus.set(focused, { from: range.from - diff, to: range.to - diff });
 			focus.apply();
+
+			// After markdown auto-conversion the caret lands on the closing tag
+			// boundary and the browser keeps typing inside the new mark — move it
+			// past the trailing ZWS anchor so continued typing stays unformatted
+			const editable = U.Dom.select('.editable', editableRef.current?.getNode());
+			if (editable) {
+				Mark.escapeMarkBoundary(editable);
+			};
 		};
 
 		// Debounce the gRPC save so rapid typing doesn't saturate the main thread

--- a/src/ts/lib/mark.ts
+++ b/src/ts/lib/mark.ts
@@ -9,6 +9,7 @@ for (const i in I.MarkType) {
 };
 
 const TagValues = Object.values(Tags).join('|');
+const TagSet = new Set(Object.values(Tags));
 const RE_HTML_TAGS = new RegExp(`<(\/)?(${TagValues})\\b(?:([^>]*)>|>)`, 'ig');
 const RE_DATA_PARAM = new RegExp('data-param="([^"]*)"', 'i');
 
@@ -1161,6 +1162,78 @@ class Mark {
 	hasZws (el: HTMLElement): boolean {
 		const text = el.textContent || '';
 		return text.includes(ZWS);
+	};
+
+	/**
+	 * Check if a node is a markup element (markupbold, markupitalic, a, etc.).
+	 */
+	isMarkupElement (node: Node): boolean {
+		return node && (node.nodeType === Node.ELEMENT_NODE) && TagSet.has((node as HTMLElement).tagName.toLowerCase());
+	};
+
+	/**
+	 * Move a collapsed caret sitting right after a closing markup tag past the
+	 * trailing ZWS anchor. The browser canonicalizes a caret on the element
+	 * boundary to the end of the text inside the tag, so typed characters would
+	 * inherit the mark's formatting (e.g. right after markdown auto-conversion).
+	 * The model offset is unchanged: domToModel does not count ZWS characters.
+	 * @param {HTMLElement} root - The editable element containing the caret.
+	 */
+	escapeMarkBoundary (root: HTMLElement) {
+		const sel = window.getSelection();
+		if (!sel || !sel.rangeCount || !sel.isCollapsed) {
+			return;
+		};
+
+		const range = sel.getRangeAt(0);
+
+		let node: Node = range.startContainer;
+		let offset = range.startOffset;
+		let moved = false;
+
+		if (!root.contains(node)) {
+			return;
+		};
+
+		for (let i = 0; i < 16; ++i) {
+			// Caret at the end of a ZWS-only closing anchor — hop out of the enclosing tag
+			if ((node.nodeType === Node.TEXT_NODE) && (node.textContent === ZWS) && (offset == 1)) {
+				const parent = node.parentNode;
+
+				if (!parent || (parent === root) || !this.isMarkupElement(parent) || (parent.lastChild !== node)) {
+					break;
+				};
+
+				const grand = parent.parentNode;
+				if (!grand) {
+					break;
+				};
+
+				offset = Array.prototype.indexOf.call(grand.childNodes, parent) + 1;
+				node = grand;
+				moved = true;
+				continue;
+			};
+
+			if (node.nodeType !== Node.ELEMENT_NODE) {
+				break;
+			};
+
+			const prev = node.childNodes[offset - 1];
+			const next = node.childNodes[offset];
+
+			if (!prev || !this.isMarkupElement(prev) || !next || (next.nodeType !== Node.TEXT_NODE) || !String(next.textContent || '').startsWith(ZWS)) {
+				break;
+			};
+
+			node = next;
+			offset = 1;
+			moved = true;
+		};
+
+		if (moved) {
+			sel.collapse(node, offset);
+		};
 	};
 
 };


### PR DESCRIPTION
## Problem

Typing inline markdown like `lalala *italic* kokoko` converted `*italic*` to italic, but the formatting then bled into everything typed afterwards — `kokoko` also became italic.

## Root cause

After `Mark.fromMarkdown` converts the markdown on keyup, `focus.apply()` restores the caret via `setStartAfter()` on the element boundary right after the closing markup tag. The browser canonicalizes that caret position to the end of the text *inside* the tag, so subsequently typed characters inherit the mark, and the next keyup parse permanently extends it. The renderer already emits a trailing zero-width-space anchor after each closing tag exactly as an escape hatch (before the ZWS refactor, `fromMarkdown` appended a real trailing space instead), but nothing ever moved the caret past it.

## Fix

- `src/ts/lib/mark.ts` — new `Mark.escapeMarkBoundary(root)`: if a collapsed caret sits right after a closing markup tag followed by a ZWS anchor, move it past the anchor (handles nested marks; the model offset is unchanged since `domToModel` doesn't count ZWS).
- `src/ts/component/block/text.tsx` — call it right after `focus.apply()` in the keyup markdown-conversion block, scoped so caret behavior elsewhere (paste, focus restore) is untouched.

Fixes all inline conversions: `*x*`, `_x_`, `**x**`, `__x__`, `` `x` ``, `~~x~~`.

## Testing

- New E2E reproducer in anytype-desktop-suite: `tests/editor/blocks/markdown-inline.spec.ts` — red before the fix (`<markupitalic>italic kokoko</markupitalic>`), green after (`<markupitalic>italic</markupitalic> kokoko`).
- `bun run typecheck` and ESLint clean; `mark.test.ts` unit tests show no new failures.