### PR TITLE
feat(chat): download single or all files from message context menu (JS-9813)

### DIFF
--- a/src/json/constant.ts
+++ b/src/json/constant.ts
@@ -72,6 +72,7 @@ export default {
 
 		string: {
 			mention:					 300,
+			fileName:					 24,
 		},
 	},
 

--- a/src/json/text.json
+++ b/src/json/text.json
@@ -140,6 +140,7 @@
 	"commonUploadComputer": "Upload from computer",
 	"commonLoad": "Load",
 	"commonDownload": "Download",
+	"commonDownloadFile": "Download %s",
 	"commonDownloadAll": "Download all",
 	"commonDownloading": "Downloading...",
 	"commonAscending": "Ascending",

--- a/src/json/text.json
+++ b/src/json/text.json
@@ -140,6 +140,7 @@
 	"commonUploadComputer": "Upload from computer",
 	"commonLoad": "Load",
 	"commonDownload": "Download",
+	"commonDownloadAll": "Download all",
 	"commonDownloading": "Downloading...",
 	"commonAscending": "Ascending",
 	"commonDescending": "Descending",

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -948,7 +948,18 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			if (target) {
 				const isFileDownloading = S.Common.isDownloading(target.id);
 
-				options.push({ id: 'download', iconParam: { name: 'menu/action/download' }, name: isFileDownloading ? translate('commonDownloading') : translate('commonDownload'), disabled: isFileDownloading });
+				// With a single file the name is obvious; only spell it out to disambiguate one file among many.
+				let name = '';
+				if (isFileDownloading) {
+					name = translate('commonDownloading');
+				} else
+				if (downloadable.length == 1) {
+					name = translate('commonDownload');
+				} else {
+					name = U.String.sprintf(translate('commonDownloadFile'), U.String.shorten(U.File.name(target), J.Constant.limit.string.fileName));
+				};
+
+				options.push({ id: 'download', iconParam: { name: 'menu/action/download' }, name, disabled: isFileDownloading });
 			};
 
 			// With many files, also offer to download all of them at once.

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -609,6 +609,13 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		const message = `#block-${U.Common.esc(block.id)} #item-${U.Common.esc(item.id)}`;
 		const isRightClick = !onMore;
 
+		// Resolve the file the user right-clicked on, so a single attachment can be downloaded on its own.
+		let targetId = '';
+		if (isRightClick) {
+			const attachmentEl = (e.target as HTMLElement)?.closest('.attachment');
+			targetId = attachmentEl?.getAttribute('data-id') || '';
+		};
+
 		let satellite = null;
 
 		if (isRightClick && canAddReaction(item)) {
@@ -656,7 +663,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 				U.Dom.removeClass(messageEl, 'hover');
 			},
 			data: {
-				options: getMessageMenuOptions(item, onMore),
+				options: getMessageMenuOptions(item, onMore, targetId),
 				satellite,
 				onSelect: (e, option) => {
 					switch (option.id) {
@@ -710,11 +717,18 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 
 						case 'download': {
 							const files = getDownloadableAttachments(item);
+							const file = targetId ? files.find(it => it.id == targetId) : files[0];
 
-							if (files.length) {
-								const file = files[0];
+							if (file) {
 								Action.downloadFile(file.id, analytics.route.chat, file.layout == I.ObjectLayout.Image);
 							};
+							break;
+						};
+
+						case 'downloadAll': {
+							const files = getDownloadableAttachments(item).map(it => ({ id: it.id, isImage: it.layout == I.ObjectLayout.Image }));
+
+							Action.downloadFiles(files, analytics.route.chat);
 							break;
 						};
 					};
@@ -914,7 +928,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		return ret;
 	};
 
-	const getMessageMenuOptions = (message: I.ChatMessage, noControls: boolean): I.Option[] => {
+	const getMessageMenuOptions = (message: I.ChatMessage, noControls: boolean, targetId?: string): I.Option[] => {
 		const isSelf = message.creator == S.Auth.account.id;
 		const downloadable = getDownloadableAttachments(message);
 		const options: any[] = [];
@@ -927,10 +941,20 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			options.push({ id: 'copy', iconParam: { name: 'menu/action/copy' }, name: translate('blockChatCopyText') });
 		};
 
-		if (downloadable.length == 1) {
-			const isFileDownloading = S.Common.isDownloading(downloadable[0].id);
+		if (downloadable.length) {
+			// With one file, or one right-clicked among many, offer to download just that file.
+			const target = (downloadable.length == 1) ? downloadable[0] : downloadable.find(it => it.id == targetId);
 
-			options.push({ id: 'download', iconParam: { name: 'menu/action/download' }, name: isFileDownloading ? translate('commonDownloading') : translate('commonDownload'), disabled: isFileDownloading });
+			if (target) {
+				const isFileDownloading = S.Common.isDownloading(target.id);
+
+				options.push({ id: 'download', iconParam: { name: 'menu/action/download' }, name: isFileDownloading ? translate('commonDownloading') : translate('commonDownload'), disabled: isFileDownloading });
+			};
+
+			// With many files, also offer to download all of them at once.
+			if (downloadable.length > 1) {
+				options.push({ id: 'downloadAll', iconParam: { name: 'menu/action/download' }, name: translate('commonDownloadAll') });
+			};
 		};
 
 		if (!U.Space.getSpaceview().isOneToOne) {

--- a/src/ts/component/block/chat/attachment/index.tsx
+++ b/src/ts/component/block/chat/attachment/index.tsx
@@ -435,9 +435,10 @@ const ChatAttachment = forwardRef<RefProps, Props>((props, ref) => {
 	}));
 
 	return (
-		<div 
+		<div
 			ref={nodeRef}
 			className={cn.join(' ')}
+			{...U.Common.dataProps({ id: object.id })}
 		>
 			{content}
 			<Icon name="chat/buttons/remove" className="remove" size={8} onClick={onRemoveHandler} />

--- a/src/ts/lib/action.ts
+++ b/src/ts/lib/action.ts
@@ -325,21 +325,34 @@ class Action {
 	 * @param {boolean} isImage - Whether to treat the file as an image.
 	 */
 	downloadFile (id: string, route: string, isImage: boolean) {
-		if (!id || S.Common.isDownloading(id)) {
+		this.downloadFiles([ { id, isImage } ], route);
+	};
+
+	/**
+	 * Downloads multiple files into a single chosen directory using one dialog.
+	 * @param {{ id: string, isImage: boolean }[]} files - The files to download.
+	 * @param {string} route - The route context for analytics.
+	 */
+	downloadFiles (files: { id: string, isImage: boolean }[], route: string) {
+		files = (files || []).filter(it => it.id && !S.Common.isDownloading(it.id));
+
+		if (!files.length) {
 			return;
 		};
 
-		const url = isImage ? S.Common.imageUrl(id, 0) : S.Common.fileUrl(id);
-
 		this.openDirectoryDialog({ buttonLabel: translate('commonDownload') }, paths => {
-			S.Common.downloadStart(id);
+			files.forEach(file => {
+				const url = file.isImage ? S.Common.imageUrl(file.id, 0) : S.Common.fileUrl(file.id);
 
-			const promise = Renderer.send('download', url, { directory: paths[0] });
-			if (promise && promise.then) {
-				promise.then(() => S.Common.downloadDone(id));
-			} else {
-				S.Common.downloadDone(id);
-			};
+				S.Common.downloadStart(file.id);
+
+				const promise = Renderer.send('download', url, { directory: paths[0] });
+				if (promise && promise.then) {
+					promise.then(() => S.Common.downloadDone(file.id));
+				} else {
+					S.Common.downloadDone(file.id);
+				};
+			});
 
 			analytics.event('DownloadMedia', { route });
 		});


### PR DESCRIPTION
## Problem

In a chat message with **more than one file**, the right-click context menu had **no Download item** at all — it only appeared when a message had exactly one downloadable file. The handler also only ever downloaded the first file (`files[0]`).

Closes JS-9813.

## Solution

The context menu now resolves the **file the user right-clicked on** and shows up to two items:

| Case | Menu |
|---|---|
| 1 file | **Download** |
| Many files, right-clicked a specific file | **Download** (that file) + **Download all** |
| Many files, opened via the "…" more button (no specific file) | **Download all** |

`Action.downloadFiles()` batches a multi-file download through a **single** directory dialog (no N popups).

## Changes

- `src/ts/component/block/chat/attachment/index.tsx` — attachment root carries `data-id` so the clicked file is identifiable.
- `src/ts/component/block/chat.tsx` — `onContextMenu` resolves the clicked file via `closest('.attachment')`; `getMessageMenuOptions` builds the two items; `download` targets the clicked/first file; new `downloadAll` handler.
- `src/ts/lib/action.ts` — new `Action.downloadFiles()` downloads many files through one directory dialog; `downloadFile` delegates to it.
- `src/json/text.json` — added `commonDownloadAll`.

## Testing

- `bun run typecheck` ✅
- `bun run lint` ✅ (biome + eslint clean on changed files)
