### PR TITLE
fix(space): stop opening stale objectId from previous space on switch (JS-9815)

### DIFF
--- a/src/ts/lib/api/command.ts
+++ b/src/ts/lib/api/command.ts
@@ -1183,11 +1183,15 @@ export const ObjectOpen = (objectId: string, traceId: string, spaceId: string, c
 		if (!message.error.code) {
 			dispatcher.onObjectView(objectId, traceId, message.objectView, true);
 
-			// Save last opened object
+			// Save last opened object.
+			// Key it by the space the object actually belongs to (not the globally-current
+			// space, which may have already changed if this is a late response after a
+			// space switch) so it never pollutes another space's bucket (JS-9815).
 			const object = S.Detail.get(objectId, objectId, []);
+			const lastSpaceId = object.spaceId || spaceId;
 
 			if (!object._empty_ && ![ I.ObjectLayout.Dashboard ].includes(object.layout) && !keyboard.isPopup()) {
-				Storage.setLastOpened({ id: object.id, layout: object.layout });
+				Storage.setLastOpened({ id: object.id, layout: object.layout, spaceId: lastSpaceId }, lastSpaceId);
 			};
 		};
 

--- a/src/ts/lib/storage.test.ts
+++ b/src/ts/lib/storage.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Storage from './storage';
+
+/**
+ * Regression coverage for JS-9815.
+ *
+ * `lastOpenedSimple` is a space-scoped storage key. The bug was that both the
+ * read and the write resolved the bucket from the globally-mutable `S.Common.space`
+ * at call time. A late `ObjectOpen` response from a previous space — arriving after
+ * the user already switched — wrote that previous object into the NEW space's bucket,
+ * so the next space switch tried to open `oldObjectId` in `newSpaceId`
+ * ("build tree: tree does not exist").
+ *
+ * The fix lets the caller pass the spaceId the object actually belongs to, so the
+ * write lands in the correct bucket regardless of the globally-current space.
+ *
+ * These tests stub the minimal globals that `storage.ts` relies on, because the
+ * vitest harness does not run the AutoImport plugin that injects `S`/`U` in the app.
+ */
+describe('Storage last-opened (per-space isolation)', () => {
+
+	let store: Record<string, string>;
+
+	beforeEach(() => {
+		store = {};
+
+		vi.stubGlobal('localStorage', {
+			getItem: (k: string) => (k in store ? store[k] : null),
+			setItem: (k: string, v: string) => { store[k] = v; },
+			removeItem: (k: string) => { delete store[k]; },
+		});
+
+		// No electron store -> storage falls back to localStorage.
+		vi.stubGlobal('U', { Common: { getElectron: () => ({}) } });
+		vi.stubGlobal('S', { Common: { space: '' }, Auth: { account: null } });
+
+		// Reset the space bucket map in both the localStorage mock and the module cache.
+		Storage.set('space', {}, true);
+	});
+
+	it('reads/writes the bucket of the explicit space, isolated across spaces', () => {
+		Storage.setLastOpened({ id: 'objA', layout: 0 }, 'spaceA');
+		Storage.setLastOpened({ id: 'objB', layout: 0 }, 'spaceB');
+
+		expect(Storage.getLastOpened('spaceA').id).toBe('objA');
+		expect(Storage.getLastOpened('spaceB').id).toBe('objB');
+	});
+
+	it('writes to the object\'s space, not the globally-current space (race guard)', () => {
+		// User has already switched to spaceB...
+		(globalThis as any).S.Common.space = 'spaceB';
+
+		// ...when a late ObjectOpen response from spaceA lands.
+		Storage.setLastOpened({ id: 'objA', layout: 0 }, 'spaceA');
+
+		// spaceB's bucket must NOT be polluted with spaceA's object.
+		expect(Storage.getLastOpened('spaceB').id).toBeUndefined();
+		expect(Storage.getLastOpened('spaceA').id).toBe('objA');
+	});
+
+	it('falls back to the current space when no spaceId is passed', () => {
+		(globalThis as any).S.Common.space = 'spaceA';
+
+		Storage.setLastOpened({ id: 'objA', layout: 0 });
+
+		expect(Storage.getLastOpened().id).toBe('objA');
+		expect(Storage.getLastOpened('spaceA').id).toBe('objA');
+	});
+
+});

--- a/src/ts/lib/storage.ts
+++ b/src/ts/lib/storage.ts
@@ -381,16 +381,17 @@ class Storage {
 	 * Gets the last opened objects from storage.
 	 * @returns {any} The last opened objects.
 	 */
-	getLastOpened () {
-		return this.get('lastOpenedSimple', this.isLocal('lastOpenedSimple')) || {};
+	getLastOpened (spaceId?: string) {
+		return this.getSpaceKey('lastOpenedSimple', this.isLocal('lastOpenedSimple'), spaceId) || {};
 	};
 
 	/**
 	 * Sets the last opened object for a window.
 	 * @param {any} param - The parameters to set.
+	 * @param {string} [spaceId] - The space the object belongs to (defaults to the current space).
 	 */
-	setLastOpened (param: any) {
-		this.set('lastOpenedSimple', param, this.isLocal('lastOpenedSimple'));
+	setLastOpened (param: any, spaceId?: string) {
+		this.setSpaceKey('lastOpenedSimple', param, this.isLocal('lastOpenedSimple'), spaceId);
 	};
 
 	/**

--- a/src/ts/lib/util/common.selfHeal.test.ts
+++ b/src/ts/lib/util/common.selfHeal.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import UtilCommon from './common';
+import Storage from '../storage';
+
+/**
+ * Regression coverage for the JS-9815 self-heal in `checkErrorOnOpen`.
+ *
+ * When opening an object fails, a STALE last-opened entry for the current space
+ * (a legacy entry without a spaceId, or one belonging to another space) is cleared
+ * so switching back does not keep replaying the bad open. A VALID same-space entry
+ * is kept — a transient open failure must not drop the user's restore point.
+ */
+describe('UtilCommon.checkErrorOnOpen self-heal', () => {
+
+	const CODE = 1; // generic error code, e.g. "build tree: tree does not exist"
+	let store: Record<string, string>;
+
+	beforeEach(() => {
+		store = {};
+
+		vi.stubGlobal('localStorage', {
+			getItem: (k: string) => (k in store ? store[k] : null),
+			setItem: (k: string, v: string) => { store[k] = v; },
+			removeItem: (k: string) => { delete store[k]; },
+		});
+
+		vi.stubGlobal('U', { Common: { getElectron: () => ({}) } });
+		vi.stubGlobal('translate', (k: string) => k);
+		vi.stubGlobal('J', { Error: { Code: {
+			ANYTYPE_NEEDS_UPGRADE: 10,
+			ANOTHER_ANYTYPE_PROCESS_IS_RUNNING: 108,
+			PROTOCOL_NEEDS_UPGRADE: 110,
+		} } });
+		vi.stubGlobal('S', {
+			Common: { space: 'spaceA' },
+			Auth: { account: null },
+			Popup: { open: vi.fn() },
+		});
+
+		Storage.set('space', {}, true);
+	});
+
+	it('clears a legacy (no-spaceId) entry whose id matches the failed object', () => {
+		Storage.setLastOpened({ id: 'objBad', layout: 0 }, 'spaceA');
+
+		UtilCommon.checkErrorOnOpen('objBad', CODE);
+
+		expect(Storage.getLastOpened('spaceA').id).toBeUndefined();
+	});
+
+	it('keeps a valid same-space entry on a transient failure', () => {
+		Storage.setLastOpened({ id: 'objGood', layout: 0, spaceId: 'spaceA' }, 'spaceA');
+
+		UtilCommon.checkErrorOnOpen('objGood', CODE);
+
+		expect(Storage.getLastOpened('spaceA').id).toBe('objGood');
+	});
+
+	it('does not touch the entry when the failed id differs', () => {
+		Storage.setLastOpened({ id: 'objGood', layout: 0 }, 'spaceA');
+
+		UtilCommon.checkErrorOnOpen('objOther', CODE);
+
+		expect(Storage.getLastOpened('spaceA').id).toBe('objGood');
+	});
+
+});

--- a/src/ts/lib/util/common.ts
+++ b/src/ts/lib/util/common.ts
@@ -511,6 +511,14 @@ class UtilCommon {
 			return false;
 		};
 
+		// Self-heal: if the object that failed to open is the stored last-opened for the
+		// current space, clear it so switching back to this space doesn't keep replaying
+		// the bad open. Recovers buckets polluted before the write-side fix (JS-9815).
+		const last = Storage.getLastOpened(S.Common.space);
+		if (last && (last.id == rootId)) {
+			Storage.setLastOpened({}, S.Common.space);
+		};
+
 		S.Popup.open('confirm', {
 			data: {
 				iconParam: { name: 'popup/header/error', color: 'orange' },

--- a/src/ts/lib/util/common.ts
+++ b/src/ts/lib/util/common.ts
@@ -512,11 +512,14 @@ class UtilCommon {
 		};
 
 		// Self-heal: if the object that failed to open is the stored last-opened for the
-		// current space, clear it so switching back to this space doesn't keep replaying
-		// the bad open. Recovers buckets polluted before the write-side fix (JS-9815).
-		const last = Storage.getLastOpened(S.Common.space);
-		if (last && (last.id == rootId)) {
-			Storage.setLastOpened({}, S.Common.space);
+		// current space AND that entry is stale — a legacy entry without a spaceId, or one
+		// belonging to another space — clear it so switching back doesn't keep replaying
+		// the bad open. A valid same-space entry is kept: a transient open failure should
+		// not drop the user's restore point (JS-9815).
+		const space = S.Common.space;
+		const last = Storage.getLastOpened(space);
+		if (last && (last.id == rootId) && (!last.spaceId || (last.spaceId != space))) {
+			Storage.setLastOpened({}, space);
 		};
 
 		S.Popup.open('confirm', {

--- a/src/ts/lib/util/space.test.ts
+++ b/src/ts/lib/util/space.test.ts
@@ -57,4 +57,18 @@ describe('UtilSpace.getLastObject (per-space validation)', () => {
 		expect(UtilSpace.getLastObject()).toBeNull();
 	});
 
+	// Legacy entries (written before the fix) have no spaceId. They live in the
+	// correct space bucket, so they are still trusted for backward compat — and the
+	// self-heal in checkErrorOnOpen recovers the rare poisoned legacy entry.
+	it('accepts a legacy entry that has no spaceId field', () => {
+		(globalThis as any).S.Common.space = 'spaceA';
+		Storage.setLastOpened({ id: 'objLegacy', layout: 0 }, 'spaceA');
+
+		const home = UtilSpace.getLastObject();
+
+		expect(home).not.toBeNull();
+		expect(home.id).toBe('objLegacy');
+		expect(home.spaceId).toBe('spaceA');
+	});
+
 });

--- a/src/ts/lib/util/space.test.ts
+++ b/src/ts/lib/util/space.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import UtilSpace from './space';
+import Storage from '../storage';
+
+/**
+ * Regression coverage for JS-9815 (read side).
+ *
+ * `getLastObject()` used to blindly stamp the current space onto whatever id was
+ * stored, with no check that the object belonged to that space — so a polluted
+ * bucket produced an `ObjectOpen(oldObjectId, newSpaceId)` and a hard
+ * "build tree: tree does not exist" error instead of a graceful fallback.
+ *
+ * The fix records the object's space alongside the id and rejects entries whose
+ * space does not match the current one.
+ */
+describe('UtilSpace.getLastObject (per-space validation)', () => {
+
+	let store: Record<string, string>;
+
+	beforeEach(() => {
+		store = {};
+
+		vi.stubGlobal('localStorage', {
+			getItem: (k: string) => (k in store ? store[k] : null),
+			setItem: (k: string, v: string) => { store[k] = v; },
+			removeItem: (k: string) => { delete store[k]; },
+		});
+
+		vi.stubGlobal('U', { Common: { getElectron: () => ({}) } });
+		vi.stubGlobal('S', { Common: { space: '' }, Auth: { account: null } });
+
+		Storage.set('space', {}, true);
+	});
+
+	it('returns the last object stamped with the current space', () => {
+		(globalThis as any).S.Common.space = 'spaceA';
+		Storage.setLastOpened({ id: 'objA', layout: 0, spaceId: 'spaceA' }, 'spaceA');
+
+		const home = UtilSpace.getLastObject();
+
+		expect(home).not.toBeNull();
+		expect(home.id).toBe('objA');
+		expect(home.spaceId).toBe('spaceA');
+	});
+
+	it('rejects an entry that belongs to a different space (no stale open)', () => {
+		// Current space is spaceA, but its bucket holds an object from spaceZ (pollution).
+		(globalThis as any).S.Common.space = 'spaceA';
+		Storage.setLastOpened({ id: 'objZ', layout: 0, spaceId: 'spaceZ' }, 'spaceA');
+
+		expect(UtilSpace.getLastObject()).toBeNull();
+	});
+
+	it('returns null when nothing was opened in the space', () => {
+		(globalThis as any).S.Common.space = 'spaceEmpty';
+
+		expect(UtilSpace.getLastObject()).toBeNull();
+	});
+
+});

--- a/src/ts/lib/util/space.ts
+++ b/src/ts/lib/util/space.ts
@@ -237,15 +237,19 @@ class UtilSpace {
 	 * @returns {any|null} The last opened object or null if not found.
 	 */
 	getLastObject () {
-		let home = Storage.getLastOpened();
+		const space = S.Common.space;
 
-		// Invalid data protection
-		if (!home || !home.id) {
+		let home = Storage.getLastOpened(space);
+
+		// Invalid data protection: ignore empty entries and entries that belong to a
+		// different space (stale/polluted bucket) to avoid opening a foreign object
+		// in the current space (JS-9815).
+		if (!home || !home.id || (home.spaceId && (home.spaceId != space))) {
 			home = null;
 		};
 
 		if (home) {
-			home.spaceId = S.Common.space;
+			home.spaceId = space;
 		};
 
 		return home;


### PR DESCRIPTION
## Problem (JS-9815)

Intermittently, switching spaces shows the "There was a problem while opening the object" error. The failing `ObjectOpen` carries the **new** spaceId but an **objectId from the previously opened space**, so the middleware returns `build tree: tree does not exist`.

## Root cause

`lastOpenedSimple` is a space-scoped storage key, but both the read and the write resolved the bucket from the globally-mutable `S.Common.space` at call time — and the write happens in the async `ObjectOpen` gRPC callback.

A late `ObjectOpen` response from the previous space, arriving after the user already switched (`S.Common.spaceSet` runs in `onInfo` during the switch), wrote that previous object into the **new** space's bucket. The next switch then read that bucket and tried to open `oldObjectId` in `newSpaceId`. `getLastObject()` made it worse by blindly stamping the current space onto whatever id it read.

## Fix

- **`command.ts`** — key the last-opened write by the object's **actual** space (`object.spaceId`, falling back to the request's `spaceId`, which is captured at call time), not the globally-current space; persist that spaceId in the entry.
- **`storage.ts`** — `getLastOpened`/`setLastOpened` accept an explicit `spaceId` (defaults to current — backward compatible).
- **`space.ts`** — `getLastObject()` validates the entry's space and returns `null` on mismatch instead of blind-stamping.
- **`common.ts`** — `checkErrorOnOpen` self-heals a **stale** last-opened entry (legacy/no-spaceId or foreign-space) when its object fails to open, so buckets polluted before this fix recover. Valid same-space entries are kept (a transient failure must not drop the restore point).

## Review

Reviewed by 3 independent agents (correctness/race, regressions, tests): write-side race confirmed completely closed; storage refactor confirmed behavior-preserving; the self-heal was narrowed per review to avoid over-clearing.

## Tests

New unit tests (vitest), all confirmed fail-before / pass-after where applicable:
- `storage.test.ts` — per-space isolation + the race guard.
- `space.test.ts` — `getLastObject` space validation + legacy passthrough.
- `common.selfHeal.test.ts` — self-heal clears stale, keeps valid, no-op on id mismatch.

typecheck + eslint + biome clean. (The repo's vitest harness has ~101 pre-existing failures from un-injected AutoImport globals — unchanged by this PR.)