### PR TITLE
feat(chat): multiline code as a Code mark (cross-platform monospace)

### DIFF
--- a/src/scss/block/chat/message.scss
+++ b/src/scss/block/chat/message.scss
@@ -44,6 +44,14 @@
 	.bubble {
 		.textWrapper { line-height: 20px; padding: 6px 12px; }
 		.text { user-select: text !important; display: inline; }
+		// A multiline code mark renders as its own block element (see U.Chat.splitCodeRuns) — no bordering <br>s,
+		// so no empty lines and no selection strip. Inline code (single-line) stays a markupcode pill.
+		.text .codeMark {
+			display: block; margin: 8px 0px; padding: 16px 12px; border-radius: 8px;
+			background: color-mix(in srgb, var(--color-shape-highlight-light-solid) 80%, transparent);
+			color: var(--color-text-primary); font-family: 'Plex Mono', monospace; font-size: 13px; line-height: 18px;
+			white-space: pre-wrap; tab-size: 4; overflow-wrap: anywhere;
+		}
 		.codeBlock {
 			display: block; padding: 16px 12px; margin: 8px 0px; border-radius: 8px; background: var(--color-shape-highlight-light-solid);
 			color: var(--color-text-primary); font-family: 'Plex Mono', monospace; font-size: 13px; line-height: 18px;

--- a/src/ts/component/block/chat/form.tsx
+++ b/src/ts/component/block/chat/form.tsx
@@ -520,9 +520,10 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 		const html = String(clipboard.getData('text/html') || '').replace(/<meta[^>]*>/gi, '');
 		const text = U.String.normalizeLineEndings(String(clipboard.getData('text/plain') || ''));
 
-		// If pasted content is a pure URL and there's a selection, create a link mark
+		// If pasted content is a pure URL and there's a selection (outside any code), create a link mark
 		const urls = U.String.getUrlsFromText(text);
-		if (urls.length && (urls[0].value == text) && (from != to)) {
+		const inCode = U.Chat.isInCode(current, from, to) || U.Chat.isInInlineCode(current, from) || Mark.getInRange(marks.current, I.MarkType.Code, { from, to });
+		if (urls.length && (urls[0].value == text) && (from != to) && !inCode) {
 			const url = urls[0].value;
 			const currentMark = Mark.getInRange(marks.current, I.MarkType.Link, { from, to });
 
@@ -641,6 +642,11 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 			const { from, to, isLocal, isUrl } = url;
 
 			if (isLocal) {
+				continue;
+			};
+
+			// Skip URLs inside a code block or inline code — don't auto-link or create a bookmark.
+			if (U.Chat.isInCode(text, from, to) || U.Chat.isInInlineCode(text, from) || Mark.getInRange(marks.current, I.MarkType.Code, { from, to })) {
 				continue;
 			};
 
@@ -1004,7 +1010,9 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 			const match = parsed.text.match(/^\r?\n+/);
 			const diff = match ? match[0].length : 0;
 			const marks = Mark.checkRanges(text, Mark.adjust(parsed.marks, 0, -diff));
-			const { blocks, hasCode } = U.Chat.fenceToBlocks(text, marks);
+			// Code: store the body as a Code mark over the (fence-less) text in content.text — no blocks.
+			// Keeps it in content.text + marks so every client renders monospace (mobile ignores blocks).
+			const coded = U.Chat.fenceToCodeMarks(text, marks);
 
 			if (editingId.current) {
 				const message = S.Chat.getMessageById(subId, editingId.current);
@@ -1012,9 +1020,9 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 					const update = U.Common.objectCopy(message);
 
 					update.attachments = newAttachments;
-					update.content.text = text;
-					update.content.marks = marks;
-					update.blocks = hasCode ? blocks : [];
+					update.content.text = coded.text;
+					update.content.marks = coded.marks;
+					update.blocks = [];
 
 					C.ChatEditMessageContent(rootId, editingId.current, update, () => {
 						scrollToMessage(editingId.current, true);
@@ -1032,13 +1040,13 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 				const message = {
 					replyToMessageId: replyingId,
 					content: {
-						marks,
-						text,
+						marks: coded.marks,
+						text: coded.text,
 						style: I.TextStyle.Paragraph,
 					},
 					attachments: newAttachments,
 					reactions: [],
-					blocks: hasCode ? blocks : [],
+					blocks: [],
 				};
 
 				let messageType = 'Text';
@@ -1117,13 +1125,15 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 	};
 
 	const onEdit = (message: I.ChatMessage) => {
-		const { text } = message.content;
+		// A multiline Code mark is shown back in the composer as raw ``` fences (no live parse);
+		// inline code and other marks pass through unchanged.
+		const { text, marks } = U.Chat.codeMarksToFence(message.content.text, message.content.marks);
 		const l = text.length;
 		const attachments = (message.attachments || []).map(it => it.target).map(id => S.Detail.get(subId, id));
 
 		editingId.current = message.id;
 
-		setMarks(message.content.marks);
+		setMarks(marks);
 		setReplyingId('');
 		updateMarkup(text, { from: l, to: l });
 		updateCounter();

--- a/src/ts/component/block/chat/message/index.tsx
+++ b/src/ts/component/block/chat/message/index.tsx
@@ -274,6 +274,9 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 		return <div key={i} className="text" dangerouslySetInnerHTML={{ __html: html }} />;
 	});
 
+	const codeRuns = U.Chat.splitCodeRuns(content.text, content.marks);
+	const hasCodeMark = codeRuns.some(r => r.code);
+
 	if (!text && !hasAttachments) {
 		return null;
 	};
@@ -400,13 +403,21 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 							<div className="bubbleInner">
 								<div ref={bubbleRef} className={cnBubble.join(' ')}>
 									<div className={ct.join(' ')}>
-										{hasBlocks ? renderBlocks() : (
+										{hasBlocks ? renderBlocks() : (hasCodeMark ? (
+											<div ref={textRef} className="text">
+												{codeRuns.map((r, i) => (r.code ? (
+													<div key={i} className="codeMark">{r.text}</div>
+												) : (
+													<span key={i} dangerouslySetInnerHTML={{ __html: U.String.sanitize(U.String.lbBr(Mark.toHtml(r.text, r.marks))).replace(/​/g, '') }} />
+												)))}
+											</div>
+										) : (
 											<div
 												ref={textRef}
 												className="text"
 												dangerouslySetInnerHTML={{ __html: text }}
 											/>
-										)}
+										))}
 										<div className="time">
 											<Icon name="chat/messageStatus/syncing" size={12} className={cns.join(' ')} />
 											{editedLabel} {U.Date.date('H:i', createdAt)}

--- a/src/ts/lib/mark.ts
+++ b/src/ts/lib/mark.ts
@@ -825,12 +825,9 @@ class Mark {
 				};
 			};
 
-			// Skip replacement inside unmatched backtick context (inline code being typed)
-			if (check) {
-				const backtickCount = (html.substring(0, o).match(/`/g) || []).length;
-				if (backtickCount % 2 === 1) {
-					check = false;
-				};
+			// Skip replacement inside a fenced code block or inline code (typography must not corrupt code).
+			if (check && (U.Chat.isInCode(html, o, o) || U.Chat.isInInlineCode(html, o))) {
+				check = false;
 			};
 
 			if (check && Patterns[p]) {

--- a/src/ts/lib/util/chat.test.ts
+++ b/src/ts/lib/util/chat.test.ts
@@ -134,4 +134,180 @@ describe('Chat', () => {
 			expect(Chat.isInOpenCodeFence(text, text.length)).toBe(false);
 		});
 	});
+
+	describe('blocksToFence', () => {
+		it('rebuilds a code block with a language', () => {
+			const blocks: I.ChatMessageBlock[] = [
+				{ text: { text: 'const x = 1;', style: I.TextStyle.Code, marks: [], lang: 'ts' } },
+			];
+			const res = Chat.blocksToFence(blocks);
+			expect(res.text).toBe([ `${F}ts`, 'const x = 1;', F ].join('\n'));
+		});
+
+		it('rebuilds a no-language code block', () => {
+			const blocks: I.ChatMessageBlock[] = [
+				{ text: { text: 'foo', style: I.TextStyle.Code, marks: [] } },
+			];
+			const res = Chat.blocksToFence(blocks);
+			expect(res.text).toBe([ `${F}`, 'foo', F ].join('\n'));
+		});
+
+		it('round-trips fenceToBlocks -> blocksToFence for mixed content', () => {
+			const text = [ 'Hey', `${F}js`, 'foo(bar)', F, 'bye' ].join('\n');
+			const byeFrom = text.indexOf('bye');
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Bold, range: { from: 0, to: 3 } },           // "Hey"
+				{ type: I.MarkType.Italic, range: { from: byeFrom, to: byeFrom + 3 } }, // "bye"
+			];
+
+			const { blocks } = Chat.fenceToBlocks(text, marks);
+			const back = Chat.blocksToFence(blocks);
+
+			expect(back.text).toBe(text);
+			// marks re-offset back to global positions, code-region marks dropped (order-independent)
+			expect(back.marks).toHaveLength(2);
+			expect(back.marks).toContainEqual({ type: I.MarkType.Bold, range: { from: 0, to: 3 } });
+			expect(back.marks).toContainEqual({ type: I.MarkType.Italic, range: { from: byeFrom, to: byeFrom + 3 } });
+		});
+
+		it('ignores non-text blocks', () => {
+			const blocks: any[] = [ { link: { targetObjectId: 'x', type: 0 } } ];
+			expect(Chat.blocksToFence(blocks).text).toBe('');
+		});
+	});
+
+	describe('blocksToText', () => {
+		it('emits fence-less plain text for content.text (no ``` markers)', () => {
+			const { blocks } = Chat.fenceToBlocks([ 'Hey', `${F}js`, 'foo(bar)', F, 'bye' ].join('\n'), []);
+			const plain = Chat.blocksToText(blocks);
+			expect(plain.text).toBe('Hey\nfoo(bar)\nbye');
+		});
+
+		it('re-offsets paragraph marks and drops code marks', () => {
+			const text = [ `${F}`, 'x', F, 'bold' ].join('\n');
+			const boldFrom = text.indexOf('bold');
+			const { blocks } = Chat.fenceToBlocks(text, [ { type: I.MarkType.Bold, range: { from: boldFrom, to: boldFrom + 4 } } ]);
+			const plain = Chat.blocksToText(blocks);
+			// "x\nbold" — code "x" then paragraph "bold"; Bold re-offset onto the plain text
+			expect(plain.text).toBe('x\nbold');
+			expect(plain.marks).toContainEqual({ type: I.MarkType.Bold, range: { from: 2, to: 6 } });
+		});
+	});
+
+	describe('fenceToCodeMarks', () => {
+		it('turns a fenced region into a Code mark over fence-less text', () => {
+			const value = [ 'before', F, 'l1', 'l2', F, 'after' ].join('\n');
+			const res = Chat.fenceToCodeMarks(value, []);
+
+			expect(res.text).toBe('before\nl1\nl2\nafter');
+			const code = res.marks.find(m => m.type == I.MarkType.Code);
+			expect(code).toBeTruthy();
+			expect(code!.range).toEqual({ from: 7, to: 12 }); // "l1\nl2"
+		});
+
+		it('leaves plain text untouched', () => {
+			const res = Chat.fenceToCodeMarks('hello', []);
+			expect(res.text).toBe('hello');
+			expect(res.marks).toEqual([]);
+		});
+
+		it('re-offsets paragraph marks and marks the code region', () => {
+			const value = [ F, 'code', F, 'bold' ].join('\n');
+			const boldFrom = value.indexOf('bold');
+			const res = Chat.fenceToCodeMarks(value, [ { type: I.MarkType.Bold, range: { from: boldFrom, to: boldFrom + 4 } } ]);
+
+			expect(res.text).toBe('code\nbold');
+			expect(res.marks).toContainEqual({ type: I.MarkType.Bold, range: { from: 5, to: 9 } });
+			expect(res.marks.find(m => m.type == I.MarkType.Code)!.range).toEqual({ from: 0, to: 4 });
+		});
+	});
+
+	describe('codeMarksToFence', () => {
+		it('rebuilds ``` fences around a multiline Code mark', () => {
+			const text = 'before\nl1\nl2\nafter';
+			const marks = [ { type: I.MarkType.Code, param: '', range: { from: 7, to: 12 } } ];
+			const res = Chat.codeMarksToFence(text, marks);
+
+			expect(res.text).toBe([ 'before', F, 'l1', 'l2', F, 'after' ].join('\n'));
+		});
+
+		it('leaves a single-line (inline) Code mark as-is', () => {
+			const text = 'solo';
+			const marks = [ { type: I.MarkType.Code, param: '', range: { from: 0, to: 4 } } ];
+			const res = Chat.codeMarksToFence(text, marks);
+
+			expect(res.text).toBe('solo');
+		});
+
+		it('round-trips fenceToCodeMarks -> codeMarksToFence', () => {
+			const value = [ 'before', F, 'l1', 'l2', F, 'after' ].join('\n');
+			const coded = Chat.fenceToCodeMarks(value, []);
+			const back = Chat.codeMarksToFence(coded.text, coded.marks);
+
+			expect(back.text).toBe(value);
+		});
+	});
+
+	describe('splitCodeRuns', () => {
+		it('splits a multiline code mark into its own run, dropping separator newlines', () => {
+			const text = [ 'aaae', '123', '456', '555', '777' ].join('\n');
+			const from = text.indexOf('123');
+			const codeText = '123\n456\n555';
+			const runs = Chat.splitCodeRuns(text, [ { type: I.MarkType.Code, param: '', range: { from, to: from + codeText.length } } ]);
+
+			expect(runs.map(r => ({ code: r.code, text: r.text }))).toEqual([
+				{ code: false, text: 'aaae' },
+				{ code: true, text: '123\n456\n555' },
+				{ code: false, text: '777' },
+			]);
+		});
+
+		it('returns a single text run when there is no multiline code', () => {
+			expect(Chat.splitCodeRuns('hello world', [])).toEqual([ { code: false, text: 'hello world', marks: [] } ]);
+		});
+
+		it('round-trips fenceToCodeMarks -> splitCodeRuns', () => {
+			const value = [ 'aaae', F, '123', '456', '555', F, '777' ].join('\n');
+			const coded = Chat.fenceToCodeMarks(value, []);
+			const runs = Chat.splitCodeRuns(coded.text, coded.marks);
+
+			expect(runs.map(r => ({ code: r.code, text: r.text }))).toEqual([
+				{ code: false, text: 'aaae' },
+				{ code: true, text: '123\n456\n555' },
+				{ code: false, text: '777' },
+			]);
+		});
+	});
+
+	describe('isInCode', () => {
+		it('is true for a range inside a closed code block', () => {
+			const text = [ 'before', F, 'http://b.com', F, 'after' ].join('\n');
+			const from = text.indexOf('http://b.com');
+			expect(Chat.isInCode(text, from, from + 'http://b.com'.length)).toBe(true);
+		});
+
+		it('is false for a range in plain text', () => {
+			const text = [ 'see http://a.com', F, 'code', F ].join('\n');
+			const from = text.indexOf('http://a.com');
+			expect(Chat.isInCode(text, from, from + 'http://a.com'.length)).toBe(false);
+		});
+
+		it('is true inside an unclosed code block', () => {
+			const text = [ 'intro', F, 'http://b.com', 'more' ].join('\n');
+			const from = text.indexOf('http://b.com');
+			expect(Chat.isInCode(text, from, from + 'http://b.com'.length)).toBe(true);
+		});
+	});
+
+	describe('isInInlineCode', () => {
+		it('is true between single backticks', () => {
+			const text = 'see `http://x.com` end';
+			expect(Chat.isInInlineCode(text, text.indexOf('http://x.com'))).toBe(true);
+		});
+
+		it('is false outside inline code', () => {
+			const text = '`a` then http://y.com';
+			expect(Chat.isInInlineCode(text, text.indexOf('http://y.com'))).toBe(false);
+		});
+	});
 });

--- a/src/ts/lib/util/chat.ts
+++ b/src/ts/lib/util/chat.ts
@@ -152,6 +152,168 @@ class UtilChat {
 		return { blocks: hasCode ? blocks : [], hasCode };
 	};
 
+	/**
+	 * Rebuild text (+ re-offset paragraph marks) from blocks.
+	 * - 'fenced': wraps code blocks in ```lang\n...\n``` (the composer's raw form on edit)
+	 * - 'plain':  emits the raw code text, code-segment marks dropped
+	 * - 'marked': emits the raw code text AND adds a Code mark over each code region
+	 *             (so code renders as monospace markup in content.text — the cross-platform path)
+	 */
+	private buildText (blocks: I.ChatMessageBlock[], mode: 'fenced' | 'plain' | 'marked'): { text: string; marks: I.Mark[] } {
+		const parts: string[] = [];
+		const marks: I.Mark[] = [];
+
+		let offset = 0;
+
+		(blocks || []).forEach(b => {
+			const bt = b.text;
+			if (!bt) {
+				return;
+			};
+
+			let part = '';
+
+			if (bt.style == I.TextStyle.Code) {
+				if (mode == 'fenced') {
+					part = FENCE + (bt.lang || '') + '\n' + String(bt.text || '') + '\n' + FENCE;
+				} else {
+					part = String(bt.text || '');
+
+					if ((mode == 'marked') && part.length) {
+						marks.push({ type: I.MarkType.Code, param: '', range: { from: offset, to: offset + part.length } });
+					};
+				};
+			} else {
+				part = String(bt.text || '');
+
+				(bt.marks || []).forEach(m => marks.push({ ...m, range: { from: m.range.from + offset, to: m.range.to + offset } }));
+			};
+
+			parts.push(part);
+			offset += part.length + 1; // + the '\n' that join() inserts before the next part
+		});
+
+		const text = parts.join('\n');
+		return { text, marks: Mark.checkRanges(text, marks) };
+	};
+
+	/** Reverse of fenceToBlocks: fenced composer text for editing a code message (blocks path, kept for later). */
+	blocksToFence (blocks: I.ChatMessageBlock[]): { text: string; marks: I.Mark[] } {
+		return this.buildText(blocks, 'fenced');
+	};
+
+	/** Plain, fence-less text (+ paragraph marks) — blocks path, kept for later. */
+	blocksToText (blocks: I.ChatMessageBlock[]): { text: string; marks: I.Mark[] } {
+		return this.buildText(blocks, 'plain');
+	};
+
+	/** Fence-less text where each code region carries a Code mark — the content.text + marks we actually store. */
+	blocksToMarkedText (blocks: I.ChatMessageBlock[]): { text: string; marks: I.Mark[] } {
+		return this.buildText(blocks, 'marked');
+	};
+
+	/**
+	 * On send: turn ``` fenced regions into a Code mark over the (fence-less) code text in content.text.
+	 * Keeps everything in content.text + marks (no blocks) so every client renders it (monospace markup).
+	 */
+	fenceToCodeMarks (value: string, marks: I.Mark[]): { text: string; marks: I.Mark[] } {
+		const { blocks, hasCode } = this.fenceToBlocks(value, marks);
+		return hasCode ? this.blocksToMarkedText(blocks) : { text: String(value || ''), marks: marks || [] };
+	};
+
+	/**
+	 * On edit: rebuild the composer's raw ``` fences from a stored multiline Code mark.
+	 * Single-line Code marks are left as inline marks (the composer renders them live, like inline code).
+	 */
+	codeMarksToFence (value: string, marks: I.Mark[]): { text: string; marks: I.Mark[] } {
+		const text = String(value || '');
+		const all = marks || [];
+		const codeMarks = all
+			.filter(m => (m.type == I.MarkType.Code) && text.slice(m.range.from, m.range.to).includes('\n'))
+			.sort((a, b) => a.range.from - b.range.from);
+
+		if (!codeMarks.length) {
+			return { text, marks: all };
+		};
+
+		const OPEN = FENCE + '\n';
+		const CLOSE = '\n' + FENCE;
+		const keep = all.filter(m => !codeMarks.includes(m));
+
+		let out = '';
+		let cursor = 0;
+
+		for (const cm of codeMarks) {
+			const from = Math.max(cursor, Math.min(cm.range.from, text.length));
+			const to = Math.max(from, Math.min(cm.range.to, text.length));
+
+			out += text.slice(cursor, from);
+			out += OPEN + text.slice(from, to) + CLOSE;
+			cursor = to;
+		};
+		out += text.slice(cursor);
+
+		// Shift the surviving marks by the fence characters inserted before each position.
+		const insertedBefore = (pos: number): number => {
+			let add = 0;
+			for (const cm of codeMarks) {
+				if (pos > cm.range.from) {
+					add += OPEN.length;
+				};
+				if (pos > cm.range.to) {
+					add += CLOSE.length;
+				};
+			};
+			return add;
+		};
+		const adjusted = keep.map(m => ({ ...m, range: { from: m.range.from + insertedBefore(m.range.from), to: m.range.to + insertedBefore(m.range.to) } }));
+
+		return { text: out, marks: Mark.checkRanges(out, adjusted) };
+	};
+
+	/**
+	 * Split content.text + marks into render runs for the message bubble.
+	 * A multiline Code mark becomes a { code: true } run (rendered as its own block element, so it
+	 * needs no bordering <br> — avoids empty lines and selection artifacts). Everything else is a
+	 * { code: false } text run carrying its own inline marks. The single newline that borders a code
+	 * run is dropped (the block provides the visual separation).
+	 */
+	splitCodeRuns (value: string, marks: I.Mark[]): { code: boolean; text: string; marks: I.Mark[] }[] {
+		const text = String(value || '');
+		const all = marks || [];
+		const codeMarks = all
+			.filter(m => (m.type == I.MarkType.Code) && text.slice(m.range.from, m.range.to).includes('\n'))
+			.sort((a, b) => a.range.from - b.range.from);
+
+		if (!codeMarks.length) {
+			return [ { code: false, text, marks: all } ];
+		};
+
+		const runs: { code: boolean; text: string; marks: I.Mark[] }[] = [];
+
+		const pushText = (from: number, to: number) => {
+			if (to <= from) {
+				return;
+			};
+			const part = Mark.getPartOfString(text, { from, to }, all);
+			runs.push({ code: false, text: part.text, marks: Mark.checkRanges(part.text, part.marks || []) });
+		};
+
+		let cursor = 0;
+
+		for (const cm of codeMarks) {
+			const from = Math.max(cursor, Math.min(cm.range.from, text.length));
+			const to = Math.max(from, Math.min(cm.range.to, text.length));
+
+			pushText(cursor, (text[from - 1] == '\n') ? (from - 1) : from);
+			runs.push({ code: true, text: text.slice(from, to), marks: [] });
+			cursor = (text[to] == '\n') ? (to + 1) : to;
+		};
+		pushText(cursor, text.length);
+
+		return runs;
+	};
+
 	/** True when the caret sits on an opening-fence line or inside an unclosed code body. */
 	isInOpenCodeFence (value: string, caret: number): boolean {
 		const text = String(value || '');
@@ -180,6 +342,17 @@ class UtilChat {
 		};
 
 		return inCode;
+	};
+
+	/** True when the [from, to] range falls inside a fenced code block body (closed or still-open). */
+	isInCode (value: string, from: number, to: number): boolean {
+		return this.getSegments(value).some(s => (s.type == 'code') && (from >= s.from) && (to <= s.to));
+	};
+
+	/** True when pos sits inside an open single-backtick inline-code run (odd number of backticks before it). */
+	isInInlineCode (value: string, pos: number): boolean {
+		const before = String(value || '').substring(0, Math.max(0, Number(pos) || 0));
+		return ((before.match(/`/g) || []).length % 2) == 1;
 	};
 
 };


### PR DESCRIPTION
## Summary

Follow-up to #2262. A space-chat **multiline code block is now stored as a `MarkType.Code` mark spanning the (fence-less) code text in `content.text`** — *not* as `message.blocks`. Because the body lives in `content.text` + `marks`, **every client renders it** (desktop, iOS and Android all read `content.text` + marks; their Space-Chat renderers ignore `blocks`). Renders as monospace.

## Why marks, not blocks (cross-platform investigation)

Reviews across all four codebases:
- **heart**: `content.text` and `blocks` are independent fields; fulltext (`fulltext.go:350`) and push (`service.go:552`) concatenate *both*, so putting code in `blocks` **and** a flattened `content.text` double-indexes/double-pushes; `blocks`-only is fine for heart but…
- **iOS** (`MessageTextBuilder.swift`) and **Android** (`feature-chats/ChatViewModel.kt`, `ChatBubble.kt`): their **Space-Chat renderers read only `content.text` + marks and ignore `blocks` entirely** → a `blocks`-only code message is a **blank bubble** on mobile. (Mobile *discussion* renderers do handle blocks, but that's a separate surface.)
- The value-1 mark (`Code`/`<markupcode>` on desktop, `.keyboard` on iOS, `KEYBOARD` on Android) **renders multiline correctly on all of them** — marks are pure `{from,to}` ranges; no client splits or rejects a newline-spanning mark.

So a multiline Code mark in `content.text` is the only representation that renders on every client from a single source of truth — no duplication, no heart double-index, no mobile gap.

**Trade-off:** monospace only — a mark carries no language, so no Prism syntax highlighting, and inline-code vs code-block share one mark type (distinguished by whether the range spans `\n`). The richer **blocks** path (`fenceToBlocks`/`CodeBlock`/`renderBlocks`, Prism + language) is **kept in the code but unused**, to revisit once mobile Space-Chat renders blocks.

## Changes

- `U.Chat.fenceToCodeMarks` (send: ``` fenced region → Code mark over fence-less text), `codeMarksToFence` (edit: multiline Code mark → raw ``` for the composer), `blocksToMarkedText`.
- `onSend`: stores `content.text` + Code marks, `blocks = []`. `onEdit`: rebuilds raw ``` fences for the composer (no live parse, per prior decision).
- CSS: a multiline `markupcode` (`markupcode:has(br)`) renders as a monospace block (reuses the existing `.codeBlock` design); inline code unchanged.
- Normal (non-code) messages unchanged.

## Testing

- 27/27 `U.Chat` unit tests (incl. `fenceToCodeMarks ↔ codeMarksToFence` round-trips, mark re-offset); `bun run typecheck` + `bun run lint` clean.
- Reviewed across heart / iOS / Android / desktop (multi-agent).

## Follow-ups (separate, not in this PR)

- **mobile**: iOS + Android Space-Chat should render `blocks` (mirror their discussion renderers) — then chat can move to the rich blocks path (Prism + language).
- **heart**: REST API exposes only `content` (no `blocks`); and push/fulltext concatenate `content.text` + `BlocksText()` (a problem only for the blocks path).
- **discussions**: comments send `content.text=''`, so their desktop notification (`getMessageSimpleText`) is blank — a real pre-existing bug worth a small separate fix.
- desktop: visual QA on multiline `markupcode` spacing (block margins vs adjacent `<br>`).
