### PR TITLE
Fix login key reported "too short" when last word lacks a trailing space

### DIFF
--- a/src/ts/component/form/phrase.tsx
+++ b/src/ts/component/form/phrase.tsx
@@ -201,7 +201,10 @@ const Phrase = forwardRef<PhraseRefProps, Props>(({
 	};
 
 	const getValue = () => {
-		return phrase.current.join(' ').trim().toLowerCase();
+		const entry = getEntryValue();
+		const list = checkValue(phrase.current.concat(entry ? entry.split(' ') : []));
+
+		return list.join(' ').trim().toLowerCase();
 	};
 
 	const placeholderCheck = () => {


### PR DESCRIPTION
## Summary

On the **Welcome back / login key** screen, entering all 12 recovery words *without* a trailing space after the last word fails with **"Key is too short"**, even though the key is correct and complete.

## Root cause

In `src/ts/component/form/phrase.tsx`, words are committed to the `phrase.current` array only when the user presses **space** or **enter**. The word still being typed lives in the contentEditable entry field. `getValue()` returned only `phrase.current`, ignoring that entry field:

```ts
const getValue = () => {
    return phrase.current.join(' ').trim().toLowerCase();
};
```

So typing the 12th word and clicking **Enter my Vault** (no trailing space) yields 11 words, and `login.tsx` rejects it as too short.

## Fix

Fold the in-progress entry value into `getValue()`, reusing the existing `checkValue()` (8-char truncation, 12-word cap). Pure read change — no state mutation:

```ts
const getValue = () => {
    const entry = getEntryValue();
    const list = checkValue(phrase.current.concat(entry ? entry.split(' ') : []));

    return list.join(' ').trim().toLowerCase();
};
```

## Test

- Type 12 words, no trailing space → **Enter my Vault** now succeeds.
- Trailing space, paste, and \<12-word cases unchanged.