### PR TITLE
fix(comments): split object-page comment menu into "Copy message link" and "Copy link"

### DIFF
--- a/src/json/text.json
+++ b/src/json/text.json
@@ -3009,7 +3009,8 @@
 	"commentDelete": "Delete",
 	"commentSend": "Send",
 	"commentCopyText": "Copy text",
-	"commentCopyLink": "Copy link to comment",
+	"commentCopyLink": "Copy link",
+	"commentCopyMessageLink": "Copy message link",
 	"commentRepliesCount": "%s replies",
 	"commentReplyCount": "%s reply",
 

--- a/src/ts/component/comment/post.tsx
+++ b/src/ts/component/comment/post.tsx
@@ -533,12 +533,20 @@ const CommentPost = (props: Props) => {
 		});
 	}, [ rootId, parts ]);
 
-	const onCopyLink = useCallback(() => {
+	const onCopyMessageLink = useCallback(() => {
 		const object = S.Detail.get(rootId, rootId);
 		const spaceObject = U.Space.getSpaceview();
 
 		U.Object.copyLink(object, spaceObject, 'deeplink', '', `&messageId=${id}`);
 	}, [ rootId, id ]);
+
+	const onCopyUrl = useCallback((url: string) => {
+		if (!url) {
+			return;
+		};
+
+		U.Common.copyToast(translate('commonLink'), url);
+	}, []);
 
 	const onReactionSelect = useCallback((icon: string) => {
 		const limit = J.Constant.limit.chat.reactions;
@@ -580,7 +588,7 @@ const CommentPost = (props: Props) => {
 		openReactionPicker(e.currentTarget as HTMLElement);
 	}, [ openReactionPicker ]);
 
-	const buildMenuOptions = useCallback((withQuickActions: boolean) => {
+	const buildMenuOptions = useCallback((withQuickActions: boolean, url?: string) => {
 		const limit = J.Constant.limit.chat.reactions;
 		const self = (reactions || []).filter(it => it.authors?.includes(account.id));
 		const canReact = (self.length < limit.self) && ((reactions || []).length < limit.all);
@@ -596,11 +604,16 @@ const CommentPost = (props: Props) => {
 
 		items.push({ id: 'copyText', name: translate('commentCopyText'), iconParam: { name: 'menu/action/copy' } });
 
+		// Only offered when the menu was opened on a URL inside the message text
+		if (url) {
+			items.push({ id: 'copyLink', name: translate('commentCopyLink'), iconParam: { name: 'menu/action/copyLink' } });
+		};
+
 		if (withQuickActions) {
 			items.push({ isDiv: true });
 		};
 
-		items.push({ id: 'copyLink', name: translate('commentCopyLink'), iconParam: { name: 'menu/action/pageLink' } });
+		items.push({ id: 'copyMessageLink', name: translate('commentCopyMessageLink'), iconParam: { name: 'menu/action/pageLink' } });
 
 		if (isSelf) {
 			items.push({ id: 'edit', name: translate('commentEdit'), iconParam: { name: 'common/edit' } });
@@ -615,16 +628,17 @@ const CommentPost = (props: Props) => {
 		return items;
 	}, [ isSelf, reactions, account.id ]);
 
-	const onMenuSelect = useCallback((item: any, anchor: HTMLElement) => {
+	const onMenuSelect = useCallback((item: any, anchor: HTMLElement, url?: string) => {
 		switch (item.id) {
 			case 'reply': onReply(); break;
 			case 'reaction': openReactionPicker(anchor); break;
 			case 'copyText': onCopyText(); break;
-			case 'copyLink': onCopyLink(); break;
+			case 'copyLink': onCopyUrl(url); break;
+			case 'copyMessageLink': onCopyMessageLink(); break;
 			case 'edit': onEdit(); break;
 			case 'delete': onDelete(); break;
 		};
-	}, [ onReply, openReactionPicker, onCopyText, onCopyLink, onEdit, onDelete ]);
+	}, [ onReply, openReactionPicker, onCopyText, onCopyUrl, onCopyMessageLink, onEdit, onDelete ]);
 
 	const onMenuClick = useCallback((e: React.MouseEvent) => {
 		const element = e.currentTarget as HTMLElement;
@@ -656,6 +670,8 @@ const CommentPost = (props: Props) => {
 		const x = e.pageX;
 		const y = e.pageY;
 		const anchor = contentWrapRef.current;
+		const link = (e.target as HTMLElement)?.closest(Mark.getTag(I.MarkType.Link)) as HTMLElement;
+		const url = link ? String(link.getAttribute('href') || '') : '';
 
 		setHover(true);
 
@@ -666,8 +682,8 @@ const CommentPost = (props: Props) => {
 			horizontal: I.MenuDirection.Right,
 			onClose: () => setHover(false),
 			data: {
-				options: buildMenuOptions(true),
-				onSelect: (e: any, item: any) => onMenuSelect(item, anchor),
+				options: buildMenuOptions(true, url),
+				onSelect: (e: any, item: any) => onMenuSelect(item, anchor, url),
 			},
 		});
 	}, [ readonly, isEditing, buildMenuOptions, onMenuSelect, setHover ]);

--- a/src/ts/component/comment/reply.tsx
+++ b/src/ts/component/comment/reply.tsx
@@ -312,12 +312,20 @@ const CommentReply = (props: Props) => {
 		});
 	}, [ targetId, id, parentId ]);
 
-	const onCopyLink = useCallback(() => {
+	const onCopyMessageLink = useCallback(() => {
 		const object = S.Detail.get(rootId, rootId);
 		const spaceObject = U.Space.getSpaceview();
 
 		U.Object.copyLink(object, spaceObject, 'deeplink', '', `&messageId=${id}`);
 	}, [ rootId, id ]);
+
+	const onCopyUrl = useCallback((url: string) => {
+		if (!url) {
+			return;
+		};
+
+		U.Common.copyToast(translate('commonLink'), url);
+	}, []);
 
 	const onCopyText = useCallback(() => {
 		const blocks = U.Comment.partsToBlocks(parts);
@@ -376,7 +384,7 @@ const CommentReply = (props: Props) => {
 		openReactionPicker(e.currentTarget as HTMLElement);
 	}, [ openReactionPicker ]);
 
-	const buildMenuOptions = useCallback((withQuickActions: boolean) => {
+	const buildMenuOptions = useCallback((withQuickActions: boolean, url?: string) => {
 		const limit = J.Constant.limit.chat.reactions;
 		const self = (reactions || []).filter(it => it.authors?.includes(account.id));
 		const canReact = (self.length < limit.self) && ((reactions || []).length < limit.all);
@@ -394,9 +402,14 @@ const CommentReply = (props: Props) => {
 
 		items.push({ id: 'copyText', name: translate('commentCopyText'), iconParam: { name: 'menu/action/copy' } });
 
+		// Only offered when the menu was opened on a URL inside the message text
+		if (url) {
+			items.push({ id: 'copyLink', name: translate('commentCopyLink'), iconParam: { name: 'menu/action/copyLink' } });
+		};
+
 		if (withQuickActions) {
 			items.push({ isDiv: true });
-			items.push({ id: 'copyLink', name: translate('commentCopyLink'), iconParam: { name: 'menu/action/pageLink' } });
+			items.push({ id: 'copyMessageLink', name: translate('commentCopyMessageLink'), iconParam: { name: 'menu/action/pageLink' } });
 		};
 
 		if (isSelf) {
@@ -412,16 +425,17 @@ const CommentReply = (props: Props) => {
 		return items;
 	}, [ isSelf, reactions, account.id, onReply ]);
 
-	const onMenuSelect = useCallback((item: any, anchor: HTMLElement) => {
+	const onMenuSelect = useCallback((item: any, anchor: HTMLElement, url?: string) => {
 		switch (item.id) {
 			case 'reply': onReply?.(); break;
 			case 'reaction': openReactionPicker(anchor); break;
 			case 'copyText': onCopyText(); break;
-			case 'copyLink': onCopyLink(); break;
+			case 'copyLink': onCopyUrl(url); break;
+			case 'copyMessageLink': onCopyMessageLink(); break;
 			case 'edit': onEdit(); break;
 			case 'delete': onDelete(); break;
 		};
-	}, [ onReply, openReactionPicker, onCopyText, onCopyLink, onEdit, onDelete ]);
+	}, [ onReply, openReactionPicker, onCopyText, onCopyUrl, onCopyMessageLink, onEdit, onDelete ]);
 
 	const onMenuClick = useCallback((e: React.MouseEvent) => {
 		const element = e.currentTarget as HTMLElement;
@@ -453,6 +467,8 @@ const CommentReply = (props: Props) => {
 		const x = e.pageX;
 		const y = e.pageY;
 		const anchor = contentWrapRef.current;
+		const link = (e.target as HTMLElement)?.closest(Mark.getTag(I.MarkType.Link)) as HTMLElement;
+		const url = link ? String(link.getAttribute('href') || '') : '';
 
 		setHover(true);
 
@@ -463,8 +479,8 @@ const CommentReply = (props: Props) => {
 			horizontal: I.MenuDirection.Right,
 			onClose: () => setHover(false),
 			data: {
-				options: buildMenuOptions(true),
-				onSelect: (e: any, item: any) => onMenuSelect(item, anchor),
+				options: buildMenuOptions(true, url),
+				onSelect: (e: any, item: any) => onMenuSelect(item, anchor, url),
 			},
 		});
 	}, [ readonly, isEditing, buildMenuOptions, onMenuSelect, setHover ]);


### PR DESCRIPTION
> **Scope:** this PR changes the **object-page comment system** (`component/comment/` — `post.tsx` / `reply.tsx`), **not** the space chat. The bug reported in [JS-9812](https://linear.app/anytype/issue/JS-9812) is in the **space chat**, fixed by **#2260**. This PR applies the same UX improvement to the comment menu as a bonus.
>
> ⚠️ The branch name `JS-9812-chat-copy-link` is a misnomer — it predates discovering that comments and chat are separate systems.

## Problem
In the object-page comment/reply context menu, a single **Copy link** action always copied the *comment* deeplink (`anytype://…&messageId=…`), regardless of what was right-clicked. Right-clicking a URL in the comment text copied the comment link instead of the URL under the cursor.

## Solution
Split into two distinct actions:
- **Copy message link** — copies the comment deeplink (former behavior, always shown).
- **Copy link** — copies the actual URL under the cursor (`<a href>`); shown in the **Copy text** group only when the menu is opened on a link.

Applied to comments (`post.tsx`) and threaded replies (`reply.tsx`). New i18n key `commentCopyMessageLink`; `commentCopyLink` → "Copy link".

## Tests
E2E coverage (comment menu) in anyproto/anytype-desktop-suite#51.

## Verification
`bun run typecheck` ✓ · `bun run lint` ✓ (0 errors)