### PR TITLE
fix(chat): exclude message timestamp from text selection

### DIFF
--- a/src/scss/block/chat/message.scss
+++ b/src/scss/block/chat/message.scss
@@ -60,7 +60,7 @@
 		.textWrapper > .codeBlock:first-child { margin-top: 0px; }
 		.time {
 			@include text-very-small; line-height: 14px; letter-spacing: -0.07px; color: var(--color-text-secondary); float: right; padding: 4px 0px 0px 4px;
-			display: flex; align-items: center; gap: 0px 4px; white-space: nowrap;
+			display: flex; align-items: center; gap: 0px 4px; white-space: nowrap; user-select: none !important;
 		}
 
 		.attachments { padding: 4px; }


### PR DESCRIPTION
## Problem
Double-clicking the last word of a chat message also selected the message timestamp (e.g. `08:07`).

## Cause
`.time` is a sibling of `.text` in the same `.textWrapper` (`.text` is `display: inline`, `.time` is `float: right`), so it shares the text flow. Without a `user-select` rule, double-click word selection extended into it.

## Fix
Add `user-select: none` to `.time` — the timestamp is metadata, not message content (same pattern already used for `.codeLang`).

Closes JS-9814