### PR TITLE
fix(chat): gate bare-domain auto-linking behind a TLD allowlist

### DIFF
--- a/src/ts/lib/util/string.test.ts
+++ b/src/ts/lib/util/string.test.ts
@@ -170,6 +170,25 @@ describe('UtilString', () => {
 		it('should match URLs with ports', () => {
 			expect(UtilString.matchUrl('http://localhost:8080')).toBe('http://localhost:8080');
 		});
+
+		it('should not match scheme-less prose with an unapproved TLD', () => {
+			expect(UtilString.matchUrl('hey.how')).toBe('');
+			expect(UtilString.matchUrl('Mr.Smith')).toBe('');
+			expect(UtilString.matchUrl('readme.md')).toBe('');
+		});
+
+		it('should match scheme-less domains with an approved TLD', () => {
+			expect(UtilString.matchUrl('example.com')).toBe('example.com');
+			expect(UtilString.matchUrl('sub.example.io')).toBe('sub.example.io');
+		});
+
+		it('should match any TLD when an explicit scheme is present', () => {
+			expect(UtilString.matchUrl('https://hey.how')).toBe('https://hey.how');
+		});
+
+		it('should still match IP hosts', () => {
+			expect(UtilString.matchUrl('192.168.1.1')).toBe('192.168.1.1');
+		});
 	});
 
 	describe('matchEmail', () => {
@@ -188,6 +207,16 @@ describe('UtilString', () => {
 		it('should match valid domains', () => {
 			expect(UtilString.matchDomain('example.com')).toBe('example.com');
 			expect(UtilString.matchDomain('sub.example.com')).toBe('sub.example.com');
+		});
+
+		it('should match domains with multi-part country-code TLDs', () => {
+			expect(UtilString.matchDomain('example.co.uk')).toBe('example.co.uk');
+		});
+
+		it('should reject prose that looks like a domain but has an unapproved TLD', () => {
+			expect(UtilString.matchDomain('hey.how')).toBe('');
+			expect(UtilString.matchDomain('test.code')).toBe('');
+			expect(UtilString.matchDomain('node.go')).toBe('');
 		});
 
 		it('should return empty string for invalid input', () => {

--- a/src/ts/lib/util/string.ts
+++ b/src/ts/lib/util/string.ts
@@ -7,6 +7,25 @@ const UNSAFE_HTML_PATTERN = /<\s*(script|iframe|svg|img|math|object|embed|style|
 const DOMAIN_REGEX = /^(?:[a-zA-Z][a-zA-Z0-9+.-]*:\/\/)?(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[A-Za-z]{2,}(?::\d{1,5})?(?:\/[^\s?#]*)?(?:\?[^\s#]*)?(?:#[^\s]*)?$/;
 const URL_REGEX = /^(?:([a-zA-Z][a-zA-Z0-9+.-]*):([^\s]+)|(?:(?:[^:@\s]+(?::[^@\s]*)?@)?(?:localhost|(?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)|(?=.{1,253}$)(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[A-Za-z]{2,}))(?::\d{1,5})?(?:\/[^\s?#]*)?(?:\?[^\s#]*)?(?:#[^\s]*)?)$/i;
 const ALLOWED_PROTOCOLS = [ 'mailto', 'tel', 'anytype' ];
+const SCHEME_REGEX = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
+
+// Intentionally tight allowlist of TLDs eligible for auto-linking bare (scheme-less)
+// domains. Kept small on purpose so prose like "hey.how" or "readme.md" is not turned
+// into a link. URLs with an explicit scheme (https://…) bypass this list entirely.
+// Word-like ccTLDs (it, in, is, no, be, at, as, so, to, by, us, am) are deliberately
+// omitted to avoid linking sentences glued by a period.
+const AUTO_LINK_TLD = new Set([
+	// Generic
+	'com', 'org', 'net', 'edu', 'gov', 'mil', 'int', 'info', 'biz',
+	'io', 'ai', 'app', 'dev', 'xyz', 'co', 'me', 'tv', 'cc',
+	'online', 'site', 'shop', 'store', 'tech', 'cloud', 'pro',
+
+	// Country-code
+	'uk', 'de', 'fr', 'ru', 'jp', 'cn', 'br', 'au', 'ca', 'nl', 'se', 'ch',
+	'es', 'eu', 'pl', 'pt', 'cz', 'dk', 'fi', 'ie', 'nz', 'kr', 'tw', 'hk',
+	'sg', 'mx', 'ar', 'cl', 'za', 'ua', 'ro', 'hu', 'tr', 'il', 'ae', 'id',
+	'th', 'vn', 'ph', 'my', 'gr',
+]);
 const ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 
 class UtilString {
@@ -302,6 +321,10 @@ class UtilString {
 		const m = String(s || '').match(URL_REGEX);
 		const ret = String(((m && m.length) ? m[0] : '') || '').trim();
 
+		if (!ret || !this.canAutoLink(ret)) {
+			return '';
+		};
+
 		try {
 			const url = new URL(ret);
 
@@ -341,7 +364,55 @@ class UtilString {
 	 */
 	matchDomain(s: string): string {
 		const m = String(s || '').trim().match(DOMAIN_REGEX);
-		return m ? m[0] : '';
+		const ret = m ? m[0] : '';
+		return (ret && this.canAutoLink(ret)) ? ret : '';
+	};
+
+	/**
+	 * Extracts the bare host (no scheme, credentials, port, path, query or hash)
+	 * from a URL-like string, lowercased.
+	 * @param {string} s - The URL-like string.
+	 * @returns {string} The host or empty string.
+	 */
+	getHost (s: string): string {
+		let host = String(s || '').trim();
+
+		host = host.replace(SCHEME_REGEX, '');	// scheme://
+		host = host.replace(/^[^@/]*@/, '');	// user:pass@
+		host = host.split(/[\/?#]/)[0];			// path / query / hash
+		host = host.split(':')[0];				// port
+
+		return host.toLowerCase();
+	};
+
+	/**
+	 * Decides whether a URL-like token should be auto-converted into a link.
+	 * Bare (scheme-less) domains must end with an approved TLD so that prose like
+	 * "hey.how" or "readme.md" is left as plain text. Tokens with an explicit scheme,
+	 * or pointing at localhost / an IP address, are always allowed.
+	 * @param {string} s - The URL-like token.
+	 * @returns {boolean} True if the token may be auto-linked.
+	 */
+	canAutoLink (s: string): boolean {
+		s = String(s || '');
+
+		// Explicit scheme — user intent is clear, link as-is.
+		if (SCHEME_REGEX.test(s) || ALLOWED_PROTOCOLS.some(p => s.toLowerCase().startsWith(`${p}:`))) {
+			return true;
+		};
+
+		const host = this.getHost(s);
+		if (!host) {
+			return false;
+		};
+
+		// localhost and IPv4 hosts are unambiguous targets.
+		if ((host == 'localhost') || /^\d{1,3}(?:\.\d{1,3}){3}$/.test(host)) {
+			return true;
+		};
+
+		const parts = host.split('.');
+		return (parts.length > 1) && AUTO_LINK_TLD.has(parts[parts.length - 1]);
 	};
 
 	/**


### PR DESCRIPTION
## Problem
Pasting text into the chat input auto-links any `word.word` token — e.g. "hey.how", "readme.md", "Mr.Smith" — because URL/domain matching treated any 2+ letter suffix as a valid TLD. This also fired spurious link-preview requests for non-existent domains.

## Fix
Gate auto-linking of **bare (scheme-less) domains** behind a tight allowlist of approved TLDs in `U.String`:
- Explicit-scheme URLs (`https://…`, `mailto:`, …) and `localhost`/IP hosts still link unconditionally.
- Centralized in `matchUrl`/`matchDomain` (via `getUrlsFromText`), so chat, comment editor, editor paste and the link menu all benefit.

| Input | Before | After |
|---|---|---|
| `hey.how are you` | `hey.how` linked + preview fetch | plain text |
| `readme.md`, `Mr.Smith` | linked | plain text |
| `example.com`, `sub.example.io`, `example.co.uk` | linked | linked |
| `https://hey.how` | linked | linked |
| `192.168.1.1`, `http://localhost:8080` | linked | linked |

Note: the TLD allowlist is intentionally tight; obscure real TLDs not in the list won't auto-link as bare domains (paste with `https://` to force a link).

## Tests
Unit tests added in `string.test.ts` for `matchUrl`/`matchDomain`; `string.test.ts` 63/63 pass.

Closes JS-9819