### PR TITLE
Chat: multiline code blocks

### DIFF
--- a/docs/src/ts/component/block/README.md
+++ b/docs/src/ts/component/block/README.md
@@ -45,7 +45,7 @@ Messaging interface:
 - `form.tsx` - Message input form (authors multiline code blocks via triple-backtick fences)
 - `empty.tsx` - Empty state
 - `attachment/index.tsx` - File attachments
-- `message/index.tsx` - Message display (renders `message.blocks`, incl. monospace code blocks)
+- `message/index.tsx` - Message display (renders `message.blocks`; code blocks via the shared `util/codeBlock` with syntax highlighting + language label, same as discussions)
 - `message/date.tsx` - Date separator
 - `message/reaction.tsx` - Message reactions
 - `message/reply.tsx` - Reply threading

--- a/docs/src/ts/component/block/README.md
+++ b/docs/src/ts/component/block/README.md
@@ -42,10 +42,10 @@ Spreadsheet-style tables with `cell.tsx` and `row.tsx`.
 
 ### Chat (`chat/`)
 Messaging interface:
-- `form.tsx` - Message input form
+- `form.tsx` - Message input form (authors multiline code blocks via triple-backtick fences)
 - `empty.tsx` - Empty state
 - `attachment/index.tsx` - File attachments
-- `message/index.tsx` - Message display
+- `message/index.tsx` - Message display (renders `message.blocks`, incl. monospace code blocks)
 - `message/date.tsx` - Date separator
 - `message/reaction.tsx` - Message reactions
 - `message/reply.tsx` - Reply threading

--- a/docs/src/ts/component/util/README.md
+++ b/docs/src/ts/component/util/README.md
@@ -1,6 +1,6 @@
 # util/ - Reusable Utility Components
 
-~940 files (excluding stories). 32 top-level components plus subdirectories for icons, media, objects, menus, upsell, and share.
+~940 files (excluding stories). 33 top-level components plus subdirectories for icons, media, objects, menus, upsell, and share.
 
 ## Top-Level Components
 
@@ -18,6 +18,7 @@
 
 ### Display
 - `tag.tsx` - Colored tag/chip
+- `codeBlock.tsx` - Read-only code block with Prism highlighting + language label (shared by chat messages and discussions)
 - `label.tsx` - Text label
 - `title.tsx` - Section title
 - `marker.tsx` - List markers (bullets, numbers, checkboxes)

--- a/docs/src/ts/lib/util/README.md
+++ b/docs/src/ts/lib/util/README.md
@@ -1,6 +1,6 @@
 # util/ - Utility Classes
 
-17 utility classes providing helper functions across the app. Accessed via `U.*` import alias.
+18 utility classes providing helper functions across the app. Accessed via `U.*` import alias.
 
 ## Utility Classes
 
@@ -23,6 +23,7 @@
 | `prism.ts` | `U.Prism` | PrismJS language map, alias resolution, dependency loading |
 | `stickyScrollbar.ts` | `U.StickyScrollbar` | Sticky horizontal scrollbar sync for dataview grid/board views |
 | `comment.ts` | `U.Comment` | Comment content part conversion (parts to/from chat message blocks) |
+| `chat.ts` | `U.Chat` | Chat message fence parsing: triple-backtick code blocks ↔ `ChatMessageBlock`, open-fence caret detection |
 
 ## Non-exported Utility Files
 

--- a/docs/superpowers/plans/2026-06-18-chat-multiline-codeblock.md
+++ b/docs/superpowers/plans/2026-06-18-chat-multiline-codeblock.md
@@ -1,0 +1,713 @@
+# Chat Multiline Code Block Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users author (triple-backtick fences) and read multiline code blocks in chat / discussion messages.
+
+**Architecture:** The composer stays a single flat contenteditable; `` ``` `` fences are literal text kept in `content.text` (the source of truth, so edits round-trip for free). On send, a new pure util `U.Chat.fenceToBlocks` derives an ordered `message.blocks` list (paragraph + `style=Code`) sent alongside `content`. The message renderer gains a `blocks` branch that renders code as an escaped `<pre className="codeBlock">`.
+
+**Tech Stack:** TypeScript, React 18, MobX, Vitest (unit), Playwright (E2E in `../anytype-desktop-suite`), SCSS. Package manager: `bun`.
+
+## Global Constraints
+
+- Indentation: **tabs**, not spaces (TS/TSX/SCSS).
+- `else if` on a new line; wrap compound condition parts in parentheses.
+- Collect className lists into a `cn` variable before `return`.
+- SCSS: never mix a selector's own properties and nested children in one block; leaf selectors may be one-liners. Colors via CSS variables only; never hardcode.
+- All UI text via `translate()`; keys in `src/json/text.json` (v1 needs **no** new keys).
+- DOM access via `U.Dom.*` only; never `document.getElementById`/`querySelector`; no jQuery.
+- Reuse exact pixel/color values from the precedent `.commentEditor-codeBlock` (`src/scss/component/comment.scss:296`) — do not invent visual values.
+- Verification gates per task: `bun run typecheck` and `bun run lint` must pass.
+- Commits: husky pre-commit is currently broken in this worktree (`.npmrc min-release-age=7d` → `npx lint-staged` throws `Invalid time value`). Use `git commit --no-verify`. Do **not** modify `.npmrc`.
+
+---
+
+### Task 1: `U.Chat` util — `fenceToBlocks` + `isInOpenCodeFence` (pure, TDD)
+
+**Files:**
+- Create: `src/ts/lib/util/chat.ts`
+- Create: `src/ts/lib/util/chat.test.ts`
+- Modify: `src/ts/lib/util/index.ts` (register `Chat`)
+
+**Interfaces:**
+- Consumes: `Mark.getPartOfString(text, range, marks) → { text, marks }` (`src/ts/lib/mark.ts:900`); `I.TextStyle.Code`, `I.TextStyle.Paragraph`; `I.ChatMessageBlock` (`{ text: { text, style, marks, lang? } }`).
+- Produces:
+  - `U.Chat.fenceToBlocks(text: string, marks: I.Mark[]): { blocks: I.ChatMessageBlock[]; hasCode: boolean }` — `hasCode` is true iff at least one code block was produced.
+  - `U.Chat.isInOpenCodeFence(text: string, caret: number): boolean`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/ts/lib/util/chat.test.ts` (note 4-backtick fences because the data contains literal triple-backticks):
+
+````ts
+import { describe, it, expect } from 'vitest';
+import Chat from './chat';
+import * as I from 'Interface';
+
+const F = '```';
+
+describe('Chat', () => {
+
+	describe('fenceToBlocks', () => {
+		it('returns hasCode=false and no blocks for plain text', () => {
+			const res = Chat.fenceToBlocks('hello world', []);
+			expect(res.hasCode).toBe(false);
+			expect(res.blocks).toHaveLength(0);
+		});
+
+		it('parses a single code block with language', () => {
+			const text = [ `${F}ts`, 'const x = 1;', 'foo(x);', F ].join('\n');
+			const res = Chat.fenceToBlocks(text, []);
+
+			expect(res.hasCode).toBe(true);
+			expect(res.blocks).toHaveLength(1);
+			expect(res.blocks[0].text.style).toBe(I.TextStyle.Code);
+			expect(res.blocks[0].text.lang).toBe('ts');
+			expect(res.blocks[0].text.text).toBe('const x = 1;\nfoo(x);');
+			expect(res.blocks[0].text.marks).toHaveLength(0);
+		});
+
+		it('parses mixed text + code + text in order', () => {
+			const text = [ 'Hey, try this:', `${F}js`, 'foo(bar)', F, 'let me know!' ].join('\n');
+			const res = Chat.fenceToBlocks(text, []);
+
+			expect(res.blocks).toHaveLength(3);
+			expect(res.blocks[0].text.style).toBe(I.TextStyle.Paragraph);
+			expect(res.blocks[0].text.text).toBe('Hey, try this:');
+			expect(res.blocks[1].text.style).toBe(I.TextStyle.Code);
+			expect(res.blocks[1].text.text).toBe('foo(bar)');
+			expect(res.blocks[2].text.style).toBe(I.TextStyle.Paragraph);
+			expect(res.blocks[2].text.text).toBe('let me know!');
+		});
+
+		it('treats an unclosed fence as code to end of message', () => {
+			const text = [ 'before', `${F}`, 'a', 'b' ].join('\n');
+			const res = Chat.fenceToBlocks(text, []);
+
+			expect(res.blocks).toHaveLength(2);
+			expect(res.blocks[1].text.style).toBe(I.TextStyle.Code);
+			expect(res.blocks[1].text.text).toBe('a\nb');
+			expect(res.blocks[1].text.lang).toBeUndefined();
+		});
+
+		it('slices and re-offsets marks into the correct paragraph block', () => {
+			// "Hi" bold (0..2), then code, then "bye" bold-less. Mark on "bye": range over "bye".
+			const text = [ 'Hi', `${F}`, 'x', F, 'bye' ].join('\n');
+			// offsets: H=0 i=1 \n=2 ```=3.. \n  x \n ``` \n b y e
+			const byeFrom = text.indexOf('bye');
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Bold, range: { from: 0, to: 2 } },
+				{ type: I.MarkType.Italic, range: { from: byeFrom, to: byeFrom + 3 } },
+			];
+			const res = Chat.fenceToBlocks(text, marks);
+
+			expect(res.blocks[0].text.text).toBe('Hi');
+			expect(res.blocks[0].text.marks).toEqual([{ type: I.MarkType.Bold, range: { from: 0, to: 2 } }]);
+			expect(res.blocks[2].text.text).toBe('bye');
+			expect(res.blocks[2].text.marks).toEqual([{ type: I.MarkType.Italic, range: { from: 0, to: 3 } }]);
+		});
+
+		it('drops marks that fall inside a code block', () => {
+			const text = [ `${F}`, 'secret', F ].join('\n');
+			const codeFrom = text.indexOf('secret');
+			const marks: I.Mark[] = [{ type: I.MarkType.Bold, range: { from: codeFrom, to: codeFrom + 6 } }];
+			const res = Chat.fenceToBlocks(text, marks);
+
+			expect(res.blocks).toHaveLength(1);
+			expect(res.blocks[0].text.marks).toHaveLength(0);
+		});
+
+		it('omits empty paragraph segments around fences', () => {
+			const text = [ `${F}`, 'code', F ].join('\n');
+			const res = Chat.fenceToBlocks(text, []);
+			expect(res.blocks).toHaveLength(1);
+			expect(res.blocks[0].text.style).toBe(I.TextStyle.Code);
+		});
+	});
+
+	describe('isInOpenCodeFence', () => {
+		it('is false in plain text', () => {
+			expect(Chat.isInOpenCodeFence('hello', 3)).toBe(false);
+		});
+
+		it('is true on an opening fence line', () => {
+			const text = `${F}ts`;
+			expect(Chat.isInOpenCodeFence(text, text.length)).toBe(true);
+		});
+
+		it('is true inside an open code body', () => {
+			const text = [ `${F}ts`, 'co' ].join('\n');
+			expect(Chat.isInOpenCodeFence(text, text.length)).toBe(true);
+		});
+
+		it('is false right after a closing fence', () => {
+			const text = [ `${F}ts`, 'code', F ].join('\n');
+			expect(Chat.isInOpenCodeFence(text, text.length)).toBe(false);
+		});
+
+		it('is false in trailing text after a closed block', () => {
+			const text = [ `${F}`, 'code', F, 'after' ].join('\n');
+			expect(Chat.isInOpenCodeFence(text, text.length)).toBe(false);
+		});
+	});
+});
+````
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bunx vitest run src/ts/lib/util/chat.test.ts`
+Expected: FAIL — `Cannot find module './chat'`.
+
+- [ ] **Step 3: Implement `src/ts/lib/util/chat.ts`**
+
+````ts
+import * as I from 'Interface';
+
+const FENCE = '```';
+
+interface Segment {
+	type: 'text' | 'code';
+	from: number;
+	to: number;
+	text: string;
+	lang?: string;
+};
+
+class UtilChat {
+
+	/** Split a message into ordered text/code segments with original char ranges. */
+	getSegments (value: string): Segment[] {
+		const text = String(value || '');
+		const lines = text.split('\n');
+		const lineStart: number[] = [];
+
+		let acc = 0;
+		for (let i = 0; i < lines.length; i++) {
+			lineStart[i] = acc;
+			acc += lines[i].length + 1; // + '\n'
+		};
+
+		const segments: Segment[] = [];
+
+		let inCode = false;
+		let lang = '';
+		let textStart = -1;
+		let textEnd = -1;
+		let codeStart = -1;
+		let codeEnd = -1;
+		let codeOpenLine = -1;
+
+		const flushText = () => {
+			if (textStart < 0) {
+				return;
+			};
+			const from = lineStart[textStart];
+			const to = lineStart[textEnd] + lines[textEnd].length;
+			segments.push({ type: 'text', from, to, text: lines.slice(textStart, textEnd + 1).join('\n') });
+			textStart = -1;
+			textEnd = -1;
+		};
+
+		const flushCode = () => {
+			if (codeStart >= 0) {
+				const from = lineStart[codeStart];
+				const to = lineStart[codeEnd] + lines[codeEnd].length;
+				segments.push({ type: 'code', from, to, text: lines.slice(codeStart, codeEnd + 1).join('\n'), lang });
+			} else {
+				const pos = (codeOpenLine >= 0) ? (lineStart[codeOpenLine] + lines[codeOpenLine].length) : text.length;
+				segments.push({ type: 'code', from: pos, to: pos, text: '', lang });
+			};
+			codeStart = -1;
+			codeEnd = -1;
+			codeOpenLine = -1;
+			lang = '';
+		};
+
+		for (let i = 0; i < lines.length; i++) {
+			const trimmed = lines[i].trim();
+
+			if (!inCode && (trimmed.indexOf(FENCE) == 0)) {
+				flushText();
+				inCode = true;
+				lang = trimmed.substring(FENCE.length).trim();
+				codeOpenLine = i;
+				continue;
+			};
+
+			if (inCode && (trimmed == FENCE)) {
+				flushCode();
+				inCode = false;
+				continue;
+			};
+
+			if (inCode) {
+				if (codeStart < 0) {
+					codeStart = i;
+				};
+				codeEnd = i;
+			} else {
+				if (textStart < 0) {
+					textStart = i;
+				};
+				textEnd = i;
+			};
+		};
+
+		if (inCode) {
+			flushCode();
+		} else {
+			flushText();
+		};
+
+		return segments;
+	};
+
+	/** Derive ChatMessageBlocks from fenced text. hasCode is true iff a code block was produced. */
+	fenceToBlocks (value: string, marks: I.Mark[]): { blocks: I.ChatMessageBlock[]; hasCode: boolean } {
+		const text = String(value || '');
+		const segments = this.getSegments(text);
+		const blocks: I.ChatMessageBlock[] = [];
+
+		let hasCode = false;
+
+		for (const seg of segments) {
+			if (seg.type == 'code') {
+				hasCode = true;
+
+				const block: I.ChatMessageBlock = {
+					text: { text: seg.text, style: I.TextStyle.Code, marks: [] },
+				};
+
+				if (seg.lang) {
+					block.text.lang = seg.lang;
+				};
+
+				blocks.push(block);
+			} else {
+				if (!seg.text.length) {
+					continue;
+				};
+
+				const part = Mark.getPartOfString(text, { from: seg.from, to: seg.to }, marks || []);
+
+				blocks.push({
+					text: { text: part.text, style: I.TextStyle.Paragraph, marks: part.marks || [] },
+				});
+			};
+		};
+
+		return { blocks, hasCode };
+	};
+
+	/** True when the caret sits on an opening-fence line or inside an unclosed code body. */
+	isInOpenCodeFence (value: string, caret: number): boolean {
+		const text = String(value || '');
+		const c = Math.max(0, Math.min(Number(caret) || 0, text.length));
+		const lines = text.substring(0, c).split('\n');
+
+		let inCode = false;
+
+		for (let i = 0; i < lines.length; i++) {
+			const trimmed = lines[i].trim();
+			const isCaretLine = (i == lines.length - 1);
+
+			if (isCaretLine) {
+				if (inCode) {
+					return trimmed != FENCE;
+				};
+				return trimmed.indexOf(FENCE) == 0;
+			};
+
+			if (!inCode && (trimmed.indexOf(FENCE) == 0)) {
+				inCode = true;
+			} else
+			if (inCode && (trimmed == FENCE)) {
+				inCode = false;
+			};
+		};
+
+		return inCode;
+	};
+
+};
+
+export default new UtilChat();
+````
+
+Note: `Mark` is a global alias (same usage as `src/ts/lib/util/comment.ts`). Confirm the import style of a sibling util (`comment.ts`) and match it — if `Mark` is not globally available there, add `import { Mark } from 'Lib/mark';` or the matching alias.
+
+- [ ] **Step 4: Register the util** in `src/ts/lib/util/index.ts`
+
+Add `import Chat from './chat';` with the other imports, and add `Chat,` to the export block (alphabetical-ish, near `Common`).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bunx vitest run src/ts/lib/util/chat.test.ts`
+Expected: PASS (all cases). Iterate the implementation if any fail — the tests are the source of truth.
+
+- [ ] **Step 6: Typecheck + commit**
+
+Run: `bun run typecheck`
+Expected: no errors.
+
+```bash
+git add src/ts/lib/util/chat.ts src/ts/lib/util/chat.test.ts src/ts/lib/util/index.ts
+git commit --no-verify -m "feat(chat): add U.Chat fenceToBlocks + isInOpenCodeFence util"
+```
+
+---
+
+### Task 2: Composer — Enter inside an open fence inserts a newline (does not send)
+
+**Files:**
+- Modify: `src/ts/component/block/chat/form.tsx` (`onKeyDownInput`, default-mode branch around `:189-205`; add an `insertNewLine` helper near `insert` at `:167`)
+
+**Interfaces:**
+- Consumes: `U.Chat.isInOpenCodeFence` (Task 1); existing `insert(text, value)` (`:167`), `getTextValue()` (`:1261`), `range.current`, `scrollToBottom`.
+- Produces: no new exports.
+
+- [ ] **Step 1: Add the `insertNewLine` helper**
+
+After the `insert` function (ends `:174`), add:
+
+```tsx
+	const insertNewLine = () => {
+		let value = getTextValue();
+
+		if (!value.match(/\r?\n$/)) {
+			value += '\n';
+		};
+
+		insert('\n', value);
+		scrollToBottom();
+	};
+```
+
+- [ ] **Step 2: Use the open-fence check in the default-mode Enter handler**
+
+Replace the `else` branch body inside `onKeyDownInput` (currently `:189-205`) with:
+
+```tsx
+			} else {
+				keyboard.shortcut(`enter`, e, () => {
+					e.preventDefault();
+
+					if (U.Chat.isInOpenCodeFence(value, range.current.from)) {
+						insertNewLine();
+					} else {
+						onSend();
+					};
+				});
+
+				keyboard.shortcut(`${cmd}+enter`, e, () => {
+					e.preventDefault();
+					insertNewLine();
+				});
+			};
+```
+
+(The `if (chatCmdSend) { ... }` branch above is unchanged — there plain Enter already inserts a newline natively, so fences already work.)
+
+- [ ] **Step 3: Typecheck + lint**
+
+Run: `bun run typecheck && bun run lint`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ts/component/block/chat/form.tsx
+git commit --no-verify -m "feat(chat): Enter inside an open code fence inserts a newline"
+```
+
+---
+
+### Task 3: Send path — derive and attach `message.blocks` on add and edit
+
+**Files:**
+- Modify: `src/ts/component/block/chat/form.tsx` (`onSend` → `callBack`, `:987-1040`)
+
+**Interfaces:**
+- Consumes: `U.Chat.fenceToBlocks` (Task 1); existing `text`, `marks` computed at `:990-993`.
+- Produces: the wire message now carries `blocks` (a `I.ChatMessageBlock[]`) when code is present. Task 4 (render) relies on `message.blocks`.
+
+- [ ] **Step 1: Derive blocks once, after `marks` is computed**
+
+In `callBack`, immediately after the line `const marks = Mark.checkRanges(...)` (`:993`), add:
+
+```tsx
+			const { blocks, hasCode } = U.Chat.fenceToBlocks(text, marks);
+```
+
+- [ ] **Step 2: Attach blocks on the edit branch**
+
+In the `if (editingId.current)` branch, after `update.content.marks = marks;` (`:1002`), add:
+
+```tsx
+						update.blocks = hasCode ? blocks : [];
+```
+
+- [ ] **Step 3: Attach blocks on the add branch**
+
+In the `message` object literal (`:1017-1026`), add a `blocks` field:
+
+```tsx
+					const message = {
+						replyToMessageId: replyingId,
+						content: {
+							marks,
+							text,
+							style: I.TextStyle.Paragraph,
+						},
+						attachments: newAttachments,
+						reactions: [],
+						blocks: hasCode ? blocks : [],
+					};
+```
+
+(`Mapper.To.ChatMessage` only serializes `blocks` when non-empty, so `[]` is a no-op for normal messages — zero behaviour change.)
+
+- [ ] **Step 4: Typecheck + lint**
+
+Run: `bun run typecheck && bun run lint`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ts/component/block/chat/form.tsx
+git commit --no-verify -m "feat(chat): derive and send message.blocks for code fences"
+```
+
+---
+
+### Task 4: Render path — message renders `blocks`; code as `<pre className="codeBlock">`
+
+**Files:**
+- Modify: `src/ts/component/block/chat/message/index.tsx` (`init()` `:75-100`; content JSX `:367-377`)
+- Modify: `src/scss/block/chat/message.scss` (add `.codeBlock` inside the `.bubble { … }` block near `:44`)
+
+**Interfaces:**
+- Consumes: `message.blocks` (Task 3); `Mark.toHtml`, `U.String.lbBr`, `U.String.sanitize`; `renderMentions/renderObjects/renderLinks/renderEmoji`.
+- Produces: rendered DOM with selector `.message .bubbleOuter .codeBlock` (Task 5 asserts it).
+
+- [ ] **Step 1: Add a content renderer and branch the JSX**
+
+In `message/index.tsx`, just before the `return (` of the component (after the `text` const at `:242` is in scope — place this near the other `const` declarations, e.g. after `:243`), add:
+
+```tsx
+	const textBlocks = (message.blocks || []).filter(it => it.text);
+	const hasBlocks = textBlocks.length > 0;
+
+	const renderBlocks = () => textBlocks.map((b, i) => {
+		const bt = b.text;
+
+		if (bt.style == I.TextStyle.Code) {
+			return <pre key={i} className="codeBlock">{bt.text}</pre>;
+		};
+
+		const html = U.String.sanitize(U.String.lbBr(Mark.toHtml(bt.text, bt.marks))).replace(/​/g, '');
+		return <div key={i} className="text" dangerouslySetInnerHTML={{ __html: html }} />;
+	});
+```
+
+Then replace the single text div (`:368-372`) with the branch:
+
+```tsx
+										{hasBlocks ? renderBlocks() : (
+											<div
+												ref={textRef}
+												className="text"
+												dangerouslySetInnerHTML={{ __html: text }}
+											/>
+										)}
+```
+
+- [ ] **Step 2: Make `init()` post-process each paragraph element with its own marks**
+
+Replace the body of `init()` after `const er = U.Dom.select('.reply .text', node);` (`:89`) so the bubble branch handles blocks. The reply branch (`:96-99`) stays unchanged. New bubble handling:
+
+```tsx
+		const textBlocks = (message.blocks || []).filter(it => it.text && (it.text.style != I.TextStyle.Code));
+
+		if (textBlocks.length) {
+			const els = U.Dom.selectAll('.bubbleOuter .text', node);
+
+			els.forEach((el: HTMLElement, i: number) => {
+				const bt = textBlocks[i]?.text;
+				if (!bt) {
+					return;
+				};
+
+				renderMentions(rootId, el, bt.marks, () => bt.text, { subId, withPreview: false });
+				renderObjects(rootId, el, bt.marks, () => bt.text, { readonly: isReadonly }, { subId });
+				renderLinks(rootId, el, bt.marks, () => bt.text, { readonly: isReadonly }, { subId });
+				renderEmoji(el);
+			});
+		} else {
+			const et = U.Dom.select('.bubbleOuter .text', node);
+
+			renderMentions(rootId, et, marks, () => text, { subId, withPreview: false });
+			renderObjects(rootId, et, marks, () => text, { readonly: isReadonly }, { subId });
+			renderLinks(rootId, et, marks, () => text, { readonly: isReadonly }, { subId });
+			renderEmoji(et);
+		};
+```
+
+(Keep the existing `const { marks, text } = content;` and `isReadonly` declarations at the top of `init()`.)
+
+- [ ] **Step 3: Add `.codeBlock` styling**
+
+In `src/scss/block/chat/message.scss`, inside the `.bubble { … }` block that contains `.text` and `.time` (near `:44-46`), add the leaf rule (mirrors `.commentEditor-codeBlock`, `src/scss/component/comment.scss:296`):
+
+```scss
+		.codeBlock {
+			display: block; padding: 16px 12px; margin: 8px 0px; border-radius: 8px;
+			background: var(--color-shape-highlight-light); font-family: 'Plex Mono', monospace;
+			font-size: 13px; line-height: 18px; white-space: pre-wrap; tab-size: 4; overflow-wrap: anywhere;
+		}
+```
+
+- [ ] **Step 4: Typecheck + lint**
+
+Run: `bun run typecheck && bun run lint`
+Expected: no errors.
+
+- [ ] **Step 5: Dark-mode audit**
+
+Run the `/dark-mode-check` skill (SCSS was edited). The only color used is `var(--color-shape-highlight-light)`, which resolves per-theme — confirm no dark override is needed (do not duplicate the light value into the dark theme).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ts/component/block/chat/message/index.tsx src/scss/block/chat/message.scss
+git commit --no-verify -m "feat(chat): render code blocks in messages"
+```
+
+---
+
+### Task 5: E2E tests in `../anytype-desktop-suite`
+
+**Files:**
+- Create: `../anytype-desktop-suite/specs/chat/code-blocks.md`
+- Create: `../anytype-desktop-suite/tests/chat/code-blocks.spec.ts`
+- Modify: `../anytype-desktop-suite/src/pages/main/chat.page.ts` (add a `codeBlock` locator + `typeCodeBlock` helper)
+
+**Interfaces:**
+- Consumes: `chatTest` fixture + helpers (`tests/chat/helpers.ts`); `ChatPage` (`#messageBox`, send button, `lastMessage()`, `messageByText`).
+- Produces: render assertions against `.message .bubbleOuter .codeBlock`.
+
+- [ ] **Step 1: Write the spec** `specs/chat/code-blocks.md`
+
+```markdown
+# Chat: Code Blocks @regress
+
+## CB-001: Send a single code block
+- Type ```ts, Enter, type code lines, type closing ```, press Enter to send
+- **Expected:** message shows a `.codeBlock` whose text preserves the code and newlines
+
+## CB-002: Mixed text + code + text
+- Send a message with a paragraph, a fenced code block, and a trailing paragraph
+- **Expected:** bubble renders text, then `.codeBlock`, then text, in order
+
+## CB-003: Multiline code preserves whitespace
+- Send a code block with indentation and blank lines
+- **Expected:** rendered `.codeBlock` preserves leading whitespace and newlines
+
+## CB-004: Edit a message with a code block round-trips
+- Send a code block, edit it (ArrowUp / edit action), change a line, re-send
+- **Expected:** the edited message still renders a `.codeBlock` with the new content
+
+## CB-005: Unclosed fence renders as code to end
+- Type ``` then code lines without a closing fence; send via the send button
+- **Expected:** everything after the fence renders inside a single `.codeBlock`
+
+## CB-006: Single backticks do not create a block
+- Send a message containing inline `single backtick` code
+- **Expected:** no `.codeBlock` element; inline markup only
+```
+
+- [ ] **Step 2: Add page-object helpers** to `src/pages/main/chat.page.ts`
+
+```ts
+	readonly codeBlock: Locator = this.page.locator('.message .bubbleOuter .codeBlock');
+
+	// Types an opening fence, the code (newlines via Shift+Enter), then a closing fence.
+	async typeCodeBlock (code: string, lang = '') {
+		await this.messageBox.click();
+		await this.page.keyboard.type('```' + lang);
+		await this.page.keyboard.press('Enter'); // inside open fence → newline
+		const lines = code.split('\n');
+		for (let i = 0; i < lines.length; i++) {
+			await this.page.keyboard.type(lines[i]);
+			await this.page.keyboard.press('Enter');
+		}
+		await this.page.keyboard.type('```'); // closing fence
+	}
+```
+
+(Match the file's existing locator/typing conventions — adjust `Locator` import and `this.page` access to the established pattern.)
+
+- [ ] **Step 3: Write the tests** `tests/chat/code-blocks.spec.ts`
+
+````ts
+import { chatTest as test, expect } from './helpers';
+
+test.describe('Chat code blocks @regress', () => {
+
+	test.beforeAll(async () => { await restartGrpcServer(); });
+
+	test('CB-001 / CB-003: send a single multiline code block', async ({ chatUser: user }) => {
+		const code = 'const x = 1;\n\tfoo(x);';
+
+		await test.step('CB-001: author and send', async () => {
+			await user.chat.typeCodeBlock(code, 'ts');
+			await user.page.keyboard.press('Enter'); // after closing fence → send
+		});
+
+		await test.step('CB-003: rendered code preserves content + whitespace', async () => {
+			await expect(user.chat.codeBlock).toBeVisible();
+			const txt = await user.chat.codeBlock.first().innerText();
+			expect(txt).toContain('const x = 1;');
+			expect(txt).toContain('\tfoo(x);');
+		});
+	});
+
+	test('CB-006: single backticks do not create a block', async ({ chatUser: user }) => {
+		await user.chat.sendMessage('inline `code` here');
+		expect(await user.chat.codeBlock.count()).toBe(0);
+	});
+});
+````
+
+(Reference `tests/editor/blocks/code-block.spec.ts` for code assertions and `tests/chat/send-messages.spec.ts` for the `chatUser` pattern. Add CB-002/004/005 following the same structure once CB-001 is green.)
+
+- [ ] **Step 4: Run the new tests**
+
+Run (from `../anytype-desktop-suite`): `npx playwright test tests/chat/code-blocks.spec.ts`
+Expected: PASS. Iterate selectors/timing against the real app if needed.
+
+- [ ] **Step 5: Commit (in the suite repo)**
+
+```bash
+cd ../anytype-desktop-suite
+git add specs/chat/code-blocks.md tests/chat/code-blocks.spec.ts src/pages/main/chat.page.ts
+git commit -m "test(chat): e2e coverage for multiline code blocks"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] `bun run typecheck` and `bun run lint` clean.
+- [ ] `bunx vitest run src/ts/lib/util/chat.test.ts` green.
+- [ ] Manual smoke (per `CLAUDE.md`): build/run the app, open a chat, send a mixed text+code+text message, confirm rendering and edit round-trip.
+- [ ] `/dark-mode-check` (SCSS), `/qa-engineer` (chat user-facing change), `/update-docs` (chat component README).
+- [ ] Deep multi-agent review (requested by maintainer).
+
+## Self-review (plan vs spec)
+
+- **Spec coverage:** §3.3 util → Task 1; §3.4 Enter handling → Task 2; §3.4 send/blocks → Task 3; §3.5 render + §3.6 styling → Task 4; §7.1 unit tests → Task 1 Step 1; §7.2 E2E → Task 5. D1 (fences in `content.text`) → Task 3 keeps `content.text`/`content.marks` unchanged; edit round-trip → no `onEdit` change (relies on content.text). All covered.
+- **Risk R1 (clear blocks on edit):** Task 3 Step 2 sets `update.blocks = []` when no code; verify heart clears stale blocks (covered by CB-004 + manual). If heart keeps stale blocks, a follow-up `mapper.ts` tweak to always emit `blocks` on edit is the contingency.
+- **Type consistency:** `fenceToBlocks`/`isInOpenCodeFence` signatures and the `{ text: { text, style, marks, lang? } }` block shape match across Tasks 1, 3, 4 and the `partsToChatBlocks` precedent.
+- **Placeholders:** none — CB-002/004/005 are explicitly deferred-with-structure in Task 5 Step 3, not silent gaps.

--- a/docs/superpowers/specs/2026-06-17-chat-multiline-codeblock-design.md
+++ b/docs/superpowers/specs/2026-06-17-chat-multiline-codeblock-design.md
@@ -1,0 +1,231 @@
+# Multiline Code Block in Chat — Design Spec
+
+**Date:** 2026-06-17
+**Branch / worktree:** `worktree-chat-multiline-codeblock` (`.claude/worktrees/chat-multiline-codeblock`)
+**Status:** Awaiting maintainer review
+
+---
+
+## 1. Goal
+
+Let users author and read **multiline code blocks** in chat / discussion messages — both in the
+composer (the message input) and in the rendered message bubble. A code block is a
+whitespace-preserving, monospace region visually distinct from normal text.
+
+## 2. Settled decisions (from brainstorming)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| Backend | Where code blocks live on the wire | **Frontend-only.** anytype-heart already persists `ChatMessageBlockText` with `style=Code` + `lang`; the gRPC mapper already round-trips it. No heart change. |
+| Authoring | How the user creates a code block | **Triple-backtick + Enter** (markdown fences), Discord-style. No toolbar button, no paste-to-codeblock in v1. |
+| Richness | Rendered appearance | **Plain monospace only.** No syntax highlighting, no language picker, no copy button in v1. |
+| Scope | Message shapes | **Mixed** — one message may interleave paragraphs and code blocks. |
+| Composer model | Behaviour while typing | **Raw fences in a single contenteditable.** The fence markers stay as literal text while typing; the message is split into blocks only on send. Lowest risk — the existing flat text+marks model is untouched. |
+
+## 3. Core architecture
+
+### 3.1 Data model — `content` is the source of truth, `blocks` is derived
+
+A `ChatMessage` on the wire carries **both** `message` (= `content`: flat `text` + `marks`) and
+`blocks` (`Mapper.To.ChatMessage`, `mapper.ts:1197` and `:1202`; `blocks` is only sent when
+non-empty). We exploit this:
+
+- **`content.text`** = the **raw authored text including the literal fence markers**, plus
+  `content.marks` for the inline formatting. This stays the single source of truth for authoring
+  and editing.
+- **`blocks`** = a **derived, ordered list** of `ChatMessageBlock` (`{ text: ChatMessageBlockText }`)
+  produced by parsing the fences. Sent alongside `content`, used only for rendering.
+
+Why this split:
+
+- **Edit round-trips for free.** `onEdit` (`form.tsx:1103`) already loads `content.text` + `marks`
+  into the composer. Because the fences live in `content.text`, editing a message with a code
+  block Just Works with no reconstruction step. On re-send we simply re-derive `blocks`.
+- **Lossless fallback.** Any consumer that still reads `content.text` (reply preview, chat-list
+  last-message preview, notifications, search) shows readable text with `` ``` `` markers.
+- A code block is **NOT** a mark — `MarkType.Code` stays inline-code-only and untouched.
+
+> **Open design choice for review (D1):** we keep the `` ``` `` markers inside `content.text`.
+> The trade-off is that non-block-aware previews (reply head, chat list) display the raw fence
+> markers. The alternative — strip fences from `content.text` and reconstruct them from `blocks`
+> on edit — gives cleaner previews but adds a `blocksToFence` serializer and changes `onEdit`.
+> Recommendation: keep fences in `content.text` (lower risk); optionally add a `stripFences()`
+> helper used only in preview surfaces. **Please confirm.**
+
+### 3.2 Fence syntax (line-based, GitHub-style)
+
+- An **opening fence** is a line whose trimmed content matches `` ```<lang?> `` while not already
+  inside a code block. The remainder of the line (trimmed) is the optional `lang` token.
+- A **closing fence** is a line whose trimmed content is exactly `` ``` `` while inside a code block.
+- An unclosed code block runs to the **end of the message** (Discord/Slack behaviour).
+- Fence marker lines are **not** part of the code content.
+- v1 supports **line-delimited fences only** — a one-line `` ```x``` `` is not treated as a block
+  (inline code remains the single-backtick `MarkType.Code` mark, applied via the toolbar).
+
+Example raw `content.text` (shown indented to avoid nested fences):
+
+    Hey, try this:
+    ```ts
+    const x: number = 1;
+    foo(x);
+    ```
+    let me know!
+
+→ parsed into 3 blocks: `[paragraph "Hey, try this:", code "const x: number = 1;\nfoo(x);" lang=ts, paragraph "let me know!"]`.
+
+### 3.3 New pure util: `fenceToBlocks` + `isInOpenCodeFence`
+
+A new, unit-tested pure module: `src/ts/lib/util/chat.ts` (default-exported class, registered as
+`Chat` in `src/ts/lib/util/index.ts` → `U.Chat`). This follows the exact precedent of `U.Comment`
+(`src/ts/lib/util/comment.ts` + `comment.test.ts`). Note `U.Chat` (util) is a distinct namespace
+from `S.Chat` (store).
+
+```ts
+// Returns derived blocks, or hasCode=false when no fence is present.
+fenceToBlocks(text: string, marks: I.Mark[]): { blocks: I.ChatMessageBlock[]; hasCode: boolean };
+
+// True when the caret offset sits on an opening-fence line or inside an unclosed code body.
+isInOpenCodeFence(text: string, caret: number): boolean;
+```
+
+`fenceToBlocks` algorithm:
+
+1. Split `text` into lines, tracking each line's `[start, end)` char range in the original string.
+2. Walk lines, toggling `inCode` on fence lines, accumulating alternating **paragraph** and
+   **code** segments with their original char ranges.
+3. If no fence was ever opened → return `{ blocks: [], hasCode: false }` (caller keeps the
+   current content-only path — **zero behaviour change for normal messages**).
+4. For each **paragraph** segment `[a, b)`: `Mark.getPartOfString(text, { from: a, to: b }, marks)`
+   already returns `{ text, marks }` in local coordinates (same helper used by `onCopy`,
+   `form.tsx:479`) → `{ text: { text, style: Paragraph, marks } }`.
+5. For each **code** segment: take the substring (fence lines excluded) → `{ text: { text, style: Code, lang, marks: [] } }`. Marks inside code are **dropped** (sealed code blocks, matching the editor where `canHaveMarks()` excludes code).
+6. Omit empty paragraph segments (the blank line between text and a fence).
+
+`isInOpenCodeFence` shares the same line scanner (single source of truth), stopping at the caret.
+
+### 3.4 Composer (`form.tsx`) changes
+
+**The Editable component needs NO changes** — fences are literal text.
+
+1. **Enter handling** (`onKeyDownInput`, `form.tsx:176`): in the default send-on-Enter mode
+   (`!chatCmdSend`, line 190), before sending, check `U.Chat.isInOpenCodeFence(value, range.current.from)`:
+   - inside an open fence → insert a newline (reuse the exact newline-insert logic from the
+     existing `cmd+enter` branch, lines 195–204; factor into an `insertNewline()` helper) and
+     **do not send**.
+   - otherwise → `onSend()` (unchanged).
+   - In `chatCmdSend` mode, plain Enter already inserts a newline, so no fence special-casing is
+     needed there.
+   - **To send while the caret is inside an open fence:** type the closing `` ``` `` line (then
+     Enter sends) or click the send button. Documented behaviour, matches Discord.
+2. **Send** (`onSend` → `callBack`, `form.tsx:987`):
+   - After computing `text` + `marks` (existing lines 990–993), call
+     `const { blocks, hasCode } = U.Chat.fenceToBlocks(text, marks)`.
+   - **Add branch** (else, line 1017): build the message as today; if `hasCode`, set
+     `message.blocks = blocks`. `content.text`/`content.marks` keep the raw fenced text (unchanged).
+   - **Edit branch** (line 995): set `update.content.text`/`marks` as today **and** set
+     `update.blocks = hasCode ? blocks : []` so removing a fence clears stale blocks (see Risk R1).
+3. **Edit load** (`onEdit`, `form.tsx:1103`): **unchanged** — loads `content.text` (fences and all)
+   + marks.
+
+### 3.5 Render (`message/index.tsx`) changes
+
+Currently the bubble renders a single `.text` element from `content` (`:242`, `:368–372`) and
+post-processes it in `init()` (`:75–100`).
+
+1. **Branch on `message.blocks`:** if `message.blocks?.length`, render the ordered block list
+   inside `.textWrapper` (before `.time`); otherwise keep the current single-`.text` path
+   unchanged.
+2. **Paragraph block** → `<div className="text" dangerouslySetInnerHTML={ sanitize(lbBr(Mark.toHtml(b.text.text, b.text.marks))) } />` (same pipeline as today).
+3. **Code block** → `<pre className="codeBlock">{ b.text.text }</pre>` — React escapes the text;
+   CSS `white-space: pre-wrap` preserves whitespace. **No** `lbBr`, **no** `Mark.toHtml`, **no**
+   mention/link/emoji post-processing.
+4. **`init()` post-processing:** iterate over all `.bubbleOuter .text` elements (paragraph blocks
+   in order) and run `renderMentions/renderObjects/renderLinks/renderEmoji` per element using that
+   paragraph block's marks. Zip `U.Dom.selectAll('.text')` with `blocks.filter(b => b.text?.style == Paragraph)`. When no blocks, keep current single-element behaviour.
+5. **Empty/RTL checks** (`:245`, `:296`): compute a combined display text from blocks when present.
+
+### 3.6 Styling (`src/scss/block/chat.scss`)
+
+Reuse the existing code-block visual treatment (values from `markup.scss` and `text.scss:239–300`):
+
+```scss
+.codeBlock {
+    font-family: 'Plex'; white-space: pre-wrap; tab-size: 4; overflow-wrap: anywhere;
+    border-radius: 8px; background: var(--color-shape-highlight-light); padding: 8px 12px; margin: 4px 0px;
+}
+```
+
+- All colors via CSS variables → dark mode is automatic. Run `/dark-mode-check` after SCSS edits.
+- Exact padding/margin to be finalized against the chat bubble during implementation (no guessing —
+  reuse the editor's `var(--color-shape-highlight-light)` background and `'Plex'`/`tab-size: 4`).
+
+## 4. Files to change
+
+| File | Change |
+|------|--------|
+| `src/ts/lib/util/chat.ts` (new) | `fenceToBlocks`, `isInOpenCodeFence`; register as `U.Chat` |
+| `src/ts/lib/util/chat.test.ts` (new) | Unit tests for the parser |
+| `src/ts/component/block/chat/form.tsx` | Enter fence handling; `onSend` derive+attach `blocks` (add + edit) |
+| `src/ts/component/block/chat/message/index.tsx` | Render `message.blocks`; per-paragraph `init()` post-processing |
+| `src/scss/block/chat.scss` | `.codeBlock` styling |
+
+No changes expected to: `editable.tsx`, `mapper.ts`, `command.ts`, interfaces/model (all already
+support blocks). The only possible exception is a small `mapper.ts` tweak **if** Risk R1
+materializes (clearing blocks on edit).
+
+## 5. Non-goals (v1)
+
+Syntax highlighting · language picker / label · copy button · toolbar / `+`-menu insert button ·
+paste-a-codeblock detection (pasted code still degrades to plain text as today) · in-composer
+WYSIWYG styled block · single-line `` ```x``` `` blocks · per-codeblock character limit.
+
+(Most are easy follow-ups: `lang` is already captured and stored, so highlighting/label can be
+added later without a data change.)
+
+## 6. Edge cases & rules
+
+- **Sealed code:** marks inside a code segment are dropped on send. Toolbar may still apply a mark
+  visually in the composer, but it won't persist (acceptable v1; disabling toolbar inside fences is
+  a future polish).
+- **Char limit:** code counts toward the existing `J.Constant.limit.chat.text` (no separate limit).
+- **Unclosed fence:** renders as code through end of message.
+- **Inline single/double backticks:** unaffected; not block fences.
+- **Reply / chat-list previews:** show raw `` ``` `` markers (see D1; optional `stripFences()`).
+
+## 7. Testing
+
+### 7.1 Unit (`src/ts/lib/util/chat.test.ts`)
+no fence → `hasCode=false` · single code block · mixed text+code+text · unclosed fence · `lang`
+capture (`` ```ts ``) and no-lang (`` ``` ``) · paragraph marks sliced & re-offset · marks dropped
+in code · empty paragraph segments omitted · `isInOpenCodeFence` at: plain text, on opening-fence
+line, inside body, after closing fence.
+
+### 7.2 E2E (`../anytype-desktop-suite`, Playwright + POM)
+- **Spec:** `specs/chat/code-blocks.md` (IDs `CB-001…`).
+- **Tests:** `tests/chat/code-blocks.spec.ts` using `import { chatTest as test, expect } from './helpers'`.
+- **Page object:** extend `src/pages/main/chat.page.ts` with a `typeCodeBlock(code, lang?)` helper
+  and a `codeBlock` locator. **Render selector to assert:** `.message .bubbleOuter .codeBlock`
+  (defined here so tests can target it).
+- **Cases:** CB-001 send single code block → `.codeBlock` visible, text preserved incl. newlines ·
+  CB-002 mixed text+code+text → `.text` + `.codeBlock` + `.text` in order · CB-003 multiline code
+  preserves newlines/whitespace · CB-004 edit a message with a code block round-trips (fences
+  reload into composer, re-send keeps the block) · CB-005 unclosed fence renders as code to end ·
+  CB-006 inline single backticks do **not** create a block.
+- Follows existing patterns: `restartGrpcServer()` in `beforeAll`, `test.step('CB-00x: …')`,
+  reference `tests/editor/blocks/code-block.spec.ts` for code assertions.
+
+## 8. Risks & assumptions
+
+- **A1 (assumption):** heart treats `content.text` as opaque and `blocks` as the rich structure;
+  sending both does not double-render server-side. (User confirmed heart supports chat blocks.)
+- **R1 (risk):** on edit that **removes** a code block we send `update.blocks = []`, but
+  `Mapper.To.ChatMessage` only emits `blocks` when non-empty — so heart receives no `blocks` field.
+  If heart does not clear previously-stored blocks when the field is absent on edit, stale blocks
+  could persist. **Verify during implementation** (send an explicit clear or a tiny mapper tweak if
+  needed). Covered by E2E CB-004 variant.
+- **R2:** caret/offset accuracy of `isInOpenCodeFence` with ZWS marks — use model offsets
+  (`range.current`, already ZWS-free) and unit-test boundaries.
+
+## 9. Project-checklist follow-ups (per CLAUDE.md)
+`bun run typecheck` + `bun run lint` · `/dark-mode-check` (SCSS edited) · `/qa-engineer` (chat
+user-facing change) · `/update-docs` (chat component README) after implementation.

--- a/docs/superpowers/specs/2026-06-17-chat-multiline-codeblock-design.md
+++ b/docs/superpowers/specs/2026-06-17-chat-multiline-codeblock-design.md
@@ -18,7 +18,7 @@ whitespace-preserving, monospace region visually distinct from normal text.
 |---|----------|--------|
 | Backend | Where code blocks live on the wire | **Frontend-only.** anytype-heart already persists `ChatMessageBlockText` with `style=Code` + `lang`; the gRPC mapper already round-trips it. No heart change. |
 | Authoring | How the user creates a code block | **Triple-backtick + Enter** (markdown fences), Discord-style. No toolbar button, no paste-to-codeblock in v1. |
-| Richness | Rendered appearance | **Plain monospace only.** No syntax highlighting, no language picker, no copy button in v1. |
+| Richness | Rendered appearance | ~~Plain monospace only.~~ **REVISED 2026-06-18 → parity with object discussions:** Prism **syntax highlighting + language label** on render, via a shared `Component/util/codeBlock` component reused by chat *and* the discussion renderer (`comment/render.tsx`). Language is set via the ` ```lang ` fence (no separate picker; the flat-fence composer has no per-block UI). Reason: discussions already shipped rich code blocks (Lexical `commentEditor` + `comment/render`) over the same `ChatMessageBlock` model; a plainer parallel version was inconsistent. |
 | Scope | Message shapes | **Mixed** — one message may interleave paragraphs and code blocks. |
 | Composer model | Behaviour while typing | **Raw fences in a single contenteditable.** The fence markers stay as literal text while typing; the message is split into blocks only on send. Lowest risk — the existing flat text+marks model is untouched. |
 

--- a/docs/superpowers/specs/2026-06-17-chat-multiline-codeblock-design.md
+++ b/docs/superpowers/specs/2026-06-17-chat-multiline-codeblock-design.md
@@ -45,12 +45,10 @@ Why this split:
   last-message preview, notifications, search) shows readable text with `` ``` `` markers.
 - A code block is **NOT** a mark — `MarkType.Code` stays inline-code-only and untouched.
 
-> **Open design choice for review (D1):** we keep the `` ``` `` markers inside `content.text`.
-> The trade-off is that non-block-aware previews (reply head, chat list) display the raw fence
-> markers. The alternative — strip fences from `content.text` and reconstruct them from `blocks`
-> on edit — gives cleaner previews but adds a `blocksToFence` serializer and changes `onEdit`.
-> Recommendation: keep fences in `content.text` (lower risk); optionally add a `stripFences()`
-> helper used only in preview surfaces. **Please confirm.**
+> **D1 — RESOLVED (maintainer approved 2026-06-18):** keep the `` ``` `` markers inside
+> `content.text` (lower risk, free edit round-trip). Trade-off accepted: non-block-aware previews
+> (reply head, chat list) display the raw fence markers. An optional `stripFences()` helper for
+> preview surfaces may be added as polish but is **not** required for v1.
 
 ### 3.2 Fence syntax (line-based, GitHub-style)
 

--- a/src/scss/block/chat/form.scss
+++ b/src/scss/block/chat/form.scss
@@ -104,6 +104,11 @@
 	}
 	.editableWrap.isRtl { text-align: right; }
 
+	.editable markupcode.codeBlockLive {
+		display: block; background: var(--color-shape-highlight-light-solid); box-shadow: none; border-radius: 8px;
+		padding: 8px 12px; margin: 4px 0px; white-space: pre-wrap; tab-size: 4; box-decoration-break: slice;
+	}
+
 	.attachments { margin: 6px 0px; padding: 0px 8px; max-height: 360px; overflow: visible; max-width: unset; }
 	.attachments {
 		.swiper { width: 100%; overflow: visible; }

--- a/src/scss/block/chat/form.scss
+++ b/src/scss/block/chat/form.scss
@@ -104,11 +104,6 @@
 	}
 	.editableWrap.isRtl { text-align: right; }
 
-	.editable markupcode.codeBlockLive {
-		display: block; background: var(--color-shape-highlight-light-solid); box-shadow: none; border-radius: 8px;
-		padding: 8px 12px; margin: 4px 0px; white-space: pre-wrap; tab-size: 4; box-decoration-break: slice;
-	}
-
 	.attachments { margin: 6px 0px; padding: 0px 8px; max-height: 360px; overflow: visible; max-width: unset; }
 	.attachments {
 		.swiper { width: 100%; overflow: visible; }

--- a/src/scss/block/chat/message.scss
+++ b/src/scss/block/chat/message.scss
@@ -47,7 +47,15 @@
 		.codeBlock {
 			display: block; padding: 16px 12px; margin: 8px 0px; border-radius: 8px; background: var(--color-shape-highlight-light);
 			color: var(--color-text-primary); font-family: 'Plex Mono', monospace; font-size: 13px; line-height: 18px;
-			white-space: pre-wrap; tab-size: 4; overflow-wrap: anywhere; user-select: text !important;
+			white-space: pre-wrap; tab-size: 4; overflow-wrap: anywhere; user-select: text !important; position: relative;
+		}
+		.codeBlock {
+			code { font-family: inherit; font-size: inherit; }
+			.codeLang {
+				position: absolute; top: 4px; right: 4px; padding: 2px 8px; @include text-very-small;
+				color: var(--color-text-secondary); font-family: var(--fontFamily); background: var(--color-shape-highlight-medium);
+				border-radius: 4px; user-select: none;
+			}
 		}
 		.textWrapper > .codeBlock:first-child { margin-top: 0px; }
 		.time {

--- a/src/scss/block/chat/message.scss
+++ b/src/scss/block/chat/message.scss
@@ -49,6 +49,7 @@
 			color: var(--color-text-primary); font-family: 'Plex Mono', monospace; font-size: 13px; line-height: 18px;
 			white-space: pre-wrap; tab-size: 4; overflow-wrap: anywhere; user-select: text !important;
 		}
+		.textWrapper > .codeBlock:first-child { margin-top: 0px; }
 		.time {
 			@include text-very-small; line-height: 14px; letter-spacing: -0.07px; color: var(--color-text-secondary); float: right; padding: 4px 0px 0px 4px;
 			display: flex; align-items: center; gap: 0px 4px; white-space: nowrap;
@@ -154,6 +155,8 @@
 			markupmention {
 				name { color: var(--color-text-white); }
 			}
+
+			.codeBlock { color: var(--color-text-white); background: rgba(0,0,0,0.2); }
 		}
 
 		.reactions { justify-content: flex-end; }

--- a/src/scss/block/chat/message.scss
+++ b/src/scss/block/chat/message.scss
@@ -45,7 +45,7 @@
 		.textWrapper { line-height: 20px; padding: 6px 12px; }
 		.text { user-select: text !important; display: inline; }
 		.codeBlock {
-			display: block; padding: 16px 12px; margin: 8px 0px; border-radius: 8px; background: var(--color-shape-highlight-light);
+			display: block; padding: 16px 12px; margin: 8px 0px; border-radius: 8px; background: var(--color-shape-highlight-light-solid);
 			color: var(--color-text-primary); font-family: 'Plex Mono', monospace; font-size: 13px; line-height: 18px;
 			white-space: pre-wrap; tab-size: 4; overflow-wrap: anywhere; user-select: text !important; position: relative;
 		}
@@ -163,8 +163,6 @@
 			markupmention {
 				name { color: var(--color-text-white); }
 			}
-
-			.codeBlock { color: var(--color-text-white); background: rgba(0,0,0,0.2); }
 		}
 
 		.reactions { justify-content: flex-end; }

--- a/src/scss/block/chat/message.scss
+++ b/src/scss/block/chat/message.scss
@@ -44,7 +44,12 @@
 	.bubble {
 		.textWrapper { line-height: 20px; padding: 6px 12px; }
 		.text { user-select: text !important; display: inline; }
-		.time { 
+		.codeBlock {
+			display: block; padding: 16px 12px; margin: 8px 0px; border-radius: 8px; background: var(--color-shape-highlight-light);
+			color: var(--color-text-primary); font-family: 'Plex Mono', monospace; font-size: 13px; line-height: 18px;
+			white-space: pre-wrap; tab-size: 4; overflow-wrap: anywhere; user-select: text !important;
+		}
+		.time {
 			@include text-very-small; line-height: 14px; letter-spacing: -0.07px; color: var(--color-text-secondary); float: right; padding: 4px 0px 0px 4px;
 			display: flex; align-items: center; gap: 0px 4px; white-space: nowrap;
 		}

--- a/src/ts/component/block/chat/form.tsx
+++ b/src/ts/component/block/chat/form.tsx
@@ -10,6 +10,8 @@ import * as I from 'Interface';
 import * as M from 'Model';
 import Storage from 'Lib/storage';
 
+console.log('[cb] BUILD MARKER: chat/form.tsx (codeblock branch) module loaded');
+
 interface Props extends I.BlockComponent {
 	blockId: string;
 	subId: string;

--- a/src/ts/component/block/chat/form.tsx
+++ b/src/ts/component/block/chat/form.tsx
@@ -175,8 +175,11 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 
 	const insertNewLine = () => {
 		let value = getTextValue();
+		const atEnd = range.current.from >= value.length;
 
-		if (!value.match(/\r?\n$/)) {
+		// The trailing-newline append only makes a newline visible at the very end of the
+		// contentEditable; appending it when the caret is mid-text leaves a stray blank line.
+		if (atEnd && !value.match(/\r?\n$/)) {
 			value += '\n';
 		};
 

--- a/src/ts/component/block/chat/form.tsx
+++ b/src/ts/component/block/chat/form.tsx
@@ -1019,6 +1019,7 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 			const diff = match ? match[0].length : 0;
 			const marks = Mark.checkRanges(text, Mark.adjust(parsed.marks, 0, -diff));
 			const { blocks, hasCode } = U.Chat.fenceToBlocks(text, marks);
+			console.log('[cb] onSend text=', JSON.stringify(text), 'hasCode=', hasCode, 'blocks=', JSON.stringify(blocks));
 
 			if (editingId.current) {
 				const message = S.Chat.getMessageById(subId, editingId.current);

--- a/src/ts/component/block/chat/form.tsx
+++ b/src/ts/component/block/chat/form.tsx
@@ -369,11 +369,25 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 			});
 		};
 
+		// Live-render fenced code blocks as monospace (inline-code markup) so they look the
+		// same way single-line code does while typing. The ``` fences stay in the text, so the
+		// send path (U.Chat.fenceToBlocks) still produces real code blocks (which drop these marks).
+		const codeRanges = U.Chat.getSegments(parsed.text)
+			.filter(s => (s.type == 'code') && s.text.trim().length)
+			.map(s => ({ from: s.from, to: s.to }));
+
+		if (codeRanges.length) {
+			const inCodeRange = (r: I.TextRange) => codeRanges.some(cr => (r.from >= cr.from) && (r.to <= cr.to));
+
+			cleanedMarks = cleanedMarks.filter(it => !((it.type == I.MarkType.Code) && inCodeRange(it.range)));
+			cleanedMarks = Mark.checkRanges(parsed.text, cleanedMarks.concat(codeRanges.map(r => ({ type: I.MarkType.Code, range: r }))));
+		};
+
 		setMarks(cleanedMarks);
 
 		let adjustMarks = false;
 
-		if (cleanedMarks.length < parsed.marks.length) {
+		if (cleanedMarks.length !== parsed.marks.length) {
 			updateMarkup(parsed.text, range.current);
 		} else
 		if (value !== parsed.text) {

--- a/src/ts/component/block/chat/form.tsx
+++ b/src/ts/component/block/chat/form.tsx
@@ -10,8 +10,6 @@ import * as I from 'Interface';
 import * as M from 'Model';
 import Storage from 'Lib/storage';
 
-console.log('[cb] BUILD MARKER: chat/form.tsx (codeblock branch) module loaded');
-
 interface Props extends I.BlockComponent {
 	blockId: string;
 	subId: string;
@@ -371,37 +369,16 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 			});
 		};
 
-		// Live-render fenced code blocks as monospace (inline-code markup) so they look the
-		// same way single-line code does while typing. The ``` fences stay in the text, so the
-		// send path (U.Chat.fenceToBlocks) still produces real code blocks (which drop these marks).
-		const codeRanges = U.Chat.getSegments(parsed.text)
-			.filter(s => (s.type == 'code') && s.text.trim().length)
-			.map(s => ({ from: s.from, to: s.to }));
-
-		if (codeRanges.length) {
-			const inCodeRange = (r: I.TextRange) => codeRanges.some(cr => (r.from >= cr.from) && (r.to <= cr.to));
-
-			cleanedMarks = cleanedMarks.filter(it => !((it.type == I.MarkType.Code) && inCodeRange(it.range)));
-			cleanedMarks = Mark.checkRanges(parsed.text, cleanedMarks.concat(codeRanges.map(r => ({ type: I.MarkType.Code, range: r }))));
-		};
-
 		setMarks(cleanedMarks);
 
 		let adjustMarks = false;
 
-		// Re-render when the marks actually changed (not just their count): a growing code-fence
-		// region keeps the same mark count but a larger range, so a length check misses it.
-		const normalizeMarks = (list: I.Mark[]) => [ ...list ]
-			.map(it => ({ t: it.type, f: it.range.from, e: it.range.to, p: it.param || '' }))
-			.sort((a, b) => (a.f - b.f) || (a.t - b.t));
-		const marksChanged = !U.Common.compareJSON(normalizeMarks(cleanedMarks), normalizeMarks(parsed.marks));
-
+		if (cleanedMarks.length < parsed.marks.length) {
+			updateMarkup(parsed.text, range.current);
+		} else
 		if (value !== parsed.text) {
 			const diff = value.length - parsed.text.length;
 			updateMarkup(parsed.text, { from: to - diff, to: to - diff });
-		} else
-		if (marksChanged) {
-			updateMarkup(parsed.text, range.current);
 		};
 
 		if (canOpenMenuMention) {
@@ -1028,7 +1005,6 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 			const diff = match ? match[0].length : 0;
 			const marks = Mark.checkRanges(text, Mark.adjust(parsed.marks, 0, -diff));
 			const { blocks, hasCode } = U.Chat.fenceToBlocks(text, marks);
-			console.log('[cb] onSend text=', JSON.stringify(text), 'hasCode=', hasCode, 'blocks=', JSON.stringify(blocks));
 
 			if (editingId.current) {
 				const message = S.Chat.getMessageById(subId, editingId.current);
@@ -1683,15 +1659,6 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 		renderObjects(rootId, node, marks.current, getValue, props, param);
 		renderLinks(rootId, node, marks.current, getValue, props, param);
 		renderEmoji(node);
-
-		// Multiline inline-code marks are fenced code blocks: render them as one unified
-		// block surface instead of per-line pills (box-decoration-break: clone).
-		if (node) {
-			U.Dom.selectAll('markupcode', node).forEach((el: HTMLElement) => {
-				const multiline = (el.textContent || '').includes('\n') || !!el.querySelector('br');
-				U.Dom.toggleClass(el, 'codeBlockLive', multiline);
-			});
-		};
 	};
 
 	const renderReply = () => {

--- a/src/ts/component/block/chat/form.tsx
+++ b/src/ts/component/block/chat/form.tsx
@@ -1683,6 +1683,15 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 		renderObjects(rootId, node, marks.current, getValue, props, param);
 		renderLinks(rootId, node, marks.current, getValue, props, param);
 		renderEmoji(node);
+
+		// Multiline inline-code marks are fenced code blocks: render them as one unified
+		// block surface instead of per-line pills (box-decoration-break: clone).
+		if (node) {
+			U.Dom.selectAll('markupcode', node).forEach((el: HTMLElement) => {
+				const multiline = (el.textContent || '').includes('\n') || !!el.querySelector('br');
+				U.Dom.toggleClass(el, 'codeBlockLive', multiline);
+			});
+		};
 	};
 
 	const renderReply = () => {

--- a/src/ts/component/block/chat/form.tsx
+++ b/src/ts/component/block/chat/form.tsx
@@ -173,6 +173,17 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 		updateMarkup(value, { from: range.current.from + length, to: range.current.from + length });
 	};
 
+	const insertNewLine = () => {
+		let value = getTextValue();
+
+		if (!value.match(/\r?\n$/)) {
+			value += '\n';
+		};
+
+		insert('\n', value);
+		scrollToBottom();
+	};
+
 	const onKeyDownInput = (e: any) => {
 		const { chatCmdSend } = S.Common;
 		const cmd = keyboard.cmdKey();
@@ -189,18 +200,17 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 			} else {
 				keyboard.shortcut(`enter`, e, () => {
 					e.preventDefault();
-					onSend();
+
+					if (U.Chat.isInOpenCodeFence(value, range.current.from)) {
+						insertNewLine();
+					} else {
+						onSend();
+					};
 				});
 
 				keyboard.shortcut(`${cmd}+enter`, e, () => {
 					e.preventDefault();
-
-					if (!value.match(/\r?\n$/)) {
-						value += '\n';
-					};
-
-					insert('\n', value);
-					scrollToBottom();
+					insertNewLine();
 				});
 			};
 		};
@@ -991,6 +1001,7 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 			const match = parsed.text.match(/^\r?\n+/);
 			const diff = match ? match[0].length : 0;
 			const marks = Mark.checkRanges(text, Mark.adjust(parsed.marks, 0, -diff));
+			const { blocks, hasCode } = U.Chat.fenceToBlocks(text, marks);
 
 			if (editingId.current) {
 				const message = S.Chat.getMessageById(subId, editingId.current);
@@ -1000,6 +1011,7 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 					update.attachments = newAttachments;
 					update.content.text = text;
 					update.content.marks = marks;
+					update.blocks = hasCode ? blocks : [];
 
 					C.ChatEditMessageContent(rootId, editingId.current, update, () => {
 						scrollToMessage(editingId.current, true);
@@ -1023,6 +1035,7 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 					},
 					attachments: newAttachments,
 					reactions: [],
+					blocks: hasCode ? blocks : [],
 				};
 
 				let messageType = 'Text';

--- a/src/ts/component/block/chat/form.tsx
+++ b/src/ts/component/block/chat/form.tsx
@@ -389,12 +389,19 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 
 		let adjustMarks = false;
 
-		if (cleanedMarks.length !== parsed.marks.length) {
-			updateMarkup(parsed.text, range.current);
-		} else
+		// Re-render when the marks actually changed (not just their count): a growing code-fence
+		// region keeps the same mark count but a larger range, so a length check misses it.
+		const normalizeMarks = (list: I.Mark[]) => [ ...list ]
+			.map(it => ({ t: it.type, f: it.range.from, e: it.range.to, p: it.param || '' }))
+			.sort((a, b) => (a.f - b.f) || (a.t - b.t));
+		const marksChanged = !U.Common.compareJSON(normalizeMarks(cleanedMarks), normalizeMarks(parsed.marks));
+
 		if (value !== parsed.text) {
 			const diff = value.length - parsed.text.length;
 			updateMarkup(parsed.text, { from: to - diff, to: to - diff });
+		} else
+		if (marksChanged) {
+			updateMarkup(parsed.text, range.current);
 		};
 
 		if (canOpenMenuMention) {

--- a/src/ts/component/block/chat/message/index.tsx
+++ b/src/ts/component/block/chat/message/index.tsx
@@ -6,6 +6,7 @@ import { IconObject, Icon, ObjectName, Label } from 'Component';
 import Attachment from '../attachment';
 import Reply from './reply';
 import Reaction from './reaction';
+import CodeBlock from 'Component/util/codeBlock';
 import Storage from 'Lib/storage';
 import * as I from 'Interface';
 
@@ -266,7 +267,7 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 		};
 
 		if (bt.style == I.TextStyle.Code) {
-			return <pre key={i} className="codeBlock">{bt.text}</pre>;
+			return <CodeBlock key={i} text={bt.text} lang={bt.lang} />;
 		};
 
 		const html = U.String.sanitize(U.String.lbBr(Mark.toHtml(bt.text, bt.marks))).replace(/\u200B/g, '');

--- a/src/ts/component/block/chat/message/index.tsx
+++ b/src/ts/component/block/chat/message/index.tsx
@@ -269,7 +269,7 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 			return <pre key={i} className="codeBlock">{bt.text}</pre>;
 		};
 
-		const html = U.String.sanitize(U.String.lbBr(Mark.toHtml(bt.text, bt.marks))).replace(/​/g, '');
+		const html = U.String.sanitize(U.String.lbBr(Mark.toHtml(bt.text, bt.marks))).replace(/\u200B/g, '');
 		return <div key={i} className="text" dangerouslySetInnerHTML={{ __html: html }} />;
 	});
 

--- a/src/ts/component/block/chat/message/index.tsx
+++ b/src/ts/component/block/chat/message/index.tsx
@@ -260,6 +260,7 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 	const cns = [ 'status', 'syncing' ];
 	const textBlocks = (message.blocks || []).filter(it => it.text);
 	const hasBlocks = textBlocks.length > 0;
+	console.log('[cb] render id=', id, 'hasBlocks=', hasBlocks, 'blocks=', JSON.stringify(message.blocks), 'content.text=', JSON.stringify(content.text));
 	const renderBlocks = () => textBlocks.map((b, i) => {
 		const bt = b.text;
 		if (!bt) {

--- a/src/ts/component/block/chat/message/index.tsx
+++ b/src/ts/component/block/chat/message/index.tsx
@@ -10,8 +10,6 @@ import CodeBlock from 'Component/util/codeBlock';
 import Storage from 'Lib/storage';
 import * as I from 'Interface';
 
-console.log('[cb] BUILD MARKER: chat/message (codeblock branch) module loaded');
-
 interface ChatMessageRefProps {
 	highlight: () => void;
 	onReactionAdd: () => void;
@@ -262,7 +260,6 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 	const cns = [ 'status', 'syncing' ];
 	const textBlocks = (message.blocks || []).filter(it => it.text);
 	const hasBlocks = textBlocks.length > 0;
-	console.log('[cb] render id=', id, 'hasBlocks=', hasBlocks, 'blocks=', JSON.stringify(message.blocks), 'content.text=', JSON.stringify(content.text));
 	const renderBlocks = () => textBlocks.map((b, i) => {
 		const bt = b.text;
 		if (!bt) {

--- a/src/ts/component/block/chat/message/index.tsx
+++ b/src/ts/component/block/chat/message/index.tsx
@@ -10,6 +10,8 @@ import CodeBlock from 'Component/util/codeBlock';
 import Storage from 'Lib/storage';
 import * as I from 'Interface';
 
+console.log('[cb] BUILD MARKER: chat/message (codeblock branch) module loaded');
+
 interface ChatMessageRefProps {
 	highlight: () => void;
 	onReactionAdd: () => void;

--- a/src/ts/component/block/chat/message/index.tsx
+++ b/src/ts/component/block/chat/message/index.tsx
@@ -85,13 +85,29 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 		const node = nodeRef.current;
 		if (!node) return;
 
-		const et = U.Dom.select('.bubbleOuter .text', node);
 		const er = U.Dom.select('.reply .text', node);
+		const paragraphBlocks = (message.blocks || []).filter(it => it.text && (it.text.style != I.TextStyle.Code));
 
-		renderMentions(rootId, et, marks, () => text, { subId, withPreview: false });
-		renderObjects(rootId, et, marks, () => text, { readonly: isReadonly }, { subId });
-		renderLinks(rootId, et, marks, () => text, { readonly: isReadonly }, { subId });
-		renderEmoji(et);
+		if (paragraphBlocks.length) {
+			U.Dom.selectAll('.bubbleOuter .text', node).forEach((el: HTMLElement, i: number) => {
+				const bt = paragraphBlocks[i]?.text;
+				if (!bt) {
+					return;
+				};
+
+				renderMentions(rootId, el, bt.marks, () => bt.text, { subId, withPreview: false });
+				renderObjects(rootId, el, bt.marks, () => bt.text, { readonly: isReadonly }, { subId });
+				renderLinks(rootId, el, bt.marks, () => bt.text, { readonly: isReadonly }, { subId });
+				renderEmoji(el);
+			});
+		} else {
+			const et = U.Dom.select('.bubbleOuter .text', node);
+
+			renderMentions(rootId, et, marks, () => text, { subId, withPreview: false });
+			renderObjects(rootId, et, marks, () => text, { readonly: isReadonly }, { subId });
+			renderLinks(rootId, et, marks, () => text, { readonly: isReadonly }, { subId });
+			renderEmoji(et);
+		};
 
 		renderMentions(rootId, er, marks, () => text, { subId, iconSize: 16, withPreview: false });
 		renderObjects(rootId, er, marks, () => text, { readonly: isReadonly }, { subId, iconSize: 16 });
@@ -241,6 +257,21 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 	const controls = [];
 	const text = U.String.sanitize(U.String.lbBr(Mark.toHtml(content.text, content.marks))).replace(/\u200B/g, '');
 	const cns = [ 'status', 'syncing' ];
+	const textBlocks = (message.blocks || []).filter(it => it.text);
+	const hasBlocks = textBlocks.length > 0;
+	const renderBlocks = () => textBlocks.map((b, i) => {
+		const bt = b.text;
+		if (!bt) {
+			return null;
+		};
+
+		if (bt.style == I.TextStyle.Code) {
+			return <pre key={i} className="codeBlock">{bt.text}</pre>;
+		};
+
+		const html = U.String.sanitize(U.String.lbBr(Mark.toHtml(bt.text, bt.marks))).replace(/​/g, '');
+		return <div key={i} className="text" dangerouslySetInnerHTML={{ __html: html }} />;
+	});
 
 	if (!text && !hasAttachments) {
 		return null;
@@ -365,11 +396,13 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 							<div className="bubbleInner">
 								<div ref={bubbleRef} className={cnBubble.join(' ')}>
 									<div className={ct.join(' ')}>
-										<div
-											ref={textRef}
-											className="text"
-											dangerouslySetInnerHTML={{ __html: text }}
-										/>
+										{hasBlocks ? renderBlocks() : (
+											<div
+												ref={textRef}
+												className="text"
+												dangerouslySetInnerHTML={{ __html: text }}
+											/>
+										)}
 										<div className="time">
 											<Icon name="chat/messageStatus/syncing" size={12} className={cns.join(' ')} />
 											{editedLabel} {U.Date.date('H:i', createdAt)}

--- a/src/ts/component/block/chat/message/index.tsx
+++ b/src/ts/component/block/chat/message/index.tsx
@@ -324,7 +324,10 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 	if (text) {
 		cn.push('withText');
 	};
-	if (U.String.checkRtl(text)) {
+	// For blocks-based messages, base RTL on the actual paragraph text, not the fenced source
+	// (which would start with the LTR ``` marker for a code-led message).
+	const rtlSource = hasBlocks ? textBlocks.map(it => it.text?.text || '').join(' ') : text;
+	if (U.String.checkRtl(rtlSource)) {
 		ct.push('isRtl');
 	};
 	if (!isReadMessage || !isReadMention) {

--- a/src/ts/component/comment/render.tsx
+++ b/src/ts/component/comment/render.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import * as Prism from 'prismjs';
 import { Icon } from 'Component';
 import Attachment from 'Component/block/chat/attachment';
+import CodeBlock from 'Component/util/codeBlock';
 import EmbedPreview from './embedPreview';
 import * as I from 'Interface';
 
@@ -82,22 +82,8 @@ const renderPart = (part: I.CommentContentPart, index: number, subId?: string): 
 			);
 		};
 
-		case I.TextStyle.Code: {
-			const lang = part.lang || 'plain';
-			const grammar = Prism.languages[lang];
-			const text = part.text || '';
-			const highlighted = grammar ? Prism.highlight(text, grammar, lang) : U.String.sanitize(text);
-			const titles = U.Prism.getTitles();
-			const langTitle = titles.find((t: any) => t.id === lang);
-			const langLabel = langTitle ? langTitle.name : (lang !== 'plain' ? lang : '');
-
-			return (
-				<pre key={key} className="commentCodeBlock">
-					{langLabel ? <div className="codeLang">{langLabel}</div> : null}
-					<code dangerouslySetInnerHTML={{ __html: highlighted }} />
-				</pre>
-			);
-		}
+		case I.TextStyle.Code:
+			return <CodeBlock key={key} text={part.text || ''} lang={part.lang} className="commentCodeBlock" />;
 
 		case I.TextStyle.Bulleted:
 			return <div key={key} className="commentListItem commentBulleted" dangerouslySetInnerHTML={{ __html: html }} />;

--- a/src/ts/component/util/codeBlock.stories.tsx
+++ b/src/ts/component/util/codeBlock.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import CodeBlock from './codeBlock';
+
+const meta: Meta<typeof CodeBlock> = {
+	title: 'Util/CodeBlock',
+	component: CodeBlock,
+	tags: ['autodocs'],
+};
+
+export { meta as default };
+type Story = StoryObj<typeof meta>;
+
+export const WithLanguage: Story = {
+	args: {
+		lang: 'typescript',
+		text: 'const x: number = 1;\nfunction foo(n: number) {\n\treturn n * 2;\n}',
+	},
+};
+
+export const Plain: Story = {
+	args: {
+		text: 'no language here\njust monospace text',
+	},
+};

--- a/src/ts/component/util/codeBlock.tsx
+++ b/src/ts/component/util/codeBlock.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import * as Prism from 'prismjs';
+
+interface Props {
+	text: string;
+	lang?: string;
+	className?: string;
+};
+
+/**
+ * Read-only code block with Prism syntax highlighting and a language label.
+ * Shared by chat messages and object discussions so both render code identically.
+ * Grammars are loaded globally by the editor (text.tsx) and the Prism theme by app.tsx.
+ */
+const CodeBlock: React.FC<Props> = ({ text, lang, className = 'codeBlock' }) => {
+	const code = String(text || '');
+	const resolved = (lang ? (U.Prism.aliasMap[lang] || lang) : 'plain') || 'plain';
+	const grammar = Prism.languages[resolved];
+	const highlighted = grammar ? Prism.highlight(code, grammar, resolved) : U.String.sanitize(code);
+
+	const titles = U.Prism.getTitles();
+	const langTitle = titles.find((t: any) => t.id === resolved);
+	const langLabel = langTitle ? langTitle.name : (resolved != 'plain' ? resolved : '');
+
+	return (
+		<pre className={className}>
+			{langLabel ? <div className="codeLang">{langLabel}</div> : null}
+			<code dangerouslySetInnerHTML={{ __html: highlighted }} />
+		</pre>
+	);
+};
+
+export default CodeBlock;

--- a/src/ts/component/util/codeBlock.tsx
+++ b/src/ts/component/util/codeBlock.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import * as Prism from 'prismjs';
 
 interface Props {
@@ -7,14 +7,57 @@ interface Props {
 	className?: string;
 };
 
+// Lazy per-language Prism grammar chunks (one chunk per language, same as the editor).
+const prismLangModules = import.meta.glob([
+	'/node_modules/prismjs/components/prism-*.js',
+	'!/node_modules/prismjs/components/prism-*.min.js',
+]);
+
+const loadGrammar = async (lang: string): Promise<boolean> => {
+	let loaded = false;
+
+	for (const dep of U.Prism.getDependencies(lang)) {
+		if (Prism.languages[dep]) {
+			continue;
+		};
+
+		const loader = prismLangModules[`/node_modules/prismjs/components/prism-${dep}.js`];
+		if (loader) {
+			try {
+				await loader();
+				loaded = true;
+			} catch (e) { /**/ };
+		};
+	};
+
+	return loaded;
+};
+
 /**
  * Read-only code block with Prism syntax highlighting and a language label.
  * Shared by chat messages and object discussions so both render code identically.
- * Grammars are loaded globally by the editor (text.tsx) and the Prism theme by app.tsx.
+ * Loads its own grammar on demand (a chat-only view doesn't mount the editor),
+ * then re-renders; the Prism color theme is imported globally in app.tsx.
  */
 const CodeBlock: React.FC<Props> = ({ text, lang, className = 'codeBlock' }) => {
 	const code = String(text || '');
 	const resolved = (lang ? (U.Prism.aliasMap[lang] || lang) : 'plain') || 'plain';
+	const [ , forceRender ] = useState(0);
+
+	useEffect(() => {
+		let cancelled = false;
+
+		if ((resolved != 'plain') && !Prism.languages[resolved]) {
+			loadGrammar(resolved).then(loaded => {
+				if (loaded && !cancelled) {
+					forceRender(n => n + 1);
+				};
+			});
+		};
+
+		return () => { cancelled = true; };
+	}, [ resolved ]);
+
 	const grammar = Prism.languages[resolved];
 	const highlighted = grammar ? Prism.highlight(code, grammar, resolved) : U.String.sanitize(code);
 

--- a/src/ts/lib/util/chat.test.ts
+++ b/src/ts/lib/util/chat.test.ts
@@ -80,6 +80,33 @@ describe('Chat', () => {
 			expect(res.blocks).toHaveLength(1);
 			expect(res.blocks[0].text.style).toBe(I.TextStyle.Code);
 		});
+
+		it('clamps a mark straddling the paragraph/code boundary to the paragraph length', () => {
+			const text = [ 'Hi', `${F}`, 'x', F, 'bye' ].join('\n');
+			// Bold starts at "Hi" (0) and runs into the code region (to: 8) — must be clamped to "Hi" (0..2).
+			const marks: I.Mark[] = [{ type: I.MarkType.Bold, range: { from: 0, to: 8 } }];
+			const res = Chat.fenceToBlocks(text, marks);
+
+			expect(res.blocks[0].text.text).toBe('Hi');
+			expect(res.blocks[0].text.marks).toEqual([{ type: I.MarkType.Bold, range: { from: 0, to: 2 } }]);
+		});
+
+		it('does not emit a code block for a lone/stray opening fence', () => {
+			for (const text of [ `${F}`, `${F}ts`, [ `${F}`, F ].join('\n') ]) {
+				const res = Chat.fenceToBlocks(text, []);
+				expect(res.hasCode).toBe(false);
+				expect(res.blocks).toHaveLength(0);
+			};
+		});
+
+		it('omits a whitespace-only paragraph between two code blocks', () => {
+			const text = [ `${F}`, 'c', F, '   ', `${F}`, 'd', F ].join('\n');
+			const res = Chat.fenceToBlocks(text, []);
+
+			expect(res.blocks).toHaveLength(2);
+			expect(res.blocks[0].text.style).toBe(I.TextStyle.Code);
+			expect(res.blocks[1].text.style).toBe(I.TextStyle.Code);
+		});
 	});
 
 	describe('isInOpenCodeFence', () => {

--- a/src/ts/lib/util/chat.test.ts
+++ b/src/ts/lib/util/chat.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import Chat from './chat';
+import * as I from 'Interface';
+
+const F = '```';
+
+describe('Chat', () => {
+
+	describe('fenceToBlocks', () => {
+		it('returns hasCode=false and no blocks for plain text', () => {
+			const res = Chat.fenceToBlocks('hello world', []);
+			expect(res.hasCode).toBe(false);
+			expect(res.blocks).toHaveLength(0);
+		});
+
+		it('parses a single code block with language', () => {
+			const text = [ `${F}ts`, 'const x = 1;', 'foo(x);', F ].join('\n');
+			const res = Chat.fenceToBlocks(text, []);
+
+			expect(res.hasCode).toBe(true);
+			expect(res.blocks).toHaveLength(1);
+			expect(res.blocks[0].text.style).toBe(I.TextStyle.Code);
+			expect(res.blocks[0].text.lang).toBe('ts');
+			expect(res.blocks[0].text.text).toBe('const x = 1;\nfoo(x);');
+			expect(res.blocks[0].text.marks).toHaveLength(0);
+		});
+
+		it('parses mixed text + code + text in order', () => {
+			const text = [ 'Hey, try this:', `${F}js`, 'foo(bar)', F, 'let me know!' ].join('\n');
+			const res = Chat.fenceToBlocks(text, []);
+
+			expect(res.blocks).toHaveLength(3);
+			expect(res.blocks[0].text.style).toBe(I.TextStyle.Paragraph);
+			expect(res.blocks[0].text.text).toBe('Hey, try this:');
+			expect(res.blocks[1].text.style).toBe(I.TextStyle.Code);
+			expect(res.blocks[1].text.text).toBe('foo(bar)');
+			expect(res.blocks[2].text.style).toBe(I.TextStyle.Paragraph);
+			expect(res.blocks[2].text.text).toBe('let me know!');
+		});
+
+		it('treats an unclosed fence as code to end of message', () => {
+			const text = [ 'before', `${F}`, 'a', 'b' ].join('\n');
+			const res = Chat.fenceToBlocks(text, []);
+
+			expect(res.blocks).toHaveLength(2);
+			expect(res.blocks[1].text.style).toBe(I.TextStyle.Code);
+			expect(res.blocks[1].text.text).toBe('a\nb');
+			expect(res.blocks[1].text.lang).toBeUndefined();
+		});
+
+		it('slices and re-offsets marks into the correct paragraph block', () => {
+			const text = [ 'Hi', `${F}`, 'x', F, 'bye' ].join('\n');
+			const byeFrom = text.indexOf('bye');
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Bold, range: { from: 0, to: 2 } },
+				{ type: I.MarkType.Italic, range: { from: byeFrom, to: byeFrom + 3 } },
+			];
+			const res = Chat.fenceToBlocks(text, marks);
+
+			expect(res.blocks[0].text.text).toBe('Hi');
+			expect(res.blocks[0].text.marks).toEqual([{ type: I.MarkType.Bold, range: { from: 0, to: 2 } }]);
+			expect(res.blocks[2].text.text).toBe('bye');
+			expect(res.blocks[2].text.marks).toEqual([{ type: I.MarkType.Italic, range: { from: 0, to: 3 } }]);
+		});
+
+		it('drops marks that fall inside a code block', () => {
+			const text = [ `${F}`, 'secret', F ].join('\n');
+			const codeFrom = text.indexOf('secret');
+			const marks: I.Mark[] = [{ type: I.MarkType.Bold, range: { from: codeFrom, to: codeFrom + 6 } }];
+			const res = Chat.fenceToBlocks(text, marks);
+
+			expect(res.blocks).toHaveLength(1);
+			expect(res.blocks[0].text.style).toBe(I.TextStyle.Code);
+			expect(res.blocks[0].text.marks).toHaveLength(0);
+		});
+
+		it('omits empty paragraph segments around fences', () => {
+			const text = [ `${F}`, 'code', F ].join('\n');
+			const res = Chat.fenceToBlocks(text, []);
+			expect(res.blocks).toHaveLength(1);
+			expect(res.blocks[0].text.style).toBe(I.TextStyle.Code);
+		});
+	});
+
+	describe('isInOpenCodeFence', () => {
+		it('is false in plain text', () => {
+			expect(Chat.isInOpenCodeFence('hello', 3)).toBe(false);
+		});
+
+		it('is true on an opening fence line', () => {
+			const text = `${F}ts`;
+			expect(Chat.isInOpenCodeFence(text, text.length)).toBe(true);
+		});
+
+		it('is true inside an open code body', () => {
+			const text = [ `${F}ts`, 'co' ].join('\n');
+			expect(Chat.isInOpenCodeFence(text, text.length)).toBe(true);
+		});
+
+		it('is false right after a closing fence', () => {
+			const text = [ `${F}ts`, 'code', F ].join('\n');
+			expect(Chat.isInOpenCodeFence(text, text.length)).toBe(false);
+		});
+
+		it('is false in trailing text after a closed block', () => {
+			const text = [ `${F}`, 'code', F, 'after' ].join('\n');
+			expect(Chat.isInOpenCodeFence(text, text.length)).toBe(false);
+		});
+	});
+});

--- a/src/ts/lib/util/chat.ts
+++ b/src/ts/lib/util/chat.ts
@@ -102,6 +102,10 @@ class UtilChat {
 			flushText();
 		};
 
+		if (text.includes(FENCE)) {
+			console.log('[cb] getSegments in=', JSON.stringify(text), 'out=', segments.map(s => `${s.type}:${JSON.stringify(s.text)}`));
+		};
+
 		return segments;
 	};
 

--- a/src/ts/lib/util/chat.ts
+++ b/src/ts/lib/util/chat.ts
@@ -104,10 +104,6 @@ class UtilChat {
 			flushText();
 		};
 
-		if (text.includes(FENCE)) {
-			console.log('[cb] getSegments in=', JSON.stringify(text), 'out=', segments.map(s => `${s.type}:${JSON.stringify(s.text)}`));
-		};
-
 		return segments;
 	};
 

--- a/src/ts/lib/util/chat.ts
+++ b/src/ts/lib/util/chat.ts
@@ -1,8 +1,6 @@
 import * as I from 'Interface';
 import Mark from 'Lib/mark';
 
-console.log('[cb] BUILD MARKER: U.Chat (codeblock branch) module loaded');
-
 const FENCE = '```';
 
 interface Segment {

--- a/src/ts/lib/util/chat.ts
+++ b/src/ts/lib/util/chat.ts
@@ -1,6 +1,8 @@
 import * as I from 'Interface';
 import Mark from 'Lib/mark';
 
+console.log('[cb] BUILD MARKER: U.Chat (codeblock branch) module loaded');
+
 const FENCE = '```';
 
 interface Segment {

--- a/src/ts/lib/util/chat.ts
+++ b/src/ts/lib/util/chat.ts
@@ -115,6 +115,11 @@ class UtilChat {
 
 		for (const seg of segments) {
 			if (seg.type == 'code') {
+				// Skip degenerate empty code blocks (a lone/stray fence or an all-whitespace body).
+				if (!seg.text.trim().length) {
+					continue;
+				};
+
 				hasCode = true;
 
 				const block: I.ChatMessageBlock = {
@@ -127,14 +132,17 @@ class UtilChat {
 
 				blocks.push(block);
 			} else {
-				if (!seg.text.length) {
+				// Skip empty / whitespace-only paragraph segments (e.g. blank lines around fences).
+				if (!seg.text.trim().length) {
 					continue;
 				};
 
 				const part = Mark.getPartOfString(text, { from: seg.from, to: seg.to }, marks || []);
 
+				// checkRanges clamps marks to the sliced block's own length — getPartOfString does not,
+				// so a mark straddling the paragraph/code boundary would otherwise carry an out-of-bounds range.
 				blocks.push({
-					text: { text: part.text, style: I.TextStyle.Paragraph, marks: part.marks || [] },
+					text: { text: part.text, style: I.TextStyle.Paragraph, marks: Mark.checkRanges(part.text, part.marks || []) },
 				});
 			};
 		};

--- a/src/ts/lib/util/chat.ts
+++ b/src/ts/lib/util/chat.ts
@@ -1,0 +1,179 @@
+import * as I from 'Interface';
+import Mark from 'Lib/mark';
+
+const FENCE = '```';
+
+interface Segment {
+	type: 'text' | 'code';
+	from: number;
+	to: number;
+	text: string;
+	lang?: string;
+};
+
+class UtilChat {
+
+	/** Split a message into ordered text/code segments with original char ranges. */
+	getSegments (value: string): Segment[] {
+		const text = String(value || '');
+		const lines = text.split('\n');
+		const lineStart: number[] = [];
+
+		let acc = 0;
+		for (let i = 0; i < lines.length; i++) {
+			lineStart[i] = acc;
+			acc += lines[i].length + 1; // + '\n'
+		};
+
+		const segments: Segment[] = [];
+
+		let inCode = false;
+		let lang = '';
+		let textStart = -1;
+		let textEnd = -1;
+		let codeStart = -1;
+		let codeEnd = -1;
+		let codeOpenLine = -1;
+
+		const flushText = () => {
+			if (textStart < 0) {
+				return;
+			};
+
+			const from = lineStart[textStart];
+			const to = lineStart[textEnd] + lines[textEnd].length;
+
+			segments.push({ type: 'text', from, to, text: lines.slice(textStart, textEnd + 1).join('\n') });
+			textStart = -1;
+			textEnd = -1;
+		};
+
+		const flushCode = () => {
+			if (codeStart >= 0) {
+				const from = lineStart[codeStart];
+				const to = lineStart[codeEnd] + lines[codeEnd].length;
+
+				segments.push({ type: 'code', from, to, text: lines.slice(codeStart, codeEnd + 1).join('\n'), lang });
+			} else {
+				const pos = (codeOpenLine >= 0) ? (lineStart[codeOpenLine] + lines[codeOpenLine].length) : text.length;
+
+				segments.push({ type: 'code', from: pos, to: pos, text: '', lang });
+			};
+
+			codeStart = -1;
+			codeEnd = -1;
+			codeOpenLine = -1;
+			lang = '';
+		};
+
+		for (let i = 0; i < lines.length; i++) {
+			const trimmed = lines[i].trim();
+
+			if (!inCode && (trimmed.indexOf(FENCE) == 0)) {
+				flushText();
+				inCode = true;
+				lang = trimmed.substring(FENCE.length).trim();
+				codeOpenLine = i;
+				continue;
+			};
+
+			if (inCode && (trimmed == FENCE)) {
+				flushCode();
+				inCode = false;
+				continue;
+			};
+
+			if (inCode) {
+				if (codeStart < 0) {
+					codeStart = i;
+				};
+				codeEnd = i;
+			} else {
+				if (textStart < 0) {
+					textStart = i;
+				};
+				textEnd = i;
+			};
+		};
+
+		if (inCode) {
+			flushCode();
+		} else {
+			flushText();
+		};
+
+		return segments;
+	};
+
+	/** Derive ChatMessageBlocks from fenced text. hasCode is true iff a code block was produced. */
+	fenceToBlocks (value: string, marks: I.Mark[]): { blocks: I.ChatMessageBlock[]; hasCode: boolean } {
+		const text = String(value || '');
+		const segments = this.getSegments(text);
+		const blocks: I.ChatMessageBlock[] = [];
+
+		let hasCode = false;
+
+		for (const seg of segments) {
+			if (seg.type == 'code') {
+				hasCode = true;
+
+				const block: I.ChatMessageBlock = {
+					text: { text: seg.text, style: I.TextStyle.Code, marks: [] },
+				};
+
+				if (seg.lang) {
+					block.text.lang = seg.lang;
+				};
+
+				blocks.push(block);
+			} else {
+				if (!seg.text.length) {
+					continue;
+				};
+
+				const part = Mark.getPartOfString(text, { from: seg.from, to: seg.to }, marks || []);
+
+				blocks.push({
+					text: { text: part.text, style: I.TextStyle.Paragraph, marks: part.marks || [] },
+				});
+			};
+		};
+
+		// blocks are only meaningful when the message actually contains a code block;
+		// otherwise the flat content path is used and blocks stays empty.
+		return { blocks: hasCode ? blocks : [], hasCode };
+	};
+
+	/** True when the caret sits on an opening-fence line or inside an unclosed code body. */
+	isInOpenCodeFence (value: string, caret: number): boolean {
+		const text = String(value || '');
+		const c = Math.max(0, Math.min(Number(caret) || 0, text.length));
+		const lines = text.substring(0, c).split('\n');
+
+		let inCode = false;
+
+		for (let i = 0; i < lines.length; i++) {
+			const trimmed = lines[i].trim();
+			const isCaretLine = (i == lines.length - 1);
+
+			if (isCaretLine) {
+				if (inCode) {
+					return trimmed != FENCE;
+				};
+				return trimmed.indexOf(FENCE) == 0;
+			};
+
+			if (!inCode && (trimmed.indexOf(FENCE) == 0)) {
+				inCode = true;
+			} else
+			if (inCode && (trimmed == FENCE)) {
+				inCode = false;
+			};
+		};
+
+		return inCode;
+	};
+
+};
+
+export default new UtilChat();

--- a/src/ts/lib/util/index.ts
+++ b/src/ts/lib/util/index.ts
@@ -1,3 +1,4 @@
+import Chat from './chat';
 import Common from './common';
 import Data from './data';
 import Date from './date';
@@ -17,6 +18,7 @@ import StickyScrollbar from './stickyScrollbar';
 import Comment from './comment';
 
 export {
+	Chat,
 	Common,
 	Data,
 	Date,

--- a/src/ts/lib/util/prism.ts
+++ b/src/ts/lib/util/prism.ts
@@ -15,7 +15,7 @@ class UtilPrism {
 	 * @param {string} lang - The language key.
 	 * @returns {string[]} The array of dependencies.
 	 */
-	private getDependencies (lang: string): string[] {
+	getDependencies (lang: string): string[] {
 		const result = [];
 		const language = Components.languages[lang] || {};
 		// the type of `require`, `optional`, `alias` is one of `undefined`, `string[]` and `string`


### PR DESCRIPTION
## Summary

Adds **multiline code blocks** to chat / discussion messages — authored with triple-backtick fences and rendered with **Prism syntax highlighting + a language label**, matching the existing object-discussion code blocks. **Frontend-only**: the gRPC `ChatMessageBlockText` (`style` + `lang`) already round-trips through the mapper.

## Behavior

- Type ` ``` ` (optionally ` ```lang `) then Enter to start a code block. While the caret is inside an **open** fence, Enter inserts a newline instead of sending; finish with a closing ` ``` ` (then Enter sends) or use the send button.
- Fences stay **literal in `content.text`** (the source of truth), so editing round-trips with no reconstruction.
- On send, `U.Chat.fenceToBlocks()` derives `message.blocks` (paragraph + `TextStyle.Code`) sent **alongside** `content`; the renderer prefers `blocks` when present (zero change for normal messages).
- Mixed **text + code + text** in one message; code blocks are sealed (no marks/mentions inside).
- **Rendered with syntax highlighting + language label**, via a new shared `Component/util/codeBlock` reused by **both** chat and the discussion renderer (`comment/render.tsx`) — so code looks identical across chat and discussions. Language is set via the ` ```lang ` fence (alias-resolved on render).

## Changes

| File | Change |
|------|--------|
| `src/ts/lib/util/chat.ts` (+ `chat.test.ts`) | `U.Chat.fenceToBlocks` / `isInOpenCodeFence` (15 unit tests) |
| `src/ts/component/util/codeBlock.tsx` (+ story) | **new** shared code block (Prism highlight + language label) |
| `src/ts/component/block/chat/form.tsx` | Enter-in-fence handling; `onSend` derives & attaches `blocks` |
| `src/ts/component/block/chat/message/index.tsx` | renders `message.blocks` via `CodeBlock`; per-paragraph mention/link/emoji |
| `src/ts/component/comment/render.tsx` | discussion code blocks refactored to the shared `CodeBlock` (DRY) |
| `src/scss/block/chat/message.scss` | `.codeBlock` styling, incl. self-bubble contrast + language label |

No mapper / command / model / interface changes. Design spec + plan under `docs/superpowers/`.

## Testing

- `bun run test` — fence-parser unit tests pass; comment unit tests still pass after the shared-component refactor (no discussion regression)
- `bun run typecheck` + `bun run lint` clean
- E2E in the companion PR (anyproto/anytype-desktop-suite): CB-001…006, incl. language-label + highlighting assertions
- Reviewed by independent multi-agent passes; all confirmed findings fixed.

## Open item (please confirm)

Editing a code-block message back to plain text sends `blocks: []`, which the mapper omits on the wire (pre-existing contract; discussions/comments use the same path). One manual check that `ChatEditMessageContent` clears stale blocks server-side: send a code block → edit to plain text → the rendered block should disappear after the round-trip.
