### PR TITLE
fix(chat): stop messages disappearing when scrolling chat history

### DIFF
--- a/docs/superpowers/plans/2026-06-26-chat-message-windowing.md
+++ b/docs/superpowers/plans/2026-06-26-chat-message-windowing.md
@@ -1,0 +1,751 @@
+# Chat Message Windowing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the chat from silently losing newer messages when scrolling up, by turning the in-memory message list into a bidirectional sliding window that re-fetches transparently when scrolling back toward an evicted edge.
+
+**Architecture:** The decision logic (edge detection, eviction count, forward re-fetch, live-add suppression) is extracted into a pure, global-free module (`Lib/util/chatWindow`) that is unit-tested. The store (`S.Chat`) holds per-`subId` edge flags (`atChatStart`/`atChatEnd`, default `true`) and reports eviction; the chat component reads/sets those flags, adds a symmetric scroll-down re-fetch with an in-flight guard and a forced re-render, and fixes the conflated `isLoaded` guard. The window cap rises 500→1000 only after the `onScroll` cost is bounded.
+
+**Tech Stack:** TypeScript, React 18 (the chat block is NOT a MobX `observer` — it re-renders via `setDummy`), MobX stores, vitest for unit tests, Electron renderer. Tabs for indentation.
+
+## Global Constraints
+
+- **Indentation: tabs**, never spaces (all `.ts`/`.tsx`/`.scss`).
+- `else if` on a new line after `}`; wrap compound-condition parts in parentheses (`(a > b) && (c < d)`).
+- Collect JSX class lists into a `cn` variable before `return`.
+- Never use raw `document.getElementById`/`querySelector` — use `U.Dom` helpers. No jQuery/`$`.
+- All UI text via `translate()`; keys in `src/json/text.json`.
+- Do not change colors, spacing, sizes, or any design value.
+- Chat page size = `J.Constant.limit.chat.messages` = **50**. Target window cap = **1000**.
+- After every code change run `bun run typecheck` and `bun run lint`; both must pass.
+- Run unit tests with `bun run test` (vitest). Tests live beside source as `*.test.ts`.
+- `BlockChat` (`src/ts/component/block/chat.tsx`) is **not** wrapped in `observer`; store mutations do not re-render it — a `setDummy(v => v + 1)` is required to render store changes.
+
+---
+
+## File Structure
+
+- **Create** `src/ts/lib/util/chatWindow.ts` — pure windowing decision helpers (no store/DOM/global deps).
+- **Create** `src/ts/lib/util/chatWindow.test.ts` — vitest unit tests for the helpers.
+- **Modify** `src/ts/store/chat.ts` — `MAX_MESSAGES`; per-`subId` edge-flag maps + getters/setters; `prepend`/`append` return `evicted` and set flags; `add` tail-insert routing + live-add suppression; `clear` resets flags.
+- **Modify** `src/ts/component/block/chat.tsx` — edge-flag wiring (replace `isLoadedPrev`), `isLoaded`→`atChatEnd` guard, `isLoadingNext` + dir>0 prefetch + `setDummy`-on-append, edge recompute in `loadMessagesByOrderId`, "new messages" affordance, `onScroll` rAF coalescing.
+- **Modify** `src/scss/page/main/chat.scss` (or the chat scroll container rule) — explicit `overflow-anchor`.
+
+---
+
+### Task 1: Pure windowing helpers
+
+**Files:**
+- Create: `src/ts/lib/util/chatWindow.ts`
+- Test: `src/ts/lib/util/chatWindow.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `evictedCount(lengthAfterInsert: number, max: number): number`
+  - `reachedEdge(pageLength: number, limit: number): boolean`
+  - `edgesAfterJump(beforeLength: number, afterLength: number, limit: number): { atChatStart: boolean; atChatEnd: boolean }`
+  - `shouldRefetchForward(atChatEnd: boolean, isBottom: boolean, isLoadingNext: boolean): boolean`
+  - `shouldSuppressLiveAdd(atChatEnd: boolean, messageOrderId: string, lastWindowOrderId: string): boolean`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/ts/lib/util/chatWindow.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { evictedCount, reachedEdge, edgesAfterJump, shouldRefetchForward, shouldSuppressLiveAdd } from './chatWindow';
+
+describe('chatWindow', () => {
+	it('evictedCount returns overflow past max, else 0', () => {
+		expect(evictedCount(550, 500)).toBe(50);
+		expect(evictedCount(500, 500)).toBe(0);
+		expect(evictedCount(10, 500)).toBe(0);
+	});
+
+	it('reachedEdge is true only for a short page', () => {
+		expect(reachedEdge(49, 50)).toBe(true);
+		expect(reachedEdge(50, 50)).toBe(false);
+		expect(reachedEdge(0, 50)).toBe(true);
+	});
+
+	it('edgesAfterJump derives both edges from before/after page lengths', () => {
+		expect(edgesAfterJump(25, 25, 50)).toEqual({ atChatStart: true, atChatEnd: true });
+		expect(edgesAfterJump(50, 10, 50)).toEqual({ atChatStart: false, atChatEnd: true });
+		expect(edgesAfterJump(50, 50, 50)).toEqual({ atChatStart: false, atChatEnd: false });
+	});
+
+	it('shouldRefetchForward only when not at end, at window bottom, and not already loading', () => {
+		expect(shouldRefetchForward(false, true, false)).toBe(true);
+		expect(shouldRefetchForward(true, true, false)).toBe(false);
+		expect(shouldRefetchForward(false, false, false)).toBe(false);
+		expect(shouldRefetchForward(false, true, true)).toBe(false);
+	});
+
+	it('shouldSuppressLiveAdd only for a genuinely-newer message while not at end', () => {
+		expect(shouldSuppressLiveAdd(false, '!z', '!m')).toBe(true);
+		expect(shouldSuppressLiveAdd(true, '!z', '!m')).toBe(false);
+		expect(shouldSuppressLiveAdd(false, '!a', '!m')).toBe(false);
+		expect(shouldSuppressLiveAdd(false, '!z', '')).toBe(false);
+	});
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun run test -- chatWindow`
+Expected: FAIL — `Cannot find module './chatWindow'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/ts/lib/util/chatWindow.ts`:
+
+```ts
+/**
+ * Pure decision helpers for the chat sliding-window.
+ * No store / DOM / global dependencies — keep this module unit-testable.
+ */
+
+/**
+ * How many messages are evicted when a list of `lengthAfterInsert` is trimmed to `max`.
+ * Returns 0 when the list is within bounds.
+ */
+export const evictedCount = (lengthAfterInsert: number, max: number): number => {
+	return Math.max(0, lengthAfterInsert - max);
+};
+
+/**
+ * A fetched page shorter than the requested `limit` means the chat boundary
+ * (oldest when paging back, newest when paging forward) was reached.
+ */
+export const reachedEdge = (pageLength: number, limit: number): boolean => {
+	return pageLength < limit;
+};
+
+/**
+ * Edge flags after rebuilding the window around an orderId (jump / deeplink / unread divider),
+ * derived from the actual before/after page lengths so the flags are not guessed.
+ */
+export const edgesAfterJump = (beforeLength: number, afterLength: number, limit: number): { atChatStart: boolean; atChatEnd: boolean } => {
+	return { atChatStart: reachedEdge(beforeLength, limit), atChatEnd: reachedEdge(afterLength, limit) };
+};
+
+/**
+ * Whether scrolling down should fetch newer messages to refill an evicted tail.
+ */
+export const shouldRefetchForward = (atChatEnd: boolean, isBottom: boolean, isLoadingNext: boolean): boolean => {
+	return (!atChatEnd) && isBottom && (!isLoadingNext);
+};
+
+/**
+ * Whether a live message must be suppressed: it is genuinely newer than the window's
+ * last message while the window is not anchored at the chat end, so appending it would
+ * place it out of order after an evicted tail. orderIds are lexids (lexicographic compare).
+ */
+export const shouldSuppressLiveAdd = (atChatEnd: boolean, messageOrderId: string, lastWindowOrderId: string): boolean => {
+	return (!atChatEnd) && (!!lastWindowOrderId) && (messageOrderId > lastWindowOrderId);
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bun run test -- chatWindow`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Typecheck, lint, commit**
+
+Run: `bun run typecheck && bun run lint`
+Expected: no errors.
+
+```bash
+git add src/ts/lib/util/chatWindow.ts src/ts/lib/util/chatWindow.test.ts
+git commit -m "feat(chat): add pure windowing decision helpers"
+```
+
+---
+
+### Task 2: Store edge-flag state + eviction reporting
+
+**Files:**
+- Modify: `src/ts/store/chat.ts` (`MAX_MESSAGES`, new flag maps + accessors, `prepend`, `append`, `clear`)
+
+**Interfaces:**
+- Consumes: `evictedCount` (Task 1).
+- Produces (on `S.Chat`):
+  - `isAtChatStart(subId: string): boolean` (default `true`)
+  - `isAtChatEnd(subId: string): boolean` (default `true`)
+  - `setAtChatStart(subId: string, v: boolean): void`
+  - `setAtChatEnd(subId: string, v: boolean): void`
+  - `prepend(subId, add): boolean` and `append(subId, add): boolean` now **return** whether they evicted.
+
+- [ ] **Step 1: Raise the cap and add the flag maps**
+
+In `src/ts/store/chat.ts`, change the constant (currently `const MAX_MESSAGES = 500;`):
+
+```ts
+const MAX_MESSAGES = 1000;
+```
+
+> NOTE: leave the value at `1000` here, but the scroll-cost hardening (Task 7) must land before this plan is shipped — it is sequenced after this task only because the store edits are foundational. If executing strictly incrementally and worried about perf in interim manual testing, temporarily keep `500` and flip to `1000` in Task 8.
+
+Add the import at the top of the file (the file already imports from `mobx`, `Interface`, `Model`):
+
+```ts
+import { evictedCount } from 'Lib/util/chatWindow';
+```
+
+Add two plain maps as class fields next to the existing `messageMap` declaration:
+
+```ts
+	private atChatStartMap: Map<string, boolean> = new Map();
+	private atChatEndMap: Map<string, boolean> = new Map();
+```
+
+- [ ] **Step 2: Add the accessors**
+
+Add these methods to `ChatStore` (place them near `getList`):
+
+```ts
+	isAtChatStart (subId: string): boolean {
+		const v = this.atChatStartMap.get(subId);
+		return v === undefined ? true : v;
+	};
+
+	isAtChatEnd (subId: string): boolean {
+		const v = this.atChatEndMap.get(subId);
+		return v === undefined ? true : v;
+	};
+
+	setAtChatStart (subId: string, v: boolean): void {
+		this.atChatStartMap.set(subId, v);
+	};
+
+	setAtChatEnd (subId: string, v: boolean): void {
+		this.atChatEndMap.set(subId, v);
+	};
+```
+
+- [ ] **Step 3: Make `prepend` report eviction and flip `atChatEnd`**
+
+Replace the body of `prepend` (currently `list.unshift(...add); if (list.length > MAX_MESSAGES) { list.splice(MAX_MESSAGES); };`):
+
+```ts
+	prepend (subId: string, add: I.ChatMessage[]): boolean {
+		const list = this.getList(subId);
+		const ids = new Set(list.map(it => it.id));
+
+		add = (add || []).filter(it => !ids.has(it.id));
+		add = add.map(it => new M.ChatMessage(it));
+
+		list.unshift(...add);
+
+		const evicted = evictedCount(list.length, MAX_MESSAGES);
+		if (evicted) {
+			list.splice(MAX_MESSAGES);
+			this.setAtChatEnd(subId, false);
+		};
+
+		return evicted > 0;
+	};
+```
+
+- [ ] **Step 4: Make `append` report eviction and flip `atChatStart`**
+
+Replace the body of `append` (currently `list.push(...add); if (list.length > MAX_MESSAGES) { list.splice(0, list.length - MAX_MESSAGES); };`):
+
+```ts
+	append (subId: string, add: I.ChatMessage[]): boolean {
+		const list = this.getList(subId);
+		const ids = new Set(list.map(it => it.id));
+
+		add = (add || []).filter(it => !ids.has(it.id));
+		add = add.map(it => new M.ChatMessage(it));
+
+		list.push(...add);
+
+		const evicted = evictedCount(list.length, MAX_MESSAGES);
+		if (evicted) {
+			list.splice(0, evicted);
+			this.setAtChatStart(subId, false);
+		};
+
+		return evicted > 0;
+	};
+```
+
+- [ ] **Step 5: Reset flags in `clear`**
+
+In `clear(subId)` (currently deletes `messageMap`/`replyMap`/`attachmentsMap`), add:
+
+```ts
+		this.atChatStartMap.delete(subId);
+		this.atChatEndMap.delete(subId);
+```
+
+- [ ] **Step 6: Typecheck, lint, commit**
+
+Run: `bun run typecheck && bun run lint`
+Expected: no errors. (No store unit test — the store depends on ambient globals not wired in vitest; correctness of the eviction math is covered by `evictedCount` tests in Task 1.)
+
+```bash
+git add src/ts/store/chat.ts
+git commit -m "feat(chat): store tracks window edges and reports eviction"
+```
+
+---
+
+### Task 3: Live-add routing + suppression in `S.Chat.add`
+
+**Files:**
+- Modify: `src/ts/store/chat.ts` (`add`)
+
+**Interfaces:**
+- Consumes: `shouldSuppressLiveAdd`, `evictedCount` (Task 1); `isAtChatEnd`, `setAtChatStart` (Task 2).
+- Produces: `add` now suppresses out-of-order tail inserts and trims the head (like `append`) for tail inserts; head inserts (`idx == 0`, previews) are untouched.
+
+Context: `add` is called from the dispatcher for live messages with `idx = list.length` (tail) and from `data.ts` previews with `idx = 0` (head). Default `atChatEnd = true` means non-open / preview subIds are never suppressed.
+
+- [ ] **Step 1: Rewrite `add`**
+
+Replace the current `add` (currently: dedup via `getMessageById`, then `list.splice(idx, 0, param); this.set(subId, list);`):
+
+```ts
+	add (subId: string, idx: number, param: I.ChatMessage): void {
+		const list = this.getList(subId);
+		const item = this.getMessageById(subId, param.id);
+
+		if (item) {
+			return;
+		};
+
+		const isTail = idx >= list.length;
+
+		// A genuinely-newer live message while the window is not at the chat end would land
+		// after an evicted tail (out of order). Suppress it; it is fetched on scroll-down /
+		// jump-to-bottom. Non-open and preview subIds keep atChatEnd === true (default).
+		if (isTail) {
+			const last = list.length ? list[list.length - 1] : null;
+			if (shouldSuppressLiveAdd(this.isAtChatEnd(subId), param.orderId, last ? last.orderId : '')) {
+				return;
+			};
+		};
+
+		list.splice(idx, 0, param);
+
+		// Tail insert behaves like append: trim the oldest head if over the cap.
+		if (isTail) {
+			const evicted = evictedCount(list.length, MAX_MESSAGES);
+			if (evicted) {
+				list.splice(0, evicted);
+				this.setAtChatStart(subId, false);
+			};
+		};
+
+		this.set(subId, list);
+	};
+```
+
+Update the chatWindow import line from Task 2 to include the new helper:
+
+```ts
+import { evictedCount, shouldSuppressLiveAdd } from 'Lib/util/chatWindow';
+```
+
+- [ ] **Step 2: Typecheck, lint, commit**
+
+Run: `bun run typecheck && bun run lint`
+Expected: no errors.
+
+```bash
+git add src/ts/store/chat.ts
+git commit -m "feat(chat): suppress out-of-order live inserts past an evicted tail"
+```
+
+---
+
+### Task 4: Component edge-flag wiring + guard fix
+
+**Files:**
+- Modify: `src/ts/component/block/chat.tsx` (`loadMessages` dir>0 guard, dir<0/dir>0 reached-edge, `subscribeMessages`, `loadMessagesByOrderId`, remove `isLoadedPrev`)
+
+**Interfaces:**
+- Consumes: `S.Chat.isAtChatEnd`/`setAtChatEnd`/`setAtChatStart` (Task 2); `edgesAfterJump`, `reachedEdge` (Task 1).
+- Produces: the dir>0 re-fetch is now gated on `atChatEnd`; jumps set both edges correctly.
+
+Context: the working tree currently has `isLoadingPrev`/`isLoadedPrev` refs (uncommitted). This task replaces the `isLoadedPrev` ref with the store flag; `isLoadingPrev` stays.
+
+- [ ] **Step 1: Add the chatWindow import**
+
+At the top of `chat.tsx`, add:
+
+```ts
+import { edgesAfterJump, reachedEdge } from 'Lib/util/chatWindow';
+```
+
+- [ ] **Step 2: Remove the `isLoadedPrev` ref, keep `isLoadingPrev`, add `isLoadingNext`**
+
+Find the ref declarations (working tree has `const isLoadingPrev = useRef(false);` and `const isLoadedPrev = useRef(false);`). Replace those two lines with:
+
+```ts
+	const isLoadingPrev = useRef(false);
+	const isLoadingNext = useRef(false);
+```
+
+(`atChatStart`/`atChatEnd` now live in the store, keyed by `subId` — no component ref.)
+
+- [ ] **Step 3: Replace every `isLoadedPrev.current` read/write**
+
+Search `chat.tsx` for `isLoadedPrev` and replace each usage:
+- The dir<0 guard `if (isLoadingPrev.current || isLoadedPrev.current) { return; }` → `if (isLoadingPrev.current || S.Chat.isAtChatStart(subId)) { return; }`
+- The dir<0 reached-oldest write `isLoadedPrev.current = true;` → `S.Chat.setAtChatStart(subId, true);`
+- The resets in `init` / `loadMessagesByOrderId` / the `clear` path (`isLoadedPrev.current = false;` and `isLoadingPrev.current = false;`) → drop the `isLoadedPrev` line (store `clear` resets the flag, default `true`); keep `isLoadingPrev.current = false;` and add `isLoadingNext.current = false;` beside it.
+
+- [ ] **Step 4: Fix the dir>0 guard (the core bug)**
+
+Find `if (!clear && (dir > 0) && isLoaded) { setIsBottom(true); return; };` in `loadMessages`. Replace with:
+
+```ts
+			if (!clear && (dir > 0) && S.Chat.isAtChatEnd(subId)) {
+				setIsBottom(true);
+				return;
+			};
+```
+
+(Leave the `isLoaded` React state and `setLoaded` everywhere else — they still drive `isEmpty`/`<Empty/>`.)
+
+- [ ] **Step 5: Set `atChatEnd` when a dir>0 fetch reaches the newest**
+
+In the dir>0 branch of the `C.ChatGetMessages` callback, find the block that handles a short page (currently `if (messages.length < J.Constant.limit.chat.messages) { setLoaded(true); setIsBottom(true); subscribeMessages(false); } else { setIsBottom(false); };`). Add the flag set in the short-page branch:
+
+```ts
+				if (dir > 0) {
+					if (reachedEdge(messages.length, J.Constant.limit.chat.messages)) {
+						S.Chat.setAtChatEnd(subId, true);
+						setLoaded(true);
+						setIsBottom(true);
+						subscribeMessages(false);
+					} else {
+						setIsBottom(false);
+					};
+				} else {
+```
+
+- [ ] **Step 6: Anchor `atChatEnd = true` on the clear/last-page load**
+
+In `subscribeMessages`, inside the `loadDepsAndReplies` callback, where it currently does `if (clear) { S.Chat.set(subId, messages); }`, add directly after the `S.Chat.set`:
+
+```ts
+				if (clear) {
+					S.Chat.set(subId, messages);
+					S.Chat.setAtChatEnd(subId, true);
+					S.Chat.setAtChatStart(subId, reachedEdge(messages.length, J.Constant.limit.chat.messages));
+				};
+```
+
+- [ ] **Step 7: Derive both edges from the jump fetch lengths**
+
+In `loadMessagesByOrderId`, the two nested `C.ChatGetMessages` calls fetch `limit` before and after the orderId into `list`. Capture each page length and set the flags in the inner callback before `callBack?.()`. Replace the inner `loadDepsAndReplies(list, () => { S.Chat.set(subId, list); callBack?.(); });` region so the lengths are recorded:
+
+```ts
+		const limit = Math.ceil(J.Constant.limit.chat.messages / 2);
+		let beforeLength = 0;
+		let afterLength = 0;
+
+		C.ChatGetMessages(chatId, orderId, '', limit, true, (message: any) => {
+			if (!message.error.code && message.messages.length) {
+				beforeLength = message.messages.length;
+				list = list.concat(message.messages);
+			};
+
+			C.ChatGetMessages(chatId, '', orderId, limit, false, (message: any) => {
+				if (!message.error.code && message.messages.length) {
+					afterLength = message.messages.length;
+					list = list.concat(message.messages);
+				};
+
+				loadDepsAndReplies(list, () => {
+					S.Chat.set(subId, list);
+
+					const edges = edgesAfterJump(beforeLength, afterLength, limit);
+					S.Chat.setAtChatStart(subId, edges.atChatStart);
+					S.Chat.setAtChatEnd(subId, edges.atChatEnd);
+
+					callBack?.();
+				});
+			});
+		});
+```
+
+(Keep the existing `isLoadingPrev`/`isLoadingNext` resets at the top of `loadMessagesByOrderId` from Step 3.)
+
+- [ ] **Step 8: Typecheck, lint, commit**
+
+Run: `bun run typecheck && bun run lint`
+Expected: no errors. `grep -n isLoadedPrev src/ts/component/block/chat.tsx` must return nothing.
+
+```bash
+git add src/ts/component/block/chat.tsx
+git commit -m "fix(chat): gate scroll-down re-fetch on atChatEnd, derive edges from fetches"
+```
+
+---
+
+### Task 5: Scroll-down recovery (re-fetch + in-flight guard + forced render)
+
+**Files:**
+- Modify: `src/ts/component/block/chat.tsx` (`loadMessages` dir>0 path, `onScroll`)
+
+**Interfaces:**
+- Consumes: `isLoadingNext` (Task 4), `S.Chat.append` returning `evicted` (Task 2), `shouldRefetchForward` (Task 1).
+- Produces: scrolling down past an evicted edge transparently appends the next page and re-renders.
+
+- [ ] **Step 1: Guard the dir>0 fetch with `isLoadingNext`**
+
+In `loadMessages`, in the non-`clear` `else` branch, mirror the existing dir<0 in-flight guard. Where the dir<0 guard sets `isLoadingPrev.current = true;` before `C.ChatGetMessages`, add a dir>0 sibling:
+
+```ts
+			if (dir > 0) {
+				if (isLoadingNext.current) {
+					return;
+				};
+				isLoadingNext.current = true;
+			};
+```
+
+In the `C.ChatGetMessages` callback, at the very top (alongside the existing dir<0 `isLoadingPrev.current = false;` and in the `message.error.code` early-return), clear it:
+
+```ts
+				if (dir > 0) {
+					isLoadingNext.current = false;
+				};
+```
+
+(Place this clear both in the error early-return block and at the start of the success path, matching how `isLoadingPrev` is cleared.)
+
+- [ ] **Step 2: Force a re-render after the dir>0 append**
+
+The dir<0 path already does `setDummy(v => v + 1)` after a growing `prepend`. Add the dir>0 sibling. In the `loadDepsAndReplies` callback where the store mutation happens, after `S.Chat[(dir < 0 ? 'prepend' : 'append')](subId, messages);` and the existing dir<0 `setDummy`, add:
+
+```ts
+						if ((dir > 0) && (S.Chat.getList(subId).length > lengthBefore)) {
+							setDummy(v => v + 1);
+						};
+```
+
+(`lengthBefore` is the `S.Chat.getList(subId).length` captured before the prepend/append, already present in the working tree's dir<0 block — hoist its capture so it covers both directions.)
+
+- [ ] **Step 3: Add the symmetric scroll-down prefetch trigger**
+
+In `onScroll`, the working tree triggers load-older with a one-viewport threshold (`const threshold = container?.offsetHeight ?? 0; if (st <= threshold) loadMessages(-1, false);`) and triggers load-newer only `if (isBottom) loadMessages(1, false);`. Replace the load-newer trigger with a symmetric threshold gated by `shouldRefetchForward`:
+
+```ts
+			const threshold = container?.offsetHeight ?? 0;
+
+			if (st <= threshold) {
+				loadMessages(-1, false);
+			};
+
+			if ((max > 0) && (st >= (max - threshold)) && shouldRefetchForward(S.Chat.isAtChatEnd(subId), true, isLoadingNext.current)) {
+				loadMessages(1, false);
+			};
+```
+
+(`max` is the existing `U.Dom.getMaxScrollHeight(isPopup)` value in `onScroll`. Passing `true` for the `isBottom` argument of `shouldRefetchForward` is intentional — the `st >= max - threshold` check already establishes "near the bottom"; the helper then enforces `!atChatEnd && !isLoadingNext`.)
+
+- [ ] **Step 4: Verify the auto-stick effect does not yank to bottom**
+
+Confirm (read-only) that the dir>0 full-page branch still calls `setIsBottom(false)` before the async append (Task 4 Step 5 keeps `else { setIsBottom(false); }`), so the `useLayoutEffect([messages.length]) → scrollToBottomCheck()` no-ops on recovery (it only sticks when `isBottom.current` is true). No code change; this is an assertion to check after Steps 1-3.
+
+- [ ] **Step 5: Typecheck, lint, manual verification, commit**
+
+Run: `bun run typecheck && bun run lint`
+Expected: no errors.
+
+Manual (build + run — scroll behavior cannot be unit-tested in jsdom):
+```bash
+ELECTRON_SKIP_NOTARIZE=1 bun run dist:mac
+./dist/mac-arm64/Anytype.app/Contents/MacOS/Anytype
+```
+In a chat with >1000 messages: scroll up well past the window, then scroll back down — the newer messages must reappear (no permanent gap, no "false bottom" stall longer than one page fetch), with no scroll jump.
+
+```bash
+git add src/ts/component/block/chat.tsx
+git commit -m "feat(chat): bidirectional scroll-down re-fetch with in-flight guard"
+```
+
+---
+
+### Task 6: "New messages" affordance for the suppressed-while-at-window-bottom case
+
+**Files:**
+- Modify: `src/ts/component/block/chat.tsx` (`setIsBottom`)
+
+**Interfaces:**
+- Consumes: `S.Chat.isAtChatEnd` (Task 2).
+- Produces: the scroll-to-bottom / new-messages button shows when either not at the window bottom OR not at the chat end.
+
+Context: `setIsBottom(v)` toggles the `#navigation-${I.ChatReadType.Message}` button's `active` class on `!v`. When `isBottom===true` but `atChatEnd===false`, a suppressed live message would otherwise show no indicator.
+
+- [ ] **Step 1: Gate the button on `(!isBottom || !atChatEnd)`**
+
+In `setIsBottom`, find the button toggle (currently `U.Dom.toggleClass(btn, 'active', !v);`). Replace with:
+
+```ts
+		if (btn) {
+			const showNav = (!v) || (!S.Chat.isAtChatEnd(getSubId()));
+			U.Dom.toggleClass(btn, 'active', showNav);
+		};
+```
+
+- [ ] **Step 2: Typecheck, lint, manual verification, commit**
+
+Run: `bun run typecheck && bun run lint`
+Expected: no errors.
+
+Manual: open a chat via the unread badge so it lands mid-history; the scroll-to-bottom button must be visible (because `!atChatEnd`) even though you may be at the window bottom.
+
+```bash
+git add src/ts/component/block/chat.tsx
+git commit -m "fix(chat): show new-messages button when window bottom is not the chat end"
+```
+
+---
+
+### Task 7: Bound the per-scroll cost (rAF-coalesce `onScroll`)
+
+**Files:**
+- Modify: `src/ts/component/block/chat.tsx` (the scroll handler binding in `rebind`/`resize`)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `onScroll` runs at most once per animation frame.
+
+Context: `onScroll` calls `getMessagesInViewport()` which does a `getBoundingClientRect` per message every event; raising the window to 1000 doubles that. Coalescing to one run per frame removes the multi-fire-per-frame cost (the dominant factor) without a viewport-scan rewrite.
+
+- [ ] **Step 1: Add a rAF-coalescing wrapper around the bound scroll handler**
+
+Add a ref near the other refs:
+
+```ts
+	const scrollRafRef = useRef(0);
+```
+
+In `rebind` (and `resize`, wherever `scrollHandlerRef.current = (e: Event) => onScroll(e);` is set), wrap it so multiple scroll events within a frame collapse to one:
+
+```ts
+		scrollHandlerRef.current = (e: Event) => {
+			if (scrollRafRef.current) {
+				return;
+			};
+			scrollRafRef.current = raf(() => {
+				scrollRafRef.current = 0;
+				onScroll(e);
+			});
+		};
+```
+
+In the cleanup `useEffect` (where `raf.cancel(frameRef.current)` is called), also cancel this one:
+
+```ts
+			raf.cancel(scrollRafRef.current);
+```
+
+- [ ] **Step 2: Typecheck, lint, manual verification, commit**
+
+Run: `bun run typecheck && bun run lint`
+Expected: no errors.
+
+Manual: scroll a large chat quickly; scrolling should stay smooth, sticky date header (`renderDates`) and read-tracking still update. Confirm no regression in load-older/newer triggering (they now fire at most once per frame, which is sufficient).
+
+```bash
+git add src/ts/component/block/chat.tsx
+git commit -m "perf(chat): coalesce scroll handler to one run per frame"
+```
+
+> If profiling still shows jank at 1000 messages, that is the trigger to escalate to render virtualization (out of scope for this plan — note it for follow-up).
+
+---
+
+### Task 8: Raise the window cap to 1000
+
+**Files:**
+- Modify: `src/ts/store/chat.ts` (`MAX_MESSAGES`) — only if Task 2 temporarily kept 500.
+
+- [ ] **Step 1: Confirm the cap value**
+
+Ensure `src/ts/store/chat.ts` has `const MAX_MESSAGES = 1000;`. If Task 2 set it directly, this task is a no-op confirmation (the sequencing exists so the cap rises only after Task 7's scroll-cost fix is in place).
+
+- [ ] **Step 2: Typecheck, lint, manual verification, commit (if changed)**
+
+Run: `bun run typecheck && bun run lint`
+Manual: in the 486-burst chat, scroll through the burst — the rest of the chat must not be evicted from view while within ~1000 messages; scrolling smooth (Task 7 in place).
+
+```bash
+git add src/ts/store/chat.ts
+git commit -m "feat(chat): raise in-memory window to 1000 messages"
+```
+
+---
+
+### Task 9: Explicit scroll anchoring + verification
+
+**Files:**
+- Modify: `src/scss/page/main/chat.scss` (chat scroll container rule)
+
+**Interfaces:** none.
+
+Context: the prepend/append paths rely on native `overflow-anchor` (default `auto`) to hold the viewport when content is inserted above / the head is evicted above. Make it explicit and verify on real Electron.
+
+- [ ] **Step 1: Confirm nothing disables anchoring**
+
+Run: `grep -rn "overflow-anchor" src/scss/`
+Expected: no `overflow-anchor: none` on the chat scroll container or its ancestors.
+
+- [ ] **Step 2: Add an explicit `overflow-anchor: auto` to the chat scroll container**
+
+In `src/scss/page/main/chat.scss`, on the chat wrapper rule that owns the scroll area (the `.wrap`/`.scrollWrapper` block — match the existing selector that contains `.scrollWrapper { flex-grow: 1; }`), add a one-line own-property rule for the scroll wrapper:
+
+```scss
+.scrollWrapper { flex-grow: 1; overflow-anchor: auto; }
+```
+
+(Do not change any other property. If the actual scrolling element is the shared page container rather than `.scrollWrapper`, leave this as the explicit default and rely on Step 3's verification; do not add `overflow-anchor` to shared page selectors that affect non-chat pages.)
+
+- [ ] **Step 3: Manual verification on real Electron (the load-bearing check)**
+
+Build and run (commands as in Task 5). In a >1000-msg chat:
+- Scroll up so an older page loads — the viewport must stay visually anchored (no jump by ~one page).
+- Scroll down so a page appends and the head evicts — the viewport must stay anchored.
+- Use fling/momentum scroll — confirm anchoring holds and the `focus` handler / `messages.length` layout effect do not fight it.
+
+If anchoring fails under any of these, implement the documented fallback (measure `scrollHeight` before the store mutation and restore `scrollTop += scrollHeight_after − scrollHeight_before` in the post-commit layout effect) — but only if the native behavior proves unreliable.
+
+- [ ] **Step 4: Lint, commit**
+
+Run: `bun run lint`
+Expected: no errors.
+
+```bash
+git add src/scss/page/main/chat.scss
+git commit -m "fix(chat): make scroll anchoring explicit on the message scroll container"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 edge state (store-owned, default true) → Task 2.
+- §2 set/reset table (subscribe-clear, jump, reached-edge, eviction, clear) → Tasks 2, 4.
+- §3 reversible eviction + scroll-down recovery (guard fix, `isLoadingNext`, prefetch, `setDummy` on append) → Tasks 4, 5.
+- §4 window size + `add` routed through append (no `add` cap) → Tasks 2, 3, 8.
+- §5 live-add suppression keyed on `orderId`, scoped via default-true → Tasks 1, 3.
+- §6 `isBottom × atChatEnd` affordance → Task 6.
+- §7 scroll-cost hardening before the cap bump → Tasks 7, 8.
+- §8 explicit `overflow-anchor` + verification → Task 9.
+- §9 known limitations (popup/main shared subId, caches, interleaved) → documented in spec; no task (accepted/out of scope).
+- Testing: pure helpers unit-tested (Task 1); store/component manual + typecheck/lint (each task).
+
+**Type consistency:** `isAtChatStart`/`isAtChatEnd`/`setAtChatStart`/`setAtChatEnd` (Task 2) used verbatim in Tasks 3-6. `prepend`/`append` return `boolean` (Task 2) — the existing single call site captures it dynamically. Helper signatures (`shouldRefetchForward`, `shouldSuppressLiveAdd`, `edgesAfterJump`, `reachedEdge`, `evictedCount`) match between Task 1 definition and Tasks 2-6 usage.
+
+**Placeholder scan:** no TBD/TODO; every code step shows complete code; manual-verification steps give exact build/run commands and observable expectations (scroll behavior is genuinely not jsdom-unit-testable — the decision logic that *is* testable was extracted into Task 1).

--- a/docs/superpowers/specs/2026-06-26-chat-message-windowing-design.md
+++ b/docs/superpowers/specs/2026-06-26-chat-message-windowing-design.md
@@ -1,0 +1,159 @@
+# Chat message windowing — design spec
+
+**Date:** 2026-06-26
+**Status:** Draft for review (revised after 5-agent review)
+**Area:** `src/ts/component/block/chat.tsx`, `src/ts/store/chat.ts`; touches `src/ts/lib/api/dispatcher.ts` indirectly via `S.Chat.add`
+
+## Problem
+
+When scrolling a chat up into history, messages disappear: after an older batch loads, messages *newer* than the current scroll position vanish from the view, and the chat appears truncated.
+
+### Root cause (evidence-backed)
+
+The in-memory chat list `S.Chat` is capped at `MAX_MESSAGES = 500` (`store/chat.ts:5`). `prepend` (loading older) does `list.unshift(...add); if (list.length > 500) list.splice(500)` — it keeps the 500 **lowest-orderId** entries and **deletes the highest-orderId (newest) ones** (`store/chat.ts:48-60`).
+
+A forward re-fetch path already exists (`loadMessages(1)` → `ChatGetMessages(chatId, '', after, …)`, `chat.tsx` dir>0 branch), **but it is disabled by a conflated guard**: `if (!clear && (dir > 0) && isLoaded) { setIsBottom(true); return; }` (`chat.tsx:251`). `isLoaded` becomes `true` the first time the user reaches the live bottom and never resets during scroll-up, so after eviction the guard short-circuits and the evicted newest messages are never re-fetched. Only the jump-to-bottom button (re-subscribe) recovers them.
+
+Confirmed from a live gRPC trace: in one scroll session the in-memory list grew 50 → 550 over ten `prepend`s, then `splice(500)` evicted the 50 newest (createdAt 2026-05-02 … 2026-06-24).
+
+**Not the cause:** an earlier hypothesis blamed a `createdAt`/`orderId` ordering mismatch. Direct inspection of the store (via `any-store-cli`) refuted this for the affected chat: **0 `createdAt`/`orderId` inversions**, every calendar day a contiguous block. Across the space (63 chats ≥30 msgs), 45 are fully clean; only 1 has notable date-interleaving. Ordering is a separate, minor concern, out of scope here.
+
+**Aggravating factor:** the affected chat has a 486-message burst within a single minute (a bulk relay) — alone it nearly fills the 500-message window, so scrolling into it evicts almost the entire rest of the chat.
+
+**Rendering constraint:** the chat has **no virtualization** — every loaded message is a DOM node (`chat.tsx` maps `items` directly), and `onScroll` is unthrottled and calls `getBoundingClientRect` per message via `getMessagesInViewport`. So the window size bounds memory, DOM, **and** per-scroll layout cost; it cannot simply be removed or raised without addressing scroll cost.
+
+## Goals
+
+- Scrolling up never silently loses newer messages; scrolling back down transparently restores them.
+- The in-memory window and per-scroll cost stay bounded.
+- A large single-day burst does not evict the rest of the visible chat.
+- New live messages arriving while scrolled up never appear out of order, and are signalled.
+
+## Non-goals
+
+- `orderId`-canonical display ordering (separate, minor; the one interleaved chat has only a visual wrinkle — see §9).
+- Full render virtualization — the proper generalization (removes the memory bound, the O(n) scroll cost, and the burst thrash at once), but a large rewrite. Tracked as the explicit follow-up if windowing + scroll-cost hardening prove insufficient (§7).
+- Backend `createdAt` semantics (import/relay timestamps are a middleware concern).
+- Comment lists (`S.Comment`) are a separate, also-uncapped store; the same class of bug exists there but is out of scope.
+
+## Current state
+
+The working tree already contains the scroll-**up** half of this work (uncommitted): `isLoadingPrev`/`isLoadedPrev` refs, a one-viewport load-older prefetch threshold, in-flight guarding, and a switch from `scrollToMessage(first.id)` to native `overflow-anchor` + a `setDummy` re-render on `prepend`. **None of `atChatEnd`, the guard fix, the `MAX_MESSAGES` bump, the `add`/dispatcher changes, or the scroll-down recovery exist yet** — so the reported bug is still reachable. This spec covers completing the bidirectional half.
+
+## Design
+
+Treat the in-memory `S.Chat` list as a **sliding window** over the full chat. Track which window edges sit at the chat's true boundaries; re-fetch when scrolling toward a non-boundary edge; never misplace or silently drop messages.
+
+### 1. Edge state — single store-owned source of truth
+
+Two flags, **owned by the store, keyed by `subId`, default `true`** (a not-yet-windowed subId — e.g. the vault/space `lastMessage` preview — must behave as "append-allowed"):
+
+- **`atChatStart(subId)`** — the window's first message is the chat's oldest. (Replaces the working-tree `isLoadedPrev` ref; `isLoadedPrev` is removed, not mirrored.)
+- **`atChatEnd(subId)`** — the window's last message is the chat's newest.
+
+Strict definition: a flag is `true` **iff the corresponding window edge equals the chat's true boundary** — not "we subscribed" or "we loaded something." The store is the single owner because three parties interact with it: the eviction that flips a flag happens *in the store* (`prepend`/`append`), the dir>0/dir<0 guards that *read* it run *in the component*, and the live-add path that reads it runs in `S.Chat.add` (driven by the dispatcher). Duplicating it in a component ref would drift.
+
+Reads from the component's scroll handlers go through a store getter. (Using the store getter instead of the `isLoaded` React state also **fixes a latent stale-closure bug**: `onScroll`/`loadMessages` are bound once at `rebind` and capture a stale `isLoaded`.)
+
+`isLoaded`/`setLoaded` React state is **kept** — it still drives `isEmpty = isLoaded && !messages.length` and the `<Empty/>` render. Only the dir>0 *guard* switches from `isLoaded` to `atChatEnd`.
+
+### 2. Where the flags are set/reset (exhaustive)
+
+| Event | `atChatStart` | `atChatEnd` |
+|---|---|---|
+| `subscribeMessages(clear)` returns the last page | `= (page < limit)` | **`= true`** (window anchored at the newest) |
+| `loadMessages(1, true)` (jump-to-bottom / reload) | from page len | `= true` |
+| `loadMessagesByOrderId(orderId)` (deeplink / unread-divider / reply / pinned) | `= (beforeFetch.length < limit)` | **`= (afterFetch.length < limit)`** — computed from the actual before/after page lengths it already fetches; **not** forced `false` |
+| `loadState` (bare, no message load) | unchanged | **unchanged — must NOT set `true`** |
+| `prepend` evicts ≥1 (loading older) | — | `= false` |
+| `append` evicts ≥1 (loading newer) | `= false` | — |
+| dir>0 fetch returns `< limit` (reached newest) | — | `= true` |
+| dir<0 fetch returns `< limit` (reached oldest) | `= true` | — |
+| dir>0 / dir<0 fetch error | unchanged | **unchanged** (a transient error must not mark an edge reached) |
+| `S.Chat.clear` / chat unmount | reset (delete key → default `true`) | reset |
+
+The critical rule (and the bug-reintroducing trap): **`atChatEnd` is set `true` only when the window is genuinely anchored at the chat's newest** — the clear-to-last-page path and the dir>0 short page. `init` routes unread/deeplink opens through `loadMessagesByOrderId`, which lands mid-history; those must derive `atChatEnd` from the after-page length, leaving it `false` so forward re-fetch stays enabled.
+
+### 3. Reversible eviction + scroll-down recovery
+
+Keep the bounded window and eviction directions (`prepend` drops the newest tail; `append` drops the oldest head). `prepend`/`append` **return whether they evicted**; the caller flips the matching flag (§2).
+
+Scroll-down recovery (dir>0), mirroring the existing dir<0 path:
+- **Guard fix:** the short-circuit `if (!clear && (dir > 0) && isLoaded)` becomes `… && atChatEnd(subId)` (read from store).
+- **In-flight guard:** add `isLoadingNext` (symmetric to `isLoadingPrev`) — set before `ChatGetMessages`, cleared in the callback **and** the error path. dir>0 currently has *no* guard, so without this the bottom-trigger spawns overlapping fetches.
+- **Prefetch threshold:** trigger the dir>0 load one viewport before the exact bottom (mirror the existing dir<0 threshold). This is **required**, not optional: it removes the "false-bottom" dead-stop where the user waits a full round-trip at a bottom that isn't the real bottom, and (by firing at `isBottom=false`) avoids the auto-stick interaction in §6.
+- **Force re-render on append:** `BlockChat` is not a MobX `observer`; the dir<0 path already calls `setDummy` after `prepend`, but the dir>0 append has none — so the recovered page would be invisible. Add `if ((dir > 0) && grew) setDummy(v => v + 1)`.
+- No jump: appending below the viewport doesn't shift content above; the simultaneous head-eviction (above the viewport) is absorbed by `overflow-anchor` (§8).
+
+### 4. Window size and the `add` path
+
+- Raise `MAX_MESSAGES` `500 → 1000` (20 × the 50-message page). 500 cannot hold even the 486-burst plus context. **1000 is a heuristic, not a hard bound:** a single day > 1000 messages still thrashes (re-fetch handles it correctly, just with churn); the real generalization is virtualization (non-goal §). Raising the window is **gated on the scroll-cost hardening in §7** — without it, 1000 doubles per-scroll reflows.
+- **Do not add a length cap inside `S.Chat.add`.** `add` has two opposite-end callers — the dispatcher's new-message tail insert (`idx = list.length`, `dispatcher.ts:1141`) and the preview/space head insert (`idx = 0`, `data.ts:425-426`). A single trim rule corrupts one of them. Instead, **route the dispatcher's tail insert through `append()`** (which trims the head and reports eviction); leave the preview head-insert untrimmed (it is one entry per chat, not a window).
+
+### 5. Live messages while scrolled up
+
+The dispatcher (`dispatcher.ts:1133-1142`) calls `S.Chat.add(subId, idx, message)` for **all** subscribed chat subIds, including the open chat and the vault/space `lastMessage` + `chatPreview` subIds. The suppression must be precisely scoped:
+
+- **Suppress** the insert **only when**: the subId is the open chat's message subId **and** `!atChatEnd(subId)` **and** `message.orderId > lastWindowOrderId` (a genuinely-newer message). Keying on `orderId`, **not** `idx == list.length`, avoids dropping a backfilled message whose `orderId` falls *between* in-window messages (which `findIndex` also resolves to `idx = list.length`).
+- **Never suppress** for preview/space subIds (default `atChatEnd = true` protects them) or for in-window/edit inserts.
+- A suppressed message is loaded later by the scroll-down recovery (§3) or jump-to-bottom (`onScrollToBottomClick` → `loadMessages(1, true)` re-subscribe). Unread/“new messages” state is server-counter-driven (`form.tsx` `messageCounter` from `S.Chat.getState`), so suppression does not break the counter or notifications.
+
+### 6. "New messages" affordance + the `isBottom × atChatEnd` quadrant
+
+The `#navigation-{ChatReadType.Message}` button (`form.tsx`) is toggled active on `!isBottom`. There is a dead zone: `isBottom = true` (user at the *window* bottom) with `atChatEnd = false` (window bottom ≠ chat end) — a suppressed live message shows no indicator. Reachable after a jump/unread-divider open that lands at the window bottom mid-history.
+
+Fix: drive the affordance on **`(!isBottom || !atChatEnd)`**, and ensure a recovery fetch is triggered when a live add is suppressed while `isBottom` (so the window converges to the end rather than stalling).
+
+### 7. Scroll-cost hardening (prerequisite for the window bump)
+
+`onScroll` is unthrottled and `getMessagesInViewport` calls `getBoundingClientRect` + `offsetHeight` per message every tick (~1 forced reflow/message/tick). At 1000 that is ~2× today's per-scroll layout thrash on an un-virtualized list. Before/with the `MAX_MESSAGES` bump:
+- Throttle/`requestAnimationFrame`-coalesce `onScroll`.
+- Replace the per-message `getBoundingClientRect` viewport scan with cached offsets or an `IntersectionObserver`.
+
+If profiling shows this is still inadequate at 1000, that is the trigger to escalate to virtualization (non-goal) rather than living with jank.
+
+### 8. Scroll anchoring
+
+The prepend path (working tree) and the §3 append head-eviction both rely on native `overflow-anchor`, which is **not set in SCSS** (relies on the Chromium `auto` default). Add an explicit `overflow-anchor: auto` on the scroll container, and **verify on the real Electron build** that (a) insertion-above (prepend) and removal-above (append evict) hold the viewport, and (b) it survives the `focus` handler / `messages.length` `useLayoutEffect` that also write `scrollTop`. If anchoring proves unreliable under fling-scroll, fall back to an explicit measured `scrollTop` adjustment.
+
+### 9. Known limitations (documented, not fixed here)
+
+- **Shared `subId` across popup + main:** `getChatSubId` has no `isPopup` discriminator, so the same chat open in both views shares one `messageMap` **and** one store-level `atChatEnd`. If either view is scrolled up, live-add suppression applies to both (the bottom-pinned twin gets the message on its next scroll/refetch). Pre-existing shared-list behavior; accepted.
+- **Detail/reply caches grow on deep scroll:** eviction prunes only `messageMap`; `replyMap` and `S.Detail` attachment entries (via `loadDeps`, which calls `destroyList(clearState=false)`) accumulate during a long session. The dep *subscription* itself is batch-scoped (replaced each `loadDeps`), so no live-subscription leak. Optional follow-up to prune on eviction.
+- **Interleaved chat (`createdAt`≠`orderId`):** `getSections` orders sections by `createdAt` while `atChatEnd`/pagination track `orderId`; for the one interleaved chat, the visual bottom may not equal the `orderId`-newest. Visual wrinkle only (no loss), tied to the out-of-scope ordering work.
+
+## Components touched
+
+- **`src/ts/store/chat.ts`** — `MAX_MESSAGES` `500 → 1000`; `prepend`/`append` return an `evicted` boolean; per-`subId` `atChatStart`/`atChatEnd` map (default `true`) with getters/setters; reset in `clear`; the dispatcher's tail insert routed through `append()` with the §5 suppression check (decided in the store, reading the flag map).
+- **`src/ts/component/block/chat.tsx`** — set/reset the edge flags per §2 (replacing `isLoadedPrev`); dir>0 guard → `atChatEnd`; `isLoadingNext` + dir>0 prefetch threshold; `setDummy` on dir>0 append; `loadMessagesByOrderId` sets both edges from page lengths; "new messages" affordance on `(!isBottom || !atChatEnd)`; `onScroll` throttling + viewport-scan replacement (§7); preserve `setIsBottom(false)`-before-append ordering (§6).
+- **`src/scss/...` chat scroll container** — explicit `overflow-anchor: auto` (§8).
+- **`src/ts/lib/api/dispatcher.ts`** — ideally **unchanged** (suppression lives in the store). If the store can't cleanly know the open subId, the minimal seam is here; prefer the store.
+
+## Data flow (scroll-down recovery)
+
+1. Earlier `prepend`s evicted the newest tail → `atChatEnd(subId) = false`.
+2. User scrolls down; `onScroll` fires the dir>0 load one viewport before the window bottom; `isLoadingNext` guards re-entry.
+3. Guard passes because `!atChatEnd`; `loadMessages(1)` fetches the page after the window's last `orderId`.
+4. `append` adds it (dedup by id), trims the oldest head if over `MAX_MESSAGES` (→ `atChatStart = false`); `setDummy` forces the render.
+5. If the page is `< limit` (reached the newest), `atChatEnd = true` and re-subscribe to live.
+
+## Edge cases
+
+- **Empty / short chat (≤ window):** clear-subscribe returns `< limit` → both edges `true`; eviction never fires; behavior identical to today.
+- **Jump near a boundary:** `loadMessagesByOrderId` sets the edges from the real before/after page lengths (§2), so a jump close to the end correctly yields `atChatEnd = true` and doesn't suppress live messages.
+- **Direction-reversal thrash:** bounded by `isLoadingPrev`/`isLoadedNext` (one in-flight per direction) and the 1000-window; the prefetch thresholds fire only when an edge actually nears the viewport.
+- **Burst > window:** the window slides through via §3 re-fetch; nothing lost, only not all held at once.
+- **Transient fetch error mid-chat:** clears the in-flight guard but leaves edges unchanged (must not mark "reached"), so recovery still works.
+
+## Testing
+
+- **Pure-logic unit tests** (extract helpers so the decision logic isn't trapped in `chat.tsx`): `nextEdgeState(op, evicted, pageLen, limit)` and `shouldRefetchForward(atChatEnd, isBottom)` / `shouldSuppressLiveAdd(subId, atChatEnd, msgOrderId, lastOrderId)`.
+- **Store unit tests:** `prepend`/`append` report eviction and flip flags; tail-insert-via-`append` trims the head; `clear` resets flags; preview head-insert is untrimmed and never suppressed.
+- **Manual / E2E** (scroll behavior needs real layout): in a >1000-msg chat **and** the 486-burst chat — (1) scroll up past the window → nothing vanishes; (2) scroll back down → window re-populates correctly, no jump, no false-bottom stall; (3) jump-to-bottom → live newest; (4) open via unread badge / `&messageId=` deeplink mid-history → forward scroll re-fetches (regression guard for the `atChatEnd`-on-subscribe trap); (5) live message while scrolled up → not out of order, indicator shows, present after jump-to-bottom.
+
+## References
+
+- gRPC trace: in-memory list 50→550 then `splice(500)` evicting the 50 newest.
+- `any-store-cli` inspection of the affected chat: 751 messages, 0 `createdAt`/`orderId` inversions, 54 contiguous day-sections, one 486-message single-minute burst.
+- Space-wide scan (63 chats ≥30 msgs): 45 fully clean ordering, 1 with notable interleaving — confirming ordering is not the cause.
+- 5-agent review (correctness, edge-cases/races, integration, UX, adversarial), 2026-06-26 — findings folded into §1–§9.

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -57,6 +57,8 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	const prevReplyKey = useRef('');
 	const pendingScrollToBottom = useRef(false);
 	const pendingScrollToMessageId = useRef('');
+	const isLoadingPrev = useRef(false);
+	const isLoadedPrev = useRef(false);
 	const object = S.Detail.get(rootId, rootId, []);
 
 	const getChatId = () => {
@@ -252,6 +254,11 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		};
 
 		if (clear) {
+			// Re-subscribing to the latest messages resets the window, so older history is
+			// reachable again — clear the prefetch guards.
+			isLoadingPrev.current = false;
+			isLoadedPrev.current = false;
+
 			subscribeMessages(clear, () => {
 				setIsBottom(true);
 				callBack?.();
@@ -262,7 +269,6 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 				return;
 			};
 
-			const first = messages[0];
 			const before = dir < 0 ? messages[0].orderId : '';
 			const after = dir > 0 ? messages[messages.length - 1].orderId : '';
 
@@ -270,8 +276,23 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 				return;
 			};
 
+			// Guard older-batch loads: skip if one is already in flight (the prefetch threshold
+			// widens the trigger band, so onScroll can fire many times) or we already hit the
+			// oldest message. Without this the prefetch would spam duplicate requests.
+			if (dir < 0) {
+				if (isLoadingPrev.current || isLoadedPrev.current) {
+					return;
+				};
+
+				isLoadingPrev.current = true;
+			};
+
 			C.ChatGetMessages(chatId, before, after, J.Constant.limit.chat.messages, false, (message: any) => {
 				if (message.error.code) {
+					if (dir < 0) {
+						isLoadingPrev.current = false;
+					};
+
 					setLoaded(true);
 					callBack?.();
 					return;
@@ -291,20 +312,35 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 					const y = U.Dom.getMaxScrollHeight(isPopup);
 					const top = U.Dom.getScrollContainerTop(isPopup);
 
+					// Fewer than a full page means there are no older messages left to fetch.
+					if (messages.length < J.Constant.limit.chat.messages) {
+						isLoadedPrev.current = true;
+					};
+
 					setIsBottom(!(top < y));
 				};
 
 				loadDepsAndReplies(messages, () => {
 					if (messages.length) {
-						if (dir < 0) {
-							setAutoLoadDisabled(true);
-						};
+						const lengthBefore = S.Chat.getList(subId).length;
 
 						S.Chat[(dir < 0 ? 'prepend' : 'append')](subId, messages);
 
-						if (first && (dir < 0)) {
-							scrollToMessage(first.id);
+						// Force a re-render so the prepended rows commit — the component is not a
+						// MobX observer. We deliberately do NOT touch scrollTop: the browser's
+						// native scroll anchoring (overflow-anchor) keeps the viewport visually
+						// static when content is inserted above and preserves scroll momentum.
+						// Setting scrollTop ourselves would interrupt the momentum and make the
+						// view jump (~1 viewport) at the moment the batch loads.
+						if ((dir < 0) && (S.Chat.getList(subId).length > lengthBefore)) {
+							setDummy(v => v + 1);
 						};
+					};
+
+					// Release the in-flight guard only after the prepend, so the wider prefetch
+					// band can't fire a duplicate request for the same batch mid-flight.
+					if (dir < 0) {
+						isLoadingPrev.current = false;
 					};
 
 					callBack?.();
@@ -321,6 +357,10 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 
 		const subId = getSubId();
 		const limit = Math.ceil(J.Constant.limit.chat.messages / 2);
+
+		// The list is rebuilt around orderId, so older history is reachable again.
+		isLoadingPrev.current = false;
+		isLoadedPrev.current = false;
 
 		let list = [];
 
@@ -808,7 +848,11 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		setIsBottom(isBottom);
 
 		if (!isAutoLoadDisabled.current) {
-			if (st <= 0) {
+			// Prefetch the previous batch one viewport before the top is reached, so scrolling
+			// into the past doesn't stall waiting for the network round-trip.
+			const threshold = container?.offsetHeight ?? 0;
+
+			if (st <= threshold) {
 				loadMessages(-1, false);
 			};
 
@@ -1359,6 +1403,8 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		setLoaded(false);
 		setIsBottom(false);
 		setFirstUnreadOrderId('');
+		isLoadingPrev.current = false;
+		isLoadedPrev.current = false;
 		loadState(() => {
 			loadPinnedMessages();
 			const subId = getSubId();

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -9,7 +9,7 @@ import { Icon, IconObject } from 'Component';
 import * as I from 'Interface';
 import * as M from 'Model';
 import Storage from 'Lib/storage';
-import { edgesAfterJump, reachedEdge } from 'Lib/util/chatWindow';
+import { edgesAfterJump, reachedEdge, shouldRefetchForward } from 'Lib/util/chatWindow';
 
 interface RefProps {
 	forceUpdate: () => void;
@@ -288,12 +288,20 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 				};
 
 				isLoadingPrev.current = true;
+			} else {
+				if (isLoadingNext.current) {
+					return;
+				};
+
+				isLoadingNext.current = true;
 			};
 
 			C.ChatGetMessages(chatId, before, after, J.Constant.limit.chat.messages, false, (message: any) => {
 				if (message.error.code) {
 					if (dir < 0) {
 						isLoadingPrev.current = false;
+					} else {
+						isLoadingNext.current = false;
 					};
 
 					setLoaded(true);
@@ -330,21 +338,22 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 
 						S.Chat[(dir < 0 ? 'prepend' : 'append')](subId, messages);
 
-						// Force a re-render so the prepended rows commit — the component is not a
-						// MobX observer. We deliberately do NOT touch scrollTop: the browser's
-						// native scroll anchoring (overflow-anchor) keeps the viewport visually
-						// static when content is inserted above and preserves scroll momentum.
-						// Setting scrollTop ourselves would interrupt the momentum and make the
-						// view jump (~1 viewport) at the moment the batch loads.
-						if ((dir < 0) && (S.Chat.getList(subId).length > lengthBefore)) {
+						// Force a re-render so the new rows commit (either direction) — the
+						// component is not a MobX observer. We deliberately do NOT touch
+						// scrollTop: native scroll anchoring (overflow-anchor) keeps the viewport
+						// static when content is inserted above and preserves momentum; setting
+						// scrollTop ourselves would jump the view (~1 viewport) at load time.
+						if (S.Chat.getList(subId).length > lengthBefore) {
 							setDummy(v => v + 1);
 						};
 					};
 
-					// Release the in-flight guard only after the prepend, so the wider prefetch
-					// band can't fire a duplicate request for the same batch mid-flight.
+					// Release the in-flight guard only after the store mutation, so the wider
+					// prefetch band can't fire a duplicate request for the same batch mid-flight.
 					if (dir < 0) {
 						isLoadingPrev.current = false;
+					} else {
+						isLoadingNext.current = false;
 					};
 
 					callBack?.();
@@ -862,15 +871,17 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		setIsBottom(isBottom);
 
 		if (!isAutoLoadDisabled.current) {
-			// Prefetch the previous batch one viewport before the top is reached, so scrolling
-			// into the past doesn't stall waiting for the network round-trip.
+			// Prefetch one viewport before each edge so scrolling doesn't stall on the network
+			// round-trip — into the past (older), and into the present (newer) when the window's
+			// tail was evicted. shouldRefetchForward keeps the newer-fetch off once we're at the
+			// chat end or a fetch is already in flight.
 			const threshold = container?.offsetHeight ?? 0;
 
 			if (st <= threshold) {
 				loadMessages(-1, false);
 			};
 
-			if (isBottom) {
+			if ((max > 0) && (st >= (max - threshold)) && shouldRefetchForward(S.Chat.isAtChatEnd(subId), true, isLoadingNext.current)) {
 				loadMessages(1, false);
 			};
 		};

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -61,6 +61,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	const pendingScrollToMessageId = useRef('');
 	const isLoadingPrev = useRef(false);
 	const isLoadingNext = useRef(false);
+	const loadEpoch = useRef(0);
 	const object = S.Detail.get(rootId, rootId, []);
 
 	const getChatId = () => {
@@ -263,9 +264,10 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 
 		if (clear) {
 			// Re-subscribing to the latest messages resets the window, so older history is
-			// reachable again — clear the prefetch guards.
+			// reachable again — clear the prefetch guards and invalidate in-flight responses.
 			isLoadingPrev.current = false;
 			isLoadingNext.current = false;
+			loadEpoch.current++;
 
 			subscribeMessages(clear, () => {
 				setIsBottom(true);
@@ -304,7 +306,17 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 				isLoadingNext.current = true;
 			};
 
+			// Snapshot the window generation. If the window is reset (jump-to-bottom, deeplink,
+			// reload, chat switch) while this request is in flight, the response is stale and must
+			// be dropped — otherwise it would prepend/append into a freshly-rebuilt window, punching
+			// a gap and corrupting the edge flags. Reset paths bump loadEpoch and clear the guards.
+			const epoch = loadEpoch.current;
+
 			C.ChatGetMessages(chatId, before, after, J.Constant.limit.chat.messages, false, (message: any) => {
+				if (loadEpoch.current != epoch) {
+					return;
+				};
+
 				if (message.error.code) {
 					if (dir < 0) {
 						isLoadingPrev.current = false;
@@ -341,6 +353,12 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 				};
 
 				loadDepsAndReplies(messages, () => {
+					// The window may have been reset during the async dep/reply fetch — re-check
+					// before mutating the store so a stale page can't stitch into a new window.
+					if (loadEpoch.current != epoch) {
+						return;
+					};
+
 					if (messages.length) {
 						const lengthBefore = S.Chat.getList(subId).length;
 						const evicted = S.Chat[(dir < 0 ? 'prepend' : 'append')](subId, messages);
@@ -382,10 +400,11 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		const subId = getSubId();
 		const limit = Math.ceil(J.Constant.limit.chat.messages / 2);
 
-		// The list is rebuilt around orderId. Reset the in-flight guards; the window edges are
-		// derived below from the actual before/after page lengths (not guessed).
+		// The list is rebuilt around orderId. Reset the in-flight guards and invalidate in-flight
+		// responses; the window edges are derived below from the actual before/after page lengths.
 		isLoadingPrev.current = false;
 		isLoadingNext.current = false;
+		loadEpoch.current++;
 
 		let list = [];
 		let beforeOk = false;
@@ -1469,6 +1488,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		setFirstUnreadOrderId('');
 		isLoadingPrev.current = false;
 		isLoadingNext.current = false;
+		loadEpoch.current++;
 		loadState(() => {
 			loadPinnedMessages();
 			const subId = getSubId();

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -9,6 +9,7 @@ import { Icon, IconObject } from 'Component';
 import * as I from 'Interface';
 import * as M from 'Model';
 import Storage from 'Lib/storage';
+import { edgesAfterJump, reachedEdge } from 'Lib/util/chatWindow';
 
 interface RefProps {
 	forceUpdate: () => void;
@@ -58,7 +59,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	const pendingScrollToBottom = useRef(false);
 	const pendingScrollToMessageId = useRef('');
 	const isLoadingPrev = useRef(false);
-	const isLoadedPrev = useRef(false);
+	const isLoadingNext = useRef(false);
 	const object = S.Detail.get(rootId, rootId, []);
 
 	const getChatId = () => {
@@ -227,6 +228,8 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			loadDepsAndReplies(messages, () => {
 				if (clear) {
 					S.Chat.set(subId, messages);
+					S.Chat.setAtChatEnd(subId, true);
+					S.Chat.setAtChatStart(subId, reachedEdge(messages.length, J.Constant.limit.chat.messages));
 				};
 
 				if (messages.length < J.Constant.limit.chat.messages) {
@@ -248,7 +251,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			return;
 		};
 
-		if (!clear && (dir > 0) && isLoaded) {
+		if (!clear && (dir > 0) && S.Chat.isAtChatEnd(subId)) {
 			setIsBottom(true);
 			return;
 		};
@@ -257,7 +260,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			// Re-subscribing to the latest messages resets the window, so older history is
 			// reachable again — clear the prefetch guards.
 			isLoadingPrev.current = false;
-			isLoadedPrev.current = false;
+			isLoadingNext.current = false;
 
 			subscribeMessages(clear, () => {
 				setIsBottom(true);
@@ -280,7 +283,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			// widens the trigger band, so onScroll can fire many times) or we already hit the
 			// oldest message. Without this the prefetch would spam duplicate requests.
 			if (dir < 0) {
-				if (isLoadingPrev.current || isLoadedPrev.current) {
+				if (isLoadingPrev.current || S.Chat.isAtChatStart(subId)) {
 					return;
 				};
 
@@ -301,7 +304,8 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 				const messages = message.messages || [];
 
 				if (dir > 0) {
-					if (messages.length < J.Constant.limit.chat.messages) {
+					if (reachedEdge(messages.length, J.Constant.limit.chat.messages)) {
+						S.Chat.setAtChatEnd(subId, true);
 						setLoaded(true);
 						setIsBottom(true);
 						subscribeMessages(false);
@@ -313,8 +317,8 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 					const top = U.Dom.getScrollContainerTop(isPopup);
 
 					// Fewer than a full page means there are no older messages left to fetch.
-					if (messages.length < J.Constant.limit.chat.messages) {
-						isLoadedPrev.current = true;
+					if (reachedEdge(messages.length, J.Constant.limit.chat.messages)) {
+						S.Chat.setAtChatStart(subId, true);
 					};
 
 					setIsBottom(!(top < y));
@@ -358,24 +362,34 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		const subId = getSubId();
 		const limit = Math.ceil(J.Constant.limit.chat.messages / 2);
 
-		// The list is rebuilt around orderId, so older history is reachable again.
+		// The list is rebuilt around orderId. Reset the in-flight guards; the window edges are
+		// derived below from the actual before/after page lengths (not guessed).
 		isLoadingPrev.current = false;
-		isLoadedPrev.current = false;
+		isLoadingNext.current = false;
 
 		let list = [];
+		let beforeLength = 0;
+		let afterLength = 0;
 
 		C.ChatGetMessages(chatId, orderId, '', limit, true, (message: any) => {
 			if (!message.error.code && message.messages.length) {
+				beforeLength = message.messages.length;
 				list = list.concat(message.messages);
 			};
 
 			C.ChatGetMessages(chatId, '', orderId, limit, false, (message: any) => {
 				if (!message.error.code && message.messages.length) {
+					afterLength = message.messages.length;
 					list = list.concat(message.messages);
 				};
 
 				loadDepsAndReplies(list, () => {
 					S.Chat.set(subId, list);
+
+					const edges = edgesAfterJump(beforeLength, afterLength, limit);
+					S.Chat.setAtChatStart(subId, edges.atChatStart);
+					S.Chat.setAtChatEnd(subId, edges.atChatEnd);
+
 					callBack?.();
 				});
 			});
@@ -1404,7 +1418,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		setIsBottom(false);
 		setFirstUnreadOrderId('');
 		isLoadingPrev.current = false;
-		isLoadedPrev.current = false;
+		isLoadingNext.current = false;
 		loadState(() => {
 			loadPinnedMessages();
 			const subId = getSubId();

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -52,6 +52,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	const [ pinnedMessages, setPinnedMessages ] = useState<I.ChatMessage[]>([]);
 	const [ pinnedIndex, setPinnedIndex ] = useState(-1);
 	const frameRef = useRef(0);
+	const scrollRafRef = useRef(0);
 	const namespace = U.Dom.getEventNamespace(isPopup);
 	const jumpIds = useRef([]);
 	const prevDepsKey = useRef('');
@@ -171,7 +172,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 
 		const container = U.Dom.getScrollContainer(isPopup);
 		if (container) {
-			scrollHandlerRef.current = (e: Event) => onScroll(e);
+			scrollHandlerRef.current = (e: Event) => onScrollRaf(e);
 			U.Dom.addEvent(container, 'scroll', scrollHandlerRef.current);
 		};
 	};
@@ -910,6 +911,20 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		Preview.previewHide(true);
 	};
 
+	// Coalesce scroll events to one onScroll run per animation frame. onScroll does an
+	// O(n) viewport scan (getBoundingClientRect per message); without this, a single
+	// gesture fires it many times per frame, and that cost doubles at the larger window.
+	const onScrollRaf = (e: Event) => {
+		if (scrollRafRef.current) {
+			return;
+		};
+
+		scrollRafRef.current = raf(() => {
+			scrollRafRef.current = 0;
+			onScroll(e);
+		});
+	};
+
 	const readMessage = (id: string, orderId: string, lastStateId: string, type: I.ChatReadType) => {
 		const chatId = getChatId();
 		const subId = getSubId();
@@ -1495,7 +1510,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		window.clearTimeout(timeoutResize.current);
 		timeoutResize.current = window.setTimeout(() => {
 			if (container) {
-				scrollHandlerRef.current = (e: Event) => onScroll(e);
+				scrollHandlerRef.current = (e: Event) => onScrollRaf(e);
 				U.Dom.addEvent(container, 'scroll', scrollHandlerRef.current);
 			};
 		}, 50);
@@ -1562,6 +1577,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			window.clearTimeout(timeoutScrollStop.current);
 			window.clearTimeout(timeoutResize.current);
 			raf.cancel(frameRef.current);
+			raf.cancel(scrollRafRef.current);
 			messageRefs.current = {};
 		};
 	}, []);

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -9,7 +9,7 @@ import { Icon, IconObject } from 'Component';
 import * as I from 'Interface';
 import * as M from 'Model';
 import Storage from 'Lib/storage';
-import { edgesAfterJump, reachedEdge, shouldRefetchForward } from 'Lib/util/chatWindow';
+import { reachedEdge, shouldRefetchForward } from 'Lib/util/chatWindow';
 
 interface RefProps {
 	forceUpdate: () => void;
@@ -121,6 +121,10 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			U.Dom.removeEvent(container, 'scroll', scrollHandlerRef.current);
 			scrollHandlerRef.current = null;
 		};
+
+		// Drop any pending coalesced scroll frame so it can't run against a switched chat.
+		raf.cancel(scrollRafRef.current);
+		scrollRafRef.current = 0;
 	};
 
 	const rebind = () => {
@@ -236,7 +240,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 				if (messages.length < J.Constant.limit.chat.messages) {
 					setLoaded(true);
 				} else {
-					setDummy(dummy + 1);
+					setDummy(v => v + 1);
 				};
 
 				callBack?.();
@@ -283,17 +287,20 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			// Guard older-batch loads: skip if one is already in flight (the prefetch threshold
 			// widens the trigger band, so onScroll can fire many times) or we already hit the
 			// oldest message. Without this the prefetch would spam duplicate requests.
+			// Only one pagination fetch in flight at a time, in EITHER direction: a backward and
+			// a forward load overlapping (e.g. a fling from top to bottom within one round-trip)
+			// could evict one end before the other's response stitches in, punching a gap.
+			if (isLoadingPrev.current || isLoadingNext.current) {
+				return;
+			};
+
 			if (dir < 0) {
-				if (isLoadingPrev.current || S.Chat.isAtChatStart(subId)) {
+				if (S.Chat.isAtChatStart(subId)) {
 					return;
 				};
 
 				isLoadingPrev.current = true;
 			} else {
-				if (isLoadingNext.current) {
-					return;
-				};
-
 				isLoadingNext.current = true;
 			};
 
@@ -336,15 +343,18 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 				loadDepsAndReplies(messages, () => {
 					if (messages.length) {
 						const lengthBefore = S.Chat.getList(subId).length;
-
-						S.Chat[(dir < 0 ? 'prepend' : 'append')](subId, messages);
+						const evicted = S.Chat[(dir < 0 ? 'prepend' : 'append')](subId, messages);
+						const grew = S.Chat.getList(subId).length > lengthBefore;
 
 						// Force a re-render so the new rows commit (either direction) — the
-						// component is not a MobX observer. We deliberately do NOT touch
-						// scrollTop: native scroll anchoring (overflow-anchor) keeps the viewport
-						// static when content is inserted above and preserves momentum; setting
-						// scrollTop ourselves would jump the view (~1 viewport) at load time.
-						if (S.Chat.getList(subId).length > lengthBefore) {
+						// component is not a MobX observer. At the MAX_MESSAGES cap a prepend/append
+						// inserts and evicts the same count, so the length is unchanged even though
+						// the content changed — repaint on `evicted` too, otherwise older history
+						// freezes at the cap. We deliberately do NOT touch scrollTop: native scroll
+						// anchoring (overflow-anchor) keeps the viewport static when content is
+						// inserted above and preserves momentum; setting scrollTop ourselves would
+						// jump the view (~1 viewport) at load time.
+						if (grew || evicted) {
 							setDummy(v => v + 1);
 						};
 					};
@@ -378,27 +388,37 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		isLoadingNext.current = false;
 
 		let list = [];
+		let beforeOk = false;
+		let afterOk = false;
 		let beforeLength = 0;
 		let afterLength = 0;
 
 		C.ChatGetMessages(chatId, orderId, '', limit, true, (message: any) => {
-			if (!message.error.code && message.messages.length) {
+			if (!message.error.code) {
+				beforeOk = true;
 				beforeLength = message.messages.length;
-				list = list.concat(message.messages);
+				if (beforeLength) {
+					list = list.concat(message.messages);
+				};
 			};
 
 			C.ChatGetMessages(chatId, '', orderId, limit, false, (message: any) => {
-				if (!message.error.code && message.messages.length) {
+				if (!message.error.code) {
+					afterOk = true;
 					afterLength = message.messages.length;
-					list = list.concat(message.messages);
+					if (afterLength) {
+						list = list.concat(message.messages);
+					};
 				};
 
 				loadDepsAndReplies(list, () => {
 					S.Chat.set(subId, list);
 
-					const edges = edgesAfterJump(beforeLength, afterLength, limit);
-					S.Chat.setAtChatStart(subId, edges.atChatStart);
-					S.Chat.setAtChatEnd(subId, edges.atChatEnd);
+					// Derive edges from the actual page lengths, but only for a fetch that
+					// SUCCEEDED — a transient error (length 0) must not be read as "reached the
+					// edge", which would permanently short-circuit pagination in that direction.
+					S.Chat.setAtChatStart(subId, beforeOk && reachedEdge(beforeLength, limit));
+					S.Chat.setAtChatEnd(subId, afterOk && reachedEdge(afterLength, limit));
 
 					callBack?.();
 				});
@@ -878,7 +898,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			// chat end or a fetch is already in flight.
 			const threshold = container?.offsetHeight ?? 0;
 
-			if (st <= threshold) {
+			if ((max > 0) && (st <= threshold)) {
 				loadMessages(-1, false);
 			};
 

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -1391,7 +1391,11 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		};
 
 		if (btn) {
-			U.Dom.toggleClass(btn, 'active', !v);
+			// Show the jump-to-bottom / new-messages button when the user is not at the window
+			// bottom, OR when the window bottom is not the chat's newest (tail was evicted) —
+			// otherwise a suppressed live message would have no affordance.
+			const showNav = (!v) || (!S.Chat.isAtChatEnd(getSubId()));
+			U.Dom.toggleClass(btn, 'active', showNav);
 		};
 	};
 

--- a/src/ts/component/block/chat/form.tsx
+++ b/src/ts/component/block/chat/form.tsx
@@ -1995,7 +1995,7 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 				<div className="navigation">
 					{reactionCounter ? <Button type={I.ChatReadType.Reaction} name="chat/navigation/reaction" icon="reaction" className="active" cnt={reactionCounter} /> : ''}
 					{mentionCounter && !spaceview.isOneToOne ? <Button type={I.ChatReadType.Mention} name="chat/navigation/mention" icon="mention" className="active" cnt={mentionCounter} /> : ''}
-					<Button type={I.ChatReadType.Message} name="chat/navigation/arrow" icon="arrow" className={(!isBottom.current || messageCounter) ? 'active' : ''} cnt={messageCounter} />
+					<Button type={I.ChatReadType.Message} name="chat/navigation/arrow" icon="arrow" className={((!isBottom.current) || messageCounter || (!S.Chat.isAtChatEnd(subId))) ? 'active' : ''} cnt={messageCounter} />
 				</div>
 
 				{form}

--- a/src/ts/lib/util/chatWindow.test.ts
+++ b/src/ts/lib/util/chatWindow.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { evictedCount, reachedEdge, edgesAfterJump, shouldRefetchForward, shouldSuppressLiveAdd } from './chatWindow';
+import { evictedCount, reachedEdge, shouldRefetchForward, shouldSuppressLiveAdd } from './chatWindow';
 
 describe('chatWindow', () => {
 	it('evictedCount returns overflow past max, else 0', () => {
@@ -12,12 +12,6 @@ describe('chatWindow', () => {
 		expect(reachedEdge(49, 50)).toBe(true);
 		expect(reachedEdge(50, 50)).toBe(false);
 		expect(reachedEdge(0, 50)).toBe(true);
-	});
-
-	it('edgesAfterJump derives both edges from before/after page lengths', () => {
-		expect(edgesAfterJump(25, 25, 50)).toEqual({ atChatStart: true, atChatEnd: true });
-		expect(edgesAfterJump(50, 10, 50)).toEqual({ atChatStart: false, atChatEnd: true });
-		expect(edgesAfterJump(50, 50, 50)).toEqual({ atChatStart: false, atChatEnd: false });
 	});
 
 	it('shouldRefetchForward only when not at end, at window bottom, and not already loading', () => {

--- a/src/ts/lib/util/chatWindow.test.ts
+++ b/src/ts/lib/util/chatWindow.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { evictedCount, reachedEdge, edgesAfterJump, shouldRefetchForward, shouldSuppressLiveAdd } from './chatWindow';
+
+describe('chatWindow', () => {
+	it('evictedCount returns overflow past max, else 0', () => {
+		expect(evictedCount(550, 500)).toBe(50);
+		expect(evictedCount(500, 500)).toBe(0);
+		expect(evictedCount(10, 500)).toBe(0);
+	});
+
+	it('reachedEdge is true only for a short page', () => {
+		expect(reachedEdge(49, 50)).toBe(true);
+		expect(reachedEdge(50, 50)).toBe(false);
+		expect(reachedEdge(0, 50)).toBe(true);
+	});
+
+	it('edgesAfterJump derives both edges from before/after page lengths', () => {
+		expect(edgesAfterJump(25, 25, 50)).toEqual({ atChatStart: true, atChatEnd: true });
+		expect(edgesAfterJump(50, 10, 50)).toEqual({ atChatStart: false, atChatEnd: true });
+		expect(edgesAfterJump(50, 50, 50)).toEqual({ atChatStart: false, atChatEnd: false });
+	});
+
+	it('shouldRefetchForward only when not at end, at window bottom, and not already loading', () => {
+		expect(shouldRefetchForward(false, true, false)).toBe(true);
+		expect(shouldRefetchForward(true, true, false)).toBe(false);
+		expect(shouldRefetchForward(false, false, false)).toBe(false);
+		expect(shouldRefetchForward(false, true, true)).toBe(false);
+	});
+
+	it('shouldSuppressLiveAdd only for a genuinely-newer message while not at end', () => {
+		expect(shouldSuppressLiveAdd(false, '!z', '!m')).toBe(true);
+		expect(shouldSuppressLiveAdd(true, '!z', '!m')).toBe(false);
+		expect(shouldSuppressLiveAdd(false, '!a', '!m')).toBe(false);
+		expect(shouldSuppressLiveAdd(false, '!z', '')).toBe(false);
+	});
+});

--- a/src/ts/lib/util/chatWindow.ts
+++ b/src/ts/lib/util/chatWindow.ts
@@ -20,14 +20,6 @@ export const reachedEdge = (pageLength: number, limit: number): boolean => {
 };
 
 /**
- * Edge flags after rebuilding the window around an orderId (jump / deeplink / unread divider),
- * derived from the actual before/after page lengths so the flags are not guessed.
- */
-export const edgesAfterJump = (beforeLength: number, afterLength: number, limit: number): { atChatStart: boolean; atChatEnd: boolean } => {
-	return { atChatStart: reachedEdge(beforeLength, limit), atChatEnd: reachedEdge(afterLength, limit) };
-};
-
-/**
  * Whether scrolling down should fetch newer messages to refill an evicted tail.
  */
 export const shouldRefetchForward = (atChatEnd: boolean, isBottom: boolean, isLoadingNext: boolean): boolean => {

--- a/src/ts/lib/util/chatWindow.ts
+++ b/src/ts/lib/util/chatWindow.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure decision helpers for the chat sliding-window.
+ * No store / DOM / global dependencies — keep this module unit-testable.
+ */
+
+/**
+ * How many messages are evicted when a list of `lengthAfterInsert` is trimmed to `max`.
+ * Returns 0 when the list is within bounds.
+ */
+export const evictedCount = (lengthAfterInsert: number, max: number): number => {
+	return Math.max(0, lengthAfterInsert - max);
+};
+
+/**
+ * A fetched page shorter than the requested `limit` means the chat boundary
+ * (oldest when paging back, newest when paging forward) was reached.
+ */
+export const reachedEdge = (pageLength: number, limit: number): boolean => {
+	return pageLength < limit;
+};
+
+/**
+ * Edge flags after rebuilding the window around an orderId (jump / deeplink / unread divider),
+ * derived from the actual before/after page lengths so the flags are not guessed.
+ */
+export const edgesAfterJump = (beforeLength: number, afterLength: number, limit: number): { atChatStart: boolean; atChatEnd: boolean } => {
+	return { atChatStart: reachedEdge(beforeLength, limit), atChatEnd: reachedEdge(afterLength, limit) };
+};
+
+/**
+ * Whether scrolling down should fetch newer messages to refill an evicted tail.
+ */
+export const shouldRefetchForward = (atChatEnd: boolean, isBottom: boolean, isLoadingNext: boolean): boolean => {
+	return (!atChatEnd) && isBottom && (!isLoadingNext);
+};
+
+/**
+ * Whether a live message must be suppressed: it is genuinely newer than the window's
+ * last message while the window is not anchored at the chat end, so appending it would
+ * place it out of order after an evicted tail. orderIds are lexids (lexicographic compare).
+ */
+export const shouldSuppressLiveAdd = (atChatEnd: boolean, messageOrderId: string, lastWindowOrderId: string): boolean => {
+	return (!atChatEnd) && (!!lastWindowOrderId) && (messageOrderId > lastWindowOrderId);
+};

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -1,6 +1,7 @@
 import { observable, action, makeObservable, set, autorun } from 'mobx';
 import * as I from 'Interface';
 import * as M from 'Model';
+import { evictedCount } from 'Lib/util/chatWindow';
 
 const MAX_MESSAGES = 500;
 
@@ -12,6 +13,8 @@ class ChatStore {
 	public attachmentsMap: Map<string, any[]> = observable(new Map());
 	public discussionParentMap: Map<string, Map<string, string>> = observable.map(new Map());
 	private badgeValue = '';
+	private atChatStartMap: Map<string, boolean> = new Map();
+	private atChatEndMap: Map<string, boolean> = new Map();
 
 	constructor () {
 		makeObservable(this, {
@@ -45,7 +48,7 @@ class ChatStore {
 	 * @param {string} subId - The subscription ID.
 	 * @param {I.ChatMessage[]} add - The chat messages to prepend.
 	 */
-	prepend (subId: string, add: I.ChatMessage[]): void {
+	prepend (subId: string, add: I.ChatMessage[]): boolean {
 		const list = this.getList(subId);
 		const ids = new Set(list.map(it => it.id));
 
@@ -54,9 +57,13 @@ class ChatStore {
 
 		list.unshift(...add);
 
-		if (list.length > MAX_MESSAGES) {
+		const evicted = evictedCount(list.length, MAX_MESSAGES);
+		if (evicted) {
 			list.splice(MAX_MESSAGES);
+			this.setAtChatEnd(subId, false);
 		};
+
+		return evicted > 0;
 	};
 
 	/**
@@ -64,7 +71,7 @@ class ChatStore {
 	 * @param {string} subId - The subscription ID.
 	 * @param {I.ChatMessage[]} add - The chat messages to append.
 	 */
-	append (subId: string, add: I.ChatMessage[]): void {
+	append (subId: string, add: I.ChatMessage[]): boolean {
 		const list = this.getList(subId);
 		const ids = new Set(list.map(it => it.id));
 
@@ -73,9 +80,13 @@ class ChatStore {
 
 		list.push(...add);
 
-		if (list.length > MAX_MESSAGES) {
-			list.splice(0, list.length - MAX_MESSAGES);
+		const evicted = evictedCount(list.length, MAX_MESSAGES);
+		if (evicted) {
+			list.splice(0, evicted);
+			this.setAtChatStart(subId, false);
 		};
+
+		return evicted > 0;
 	};
 
 	/**
@@ -308,6 +319,44 @@ class ChatStore {
 		this.messageMap.delete(subId);
 		this.replyMap.delete(subId);
 		this.attachmentsMap.delete(subId);
+		this.atChatStartMap.delete(subId);
+		this.atChatEndMap.delete(subId);
+	};
+
+	/**
+	 * Whether the window's first message is the chat's oldest. Default true (untracked subId).
+	 * @param {string} subId - The subscription ID.
+	 */
+	isAtChatStart (subId: string): boolean {
+		const v = this.atChatStartMap.get(subId);
+		return v === undefined ? true : v;
+	};
+
+	/**
+	 * Whether the window's last message is the chat's newest. Default true (untracked subId).
+	 * @param {string} subId - The subscription ID.
+	 */
+	isAtChatEnd (subId: string): boolean {
+		const v = this.atChatEndMap.get(subId);
+		return v === undefined ? true : v;
+	};
+
+	/**
+	 * Sets whether the window is anchored at the chat's oldest message.
+	 * @param {string} subId - The subscription ID.
+	 * @param {boolean} v - The value.
+	 */
+	setAtChatStart (subId: string, v: boolean): void {
+		this.atChatStartMap.set(subId, v);
+	};
+
+	/**
+	 * Sets whether the window is anchored at the chat's newest message.
+	 * @param {string} subId - The subscription ID.
+	 * @param {boolean} v - The value.
+	 */
+	setAtChatEnd (subId: string, v: boolean): void {
+		this.atChatEndMap.set(subId, v);
 	};
 
 	/**

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -1,7 +1,7 @@
 import { observable, action, makeObservable, set, autorun } from 'mobx';
 import * as I from 'Interface';
 import * as M from 'Model';
-import { evictedCount } from 'Lib/util/chatWindow';
+import { evictedCount, shouldSuppressLiveAdd } from 'Lib/util/chatWindow';
 
 const MAX_MESSAGES = 500;
 
@@ -98,12 +98,34 @@ class ChatStore {
 	add (subId: string, idx: number, param: I.ChatMessage): void {
 		const list = this.getList(subId);
 		const item = this.getMessageById(subId, param.id);
-		
+
 		if (item) {
 			return;
 		};
 
+		const isTail = idx >= list.length;
+
+		// A genuinely-newer live message while the window is not at the chat end would land
+		// after an evicted tail (out of order). Suppress it; it is fetched on scroll-down /
+		// jump-to-bottom. Non-open and preview subIds keep atChatEnd === true (default).
+		if (isTail) {
+			const last = list.length ? list[list.length - 1] : null;
+			if (shouldSuppressLiveAdd(this.isAtChatEnd(subId), param.orderId, last ? last.orderId : '')) {
+				return;
+			};
+		};
+
 		list.splice(idx, 0, param);
+
+		// Tail insert behaves like append: trim the oldest head if over the cap.
+		if (isTail) {
+			const evicted = evictedCount(list.length, MAX_MESSAGES);
+			if (evicted) {
+				list.splice(0, evicted);
+				this.setAtChatStart(subId, false);
+			};
+		};
+
 		this.set(subId, list);
 	};
 

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -3,7 +3,7 @@ import * as I from 'Interface';
 import * as M from 'Model';
 import { evictedCount, shouldSuppressLiveAdd } from 'Lib/util/chatWindow';
 
-const MAX_MESSAGES = 500;
+const MAX_MESSAGES = 1000;
 
 class ChatStore {
 

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -3,7 +3,7 @@ import * as I from 'Interface';
 import * as M from 'Model';
 import { evictedCount, shouldSuppressLiveAdd } from 'Lib/util/chatWindow';
 
-const MAX_MESSAGES = 1000;
+const MAX_MESSAGES = 500;
 
 class ChatStore {
 

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -390,6 +390,8 @@ class ChatStore {
 		this.stateMap.clear();
 		this.attachmentsMap.clear();
 		this.discussionParentMap.clear();
+		this.atChatStartMap.clear();
+		this.atChatEndMap.clear();
 	};
 
 	/**


### PR DESCRIPTION
## Problem

Scrolling a chat up into history made newer messages vanish: the in-memory list is capped (`MAX_MESSAGES`), and `prepend` evicted the newest messages with no way to bring them back. A forward re-fetch path existed but was dead — gated by a conflated `isLoaded` flag that never reset on scroll-up.

Verified against the CRDT store that the affected chat is cleanly ordered (`createdAt` ≈ `orderId`); the loss was eviction, not ordering.

## Fix

Treat `S.Chat` as a sliding window with explicit, store-owned edge flags:

- `atChatStart` / `atChatEnd` per `subId` (default `true`); `prepend`/`append` report eviction and flip the opposite edge.
- Scroll-down re-fetch gated on `atChatEnd` (not `isLoaded`), with a symmetric one-viewport prefetch and a single-in-flight guard across both directions.
- Repaint on eviction, not just length growth — otherwise history froze at the cap.
- Out-of-order live messages suppressed while scrolled up (keyed on `orderId`); nav button reflects `!atChatEnd`.
- `loadEpoch` guard drops a response whose window was reset (jump / deeplink / reload / switch) mid-flight.
- `onScroll` coalesced to one run per frame.
- Edges on a deeplink/unread open derived from real page lengths, only on fetch success.

Decision helpers extracted to `Lib/util/chatWindow` (unit-tested). Cap stays at **500**; raising it is deferred to dedicated perf work (the un-virtualized list re-renders fully per `setDummy`).

## Tests

`chatWindow` unit tests pass; `typecheck` and `lint` clean. Scroll behaviour verified manually in-app (scroll up past the window → down restores, jump-to-bottom, anchoring).

## Follow-ups

Render perf (memoize `<Message>` / virtualize) to allow a larger cap; `replyMap` / `dbClearChat` memory cleanup; popup+main shared-`subId`.
