### PR TITLE
fix(chat): split space-chat message menu into "Copy message link" and "Copy link" (JS-9812)

### DIFF
--- a/src/json/text.json
+++ b/src/json/text.json
@@ -925,6 +925,8 @@
 	"blockChatReplying": "Replying to %s",
 	"blockChatFormReadonly": "Only editors can send messages. Contact the owner to request access.",
 	"blockChatCopyText": "Copy Text",
+	"blockChatCopyLink": "Copy link",
+	"blockChatCopyMessageLink": "Copy message link",
 	"blockChatDownloadFiles": "Download %s files",
 	"blockChatMarkAsUnread": "Mark as unread",
 	"blockChatAddAttachment": "Add attachment",

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -609,6 +609,11 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		const message = `#block-${U.Common.esc(block.id)} #item-${U.Common.esc(item.id)}`;
 		const isRightClick = !onMore;
 
+		// Right-clicking a URL inside the message text offers a "Copy link" for that URL,
+		// distinct from "Copy message link" (the message deeplink)
+		const linkEl = isRightClick ? (e.target as HTMLElement)?.closest('a.markuplink') as HTMLElement : null;
+		const url = linkEl ? String(linkEl.getAttribute('href') || '') : '';
+
 		let satellite = null;
 
 		if (isRightClick && canAddReaction(item)) {
@@ -656,7 +661,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 				U.Dom.removeClass(messageEl, 'hover');
 			},
 			data: {
-				options: getMessageMenuOptions(item, onMore),
+				options: getMessageMenuOptions(item, onMore, url),
 				satellite,
 				onSelect: (e, option) => {
 					switch (option.id) {
@@ -683,6 +688,12 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 							const object = S.Detail.get(rootId, rootId);
 
 							U.Object.copyLink(object, space, 'deeplink', '', `&messageId=${item.id}`);
+							analytics.event('ClickMessageMenuLink', { chatId: analyticsChatId });
+							break;
+						};
+
+						case 'copyLink': {
+							U.Common.copyToast(translate('commonLink'), url);
 							analytics.event('ClickMessageMenuLink', { chatId: analyticsChatId });
 							break;
 						};
@@ -914,7 +925,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		return ret;
 	};
 
-	const getMessageMenuOptions = (message: I.ChatMessage, noControls: boolean): I.Option[] => {
+	const getMessageMenuOptions = (message: I.ChatMessage, noControls: boolean, url?: string): I.Option[] => {
 		const isSelf = message.creator == S.Auth.account.id;
 		const downloadable = getDownloadableAttachments(message);
 		const options: any[] = [];
@@ -925,6 +936,11 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 
 		if (message.content.text) {
 			options.push({ id: 'copy', iconParam: { name: 'menu/action/copy' }, name: translate('blockChatCopyText') });
+		};
+
+		// Only offered when the menu was opened on a URL inside the message text
+		if (url) {
+			options.push({ id: 'copyLink', iconParam: { name: 'menu/action/copyLink' }, name: translate('blockChatCopyLink') });
 		};
 
 		if (downloadable.length == 1) {
@@ -945,13 +961,13 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			options.push({ isDiv: true });
 			options.push({ id: 'edit', iconParam: { name: 'common/edit' }, name: translate('commonEdit') });
 			options.push({ isDiv: true });
-			options.push({ id: 'link', iconParam: { name: 'menu/action/pageLink' }, name: translate('commonCopyLink') });
+			options.push({ id: 'link', iconParam: { name: 'menu/action/pageLink' }, name: translate('blockChatCopyMessageLink') });
 			options.push({ id: 'delete', iconParam: { name: 'menu/action/remove', color: 'destructive' }, name: translate('commonDelete'), color: 'destructive' });
 		} else {
 			if (options.length) {
 				options.push({ isDiv: true });
 			};
-			options.push({ id: 'link', iconParam: { name: 'menu/action/pageLink' }, name: translate('commonCopyLink') });
+			options.push({ id: 'link', iconParam: { name: 'menu/action/pageLink' }, name: translate('blockChatCopyMessageLink') });
 
 			// Owners and Admins can delete any message in the space
 			if (U.Space.canMyParticipantModerate()) {


### PR DESCRIPTION
> ✅ **This is the fix for [JS-9812](https://linear.app/anytype/issue/JS-9812)** — the **space chat** (`component/block/chat/`, menu built in `block/chat.tsx`).
> For the same change applied to the separate **object-page comment** system, see the bonus PR **#2259**.

## Problem
In the **space chat**, the message context menu had a single **Copy Link** action that always copied the *message* deeplink (`anytype://…&messageId=…`), even when right-clicking a URL in the message text — misleading.

## Solution
Split the menu action in `block/chat.tsx`:
- **Copy message link** — copies the message deeplink (former `link` behavior, always shown).
- **Copy link** — copies the actual URL under the cursor; shown in the **Copy text** group only when the menu is opened on a link (`a.markuplink`) in the message text.

URL is detected from the right-click target (`(e.target).closest('a.markuplink')`) in the existing `onContextMenu` handler — no message-component change needed, since chat renders links as `<a href class="markuplink">` and the contextmenu fires on the message element. New i18n keys `blockChatCopyLink` / `blockChatCopyMessageLink`.

## Test plan
- Right-click a plain message → **Copy message link**, no standalone **Copy link**.
- Right-click a URL in a message → **Copy text** + **Copy link** (grouped) and **Copy message link**.
- **Copy link** → URL on clipboard (no `messageId=` deeplink).
- **Copy message link** → `anytype://…messageId=…` deeplink on clipboard.

## Tests
E2E coverage (space-chat menu) in anyproto/anytype-desktop-suite#51.

## Verification
`bun run typecheck` ✓ (no errors in changed files) · `bun run lint` ✓