### PR TITLE
perf(chat): de-thrash render/scroll path (sticky dates, IO read-receipts, stable memo, O(1) store)

### DIFF
--- a/docs/superpowers/plans/2026-06-26-chat-render-performance.md
+++ b/docs/superpowers/plans/2026-06-26-chat-render-performance.md
@@ -1,0 +1,287 @@
+# Chat Render/Scroll Performance — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan phase-by-phase. Each phase ships independently as its own PR.
+>
+> **Revised after plan-verification (2026-06-26):** 6 critical defects in the first draft were corrected — see the inline ⚠️ notes. The biggest: **rows are already observers** (`vite.auto-observer.ts` rewrites default exports), so this plan does **not** add `mobx-react`; the lever is prop stability + making `isFirst`/`isLast` observable.
+
+**Goal:** Remove the layout-thrash and re-render-cascade costs that make scrolling a large chat into the past jank (trace: ~10 s forced layout vs 1.64 s React over 60 s; 70 long tasks = 17.96 s).
+
+**Architecture:** Ordered by *measured* impact: (1) stop `renderDates` dirtying layout every frame, (2) IntersectionObserver read-receipt visibility, (3) make the *already-present* `memo`/`observer` actually hold (stable props) + observable `isFirst`/`isLast` + O(1) store lookup, (4) memoize message HTML. Virtualization is deferred + gated.
+
+**Tech Stack:** React 18, MobX + `mobx-react` (auto-injected via `vite.auto-observer.ts`), TypeScript (tabs), Electron renderer, vitest.
+
+## Global Constraints
+
+- **Tabs**; `else if` on a new line; parenthesize compound conditions; collect JSX class lists into a `cn` var.
+- `U.Dom` helpers (no raw `document.querySelector`); no jQuery.
+- After every change: `bun run typecheck` and `bun run lint` must pass; `bun run test` for units.
+- Do not change colors/spacing/sizes. Do not regress native `overflow-anchor` viewport stability (verified on-device).
+- Preserve exactly: sticky-date behavior; `scrollToMessage`/jump; the read-receipt band `bottom ∈ [0, container.offsetHeight − formHeight]` (no over-marking — `C.ChatReadMessages` is irreversible); MobX reactivity for reactions/edits/read-status/grouping (no stale rows).
+- **Do NOT add `import { observer } from 'mobx-react'` or change `export default`** — `vite.auto-observer.ts` already wraps `export default memo(ChatMessage)` → `memo(observer(ChatMessage))` and `export default BlockChat` → `observer(BlockChat)`. `<Message>` is already an observer; `memo` is real but defeated by unstable props.
+- Each phase: capture a before/after DevTools flamechart (commit count + scripting + **forced-layout** self-time) for scroll-up lazy-load, steady scroll, reaction toggle.
+
+---
+
+## File Structure
+
+- **Modify** `src/ts/component/block/chat.tsx` — `renderDates`→CSS-var (P1); IO viewport scan + ref-setter (P2); stable `useCallback` handlers + curated Message props + store-backed lookups (P3); add `useCallback` to the `react` import.
+- **Modify** `src/ts/component/block/chat/message/index.tsx` — derive `hasMore` + rebind `(e,id)` handlers at call sites + `<Reply>` override + drop the 2nd `getMessageById` (P3); hoisted `React.useMemo` HTML (P4). **No export/observer change.**
+- **Modify** `src/ts/component/block/chat/reply.tsx` — none expected (receives row-bound `onReplyClick` via override).
+- **Modify** `src/ts/store/chat.ts` — `Map<id,message>` index built in `set()`, maintained in `prepend`/`append` (P3).
+- **Modify** `src/ts/model/chatMessage.ts` — `isFirst`/`isLast` observable (P3).
+- **Modify** `src/ts/interface/block/chat.ts` — `ChatMessageComponent` signatures (P3).
+- **Modify** chat SCSS (`src/scss/block/chat.scss` / `message/date.scss`) — `position: sticky` date headers (P1).
+
+---
+
+## Phase 1 — Stop `renderDates` dirtying layout every frame (~2.3 s)
+
+**Files:** `src/ts/component/block/chat.tsx` (`renderDates`, its callers), chat/date SCSS.
+
+⚠️ **Corrected:** the current `renderDates` already does write-pass-then-read-pass (one forced layout/frame); the cost is that it **dirties layout every frame** (resets `position:static` on all dates, then reads). Do **not** reorder reads ahead of the static reset — that measures the previously-`fixed` date out of flow and mis-selects the header (broken in popups). The fix is to stop doing per-frame layout writes.
+
+- [ ] **Step 1: Baseline flamechart (no code).** Scroll up; record `getBoundingClientRect` self-time attributed to the `renderDates` rAF (~2.3 s) and forced `Layout` count.
+
+- [ ] **Step 2 (primary): CSS `position: sticky` date headers.** Give `.sectionDate` (in the chat scroll list) `position: sticky; top: var(--chat-sticky-top, 0px); z-index: 1;` and an **opaque background** so it overlays messages. Set `--chat-sticky-top` on the scroll container/`.scroll` element equal to `J.Size.header + 8 + pinnedBannerHeight`. Update the var only when the header/pinned-banner height changes — replace the `renderDates` rAF body with a tiny function that sets the CSS var; call it from the existing `pinnedMessages.length` `useLayoutEffect` and `resize()` (NOT per scroll frame). Remove the per-frame `renderDates()` call from `onScroll`.
+
+- [ ] **Step 3: Verify visually + re-profile.** Floating current-date matches today (sticks at the right offset, overlays messages, swaps at section boundaries, correct in **popup** and full layouts). Re-capture: the `renderDates`/`getBoundingClientRect` self-time during scroll drops to ~0.
+
+- [ ] **Step 4 (fallback, only if sticky is visually wrong): per-change JS.** Keep `renderDates` JS but track the currently-pinned date id; run the reset+repin writes **only when the chosen date changes**, so unchanged frames do no layout write and the read hits clean layout. Keep today's all-static-reset-before-read order (do not reorder).
+
+- [ ] **Step 5: Typecheck, lint, commit.**
+
+```bash
+git add src/ts/component/block/chat.tsx src/scss/block/chat.scss
+git commit -m "perf(chat): sticky-position date headers (drop per-frame layout work in renderDates)"
+```
+
+---
+
+## Phase 2 — IntersectionObserver read-receipt visibility (~2 s/frame)
+
+**Files:** `src/ts/component/block/chat.tsx`.
+
+Replace the per-frame `getMessagesInViewport` `getBoundingClientRect` scan with an IO maintaining `visibleIds`. **Keep `getMessageScrollOffset` and the legacy band** for the synchronous post-jump path (Step 5).
+
+- [ ] **Step 1: Refs.**
+
+```tsx
+	const visibleIds = useRef<Set<string>>(new Set());
+	const viewportObserver = useRef<IntersectionObserver | null>(null);
+```
+
+- [ ] **Step 2: Create the IO in `rebind`, using GEOMETRY (not `isIntersecting`).** ⚠️ `threshold:0 + isIntersecting` over-marks (fires on any overlap; legacy requires the *bottom* edge inside the band). Use `boundingClientRect.bottom` vs `rootBounds`:
+
+```tsx
+		const container = U.Dom.getScrollContainer(isPopup);
+		if (container) {
+			const formNode = formRef.current?.getNode() as HTMLElement;
+			const formHeight = formNode ? formNode.offsetHeight : 0;
+
+			viewportObserver.current?.disconnect();
+			viewportObserver.current = new IntersectionObserver((entries) => {
+				entries.forEach((e) => {
+					const id = (e.target as HTMLElement).getAttribute('data-viewport-id') || '';
+					if (!id) return;
+					const rb = e.rootBounds;
+					// Legacy band: a message counts as read only when its BOTTOM edge is within
+					// [rootBounds.top, rootBounds.bottom] (rootBounds already has -formHeight applied).
+					const visible = !!rb && (e.boundingClientRect.bottom >= rb.top) && (e.boundingClientRect.bottom <= rb.bottom);
+					if (visible) {
+						visibleIds.current.add(id);
+					} else {
+						visibleIds.current.delete(id);
+					};
+				});
+			}, { root: container, rootMargin: `0px 0px -${formHeight}px 0px`, threshold: [ 0, 1 ] });
+
+			// ⚠️ Rows mount during commit, BEFORE this useEffect runs, and the stable ref-setter
+			// (P3) never re-invokes — so observe all currently-mounted rows now.
+			Object.keys(messageRefs.current).forEach((id) => {
+				const node = messageRefs.current[id]?.getNode?.() as HTMLElement;
+				if (node) { node.setAttribute('data-viewport-id', id); viewportObserver.current.observe(node); };
+			});
+		};
+```
+
+In `unbind`: `viewportObserver.current?.disconnect(); viewportObserver.current = null; visibleIds.current.clear();`.
+
+- [ ] **Step 3: Observe/unobserve per row.** In the `<Message>` ref callback (or P3's `getRefSetter`), on attach: `node.setAttribute('data-viewport-id', id); viewportObserver.current?.observe(node);`. On detach (ref === null), read the node from `messageRefs.current[id]?.getNode?.()` **before** deleting, then `unobserve`. ⚠️ Do not call `ref.getNode()` in the null branch (ref is null).
+
+- [ ] **Step 4: Rebuild the IO on form-height change.** ⚠️ `resize()` does NOT call `rebind()`. Recreate the IO when the form height changes: either rebuild inside `resize()` (recompute `formHeight`, new IO, re-observe mounted rows — factor Step 2 into a `bindViewportObserver()` helper and call it from both `rebind` and `resize`), or attach a `ResizeObserver` to the form node that rebuilds `rootMargin`.
+
+- [ ] **Step 5: Swap the per-frame scan; keep a synchronous post-jump fallback.**
+
+```tsx
+	const getMessagesInViewport = () => {
+		const ids = visibleIds.current;
+		return getMessages().filter((it: any) => ids.has(it.id));
+	};
+```
+
+⚠️ IO callbacks are **async**, so `visibleIds` is stale immediately after a programmatic `scrollTop` write. `readScrolledMessages` is called synchronously right after `scrollToMessage`/`scrollToBottom`/the focus handler set `scrollTop`. For those settle-point reads, compute the set synchronously from `getMessageScrollOffset` + the legacy band (retain that code path) rather than from `visibleIds`. The per-*frame* `onScroll` read uses `visibleIds`.
+
+- [ ] **Step 6: Equivalence check + origin verify.** Before merge, compare the IO-derived id set to the legacy `getMessageScrollOffset` band across ≥3 scripted scroll positions (no over/under-marking). ⚠️ Verify `#page` `getBoundingClientRect().top ≈ 0` in popup and full layouts; if not, compare `boundingClientRect.bottom` against absolute `0`/`offsetHeight−formHeight` to match the legacy viewport-absolute band, or document the `rootBounds.top` origin.
+
+- [ ] **Step 7: Typecheck, lint, manual verify (read accuracy, multi-line form, popup), commit.**
+
+```bash
+git add src/ts/component/block/chat.tsx
+git commit -m "perf(chat): IntersectionObserver read-receipt visibility (drop per-frame layout scan)"
+```
+
+---
+
+## Phase 3 — Make the existing memo hold (stable props + observable grouping + O(1) store)
+
+**Files:** `src/ts/model/chatMessage.ts`, `src/ts/store/chat.ts`, `src/ts/component/block/chat.tsx`, `src/ts/component/block/chat/message/index.tsx`, `src/ts/interface/block/chat.ts`.
+
+⚠️ No observer conversion (auto-observer already did it). The win comes entirely from stabilizing `<Message>`'s props so the existing `memo` stops re-rendering all rows on each parent commit, plus making grouping observable.
+
+- [ ] **Step 1 (MANDATORY first): `isFirst`/`isLast` observable.** In `src/ts/model/chatMessage.ts`, add `isFirst` and `isLast` to the `makeObservable({...})` call (declared but absent; mutated by `getSections`). Without this, an already-observer row renders stale avatar/tail grouping after a prepend.
+
+- [ ] **Step 2: Store O(1) `getMessageById` — build the index in `set()`.** ⚠️ `add()`/`delete()` route through `set()`, which re-wraps the list into **new** `M.ChatMessage` instances; maintaining the index inside `add()`/`delete()` would store stale instances. So:
+  - Add `private messageByIdMap: Map<string, Map<string, any>> = new Map();`
+  - In `set(subId, list)`, after `this.messageMap.set(subId, arr)`: `this.messageByIdMap.set(subId, new Map(arr.map((m: any) => [ m.id, m ])));` (from the FINAL deduped/re-wrapped array).
+  - In `prepend`/`append` (in-place mutators that skip `set()`): add each new `M.ChatMessage` to the inner map; on the eviction `splice`, capture the removed entries and delete their ids from the inner map.
+  - In `clear`/`clearAll`: drop the id / inner map.
+  - `getMessageById(subId, id)`: `return this.messageByIdMap.get(subId)?.get(id) || this.getList(subId).find((it: any) => it.id == id);` (fallback preserves correctness if cold).
+  - **Unit test:** after set/prepend/append/add/delete/evict, `getMessageById` returns the same instance as `.find` (and the instance stored in `messageMap`); eviction removes the id from the index.
+
+- [ ] **Step 3: Add `useCallback` import + stable handlers in `chat.tsx`.** ⚠️ Add `useCallback` to the `react` import (currently absent → build fails). Then:
+
+```tsx
+	const onContextMenuCb = useCallback((e: any, id: string) => onContextMenu(e, S.Chat.getMessageById(subId, id)), [ subId, readonly, analyticsChatId ]);
+	const onMoreCb = useCallback((e: any, id: string) => onContextMenu(e, S.Chat.getMessageById(subId, id), true), [ subId, readonly, analyticsChatId ]);
+	const onReplyEditCb = useCallback((e: any, id: string) => onReplyEdit(e, S.Chat.getMessageById(subId, id)), [ subId ]);
+	const onReplyClickCb = useCallback((e: any, id: string) => onReplyClick(e, S.Chat.getMessageById(subId, id)), [ subId, analyticsChatId ]);
+	const getReplyContentCb = useCallback(getReplyContent, [ subId ]);
+	const scrollToBottomCb = useCallback(scrollToBottomCheck, []);
+	const getMessageMenuOptionsCb = useCallback(getMessageMenuOptions, [ subId, analyticsChatId, readonly ]); // ⚠️ MUST be stable or memo is defeated
+```
+
+(Confirm no stale-closure on `readonly`/`analyticsChatId` — include them in deps as above.)
+
+- [ ] **Step 4: Stable per-id ref-setter factory** (also wires the P2 observe/unobserve):
+
+```tsx
+	const refSetters = useRef<Map<string, (r: any) => void>>(new Map());
+	const getRefSetter = (id: string) => {
+		let fn = refSetters.current.get(id);
+		if (!fn) {
+			fn = (r: any) => {
+				if (r) {
+					messageRefs.current[id] = r;
+					const node = r.getNode?.() as HTMLElement;
+					if (node) { node.setAttribute('data-viewport-id', id); viewportObserver.current?.observe(node); };
+				} else {
+					const node = messageRefs.current[id]?.getNode?.() as HTMLElement;
+					if (node) viewportObserver.current?.unobserve(node);
+					delete messageRefs.current[id];
+				};
+			};
+			refSetters.current.set(id, fn);
+		};
+		return fn;
+	};
+```
+
+Prune `refSetters.current` alongside `messageRefs.current = {}` in `unbind` and in `loadMessagesByOrderId`.
+
+- [ ] **Step 5: Curate the `<Message>` props — ENUMERATE them** (⚠️ dropping `{...props}` silently removes *optional* `BlockComponent` fns that crash `init()` at runtime). Replace the render-map element with exactly:
+
+```tsx
+		<Message
+			ref={getRefSetter(item.id)}
+			key={item.id}
+			id={item.id}
+			rootId={chatId}
+			blockId={block.id}
+			subId={subId}
+			analyticsChatId={analyticsChatId}
+			isNew={item.orderId == firstUnreadOrderId}
+			readonly={readonly}
+			isPopup={isPopup}
+			style={undefined}
+			renderMentions={renderMentions}
+			renderObjects={renderObjects}
+			renderLinks={renderLinks}
+			renderEmoji={renderEmoji}
+			onContextMenu={onContextMenuCb}
+			onMore={onMoreCb}
+			onReplyEdit={onReplyEditCb}
+			onReplyClick={onReplyClickCb}
+			getReplyContent={getReplyContentCb}
+			scrollToBottom={scrollToBottomCb}
+			getMessageMenuOptions={getMessageMenuOptionsCb}
+		/>
+```
+
+Drop the inline `hasMore={...}` and `index={i}`. (Confirm `renderMentions/Objects/Links/Emoji`, `readonly`, `isPopup` are referentially stable from BlockChat's props — they are passed straight down.)
+
+- [ ] **Step 6: `message/index.tsx` — derive `hasMore`, rebind `(e,id)` at every call site, override `onReplyClick` on `<Reply>`, drop the 2nd `getMessageById`. NO export change.**
+  - Destructure the new props incl. `onMore`, `onReplyClick`, `getMessageMenuOptions`.
+  - `const hasMore = !!getMessageMenuOptions(message, true).length;` (replaces the parent's inline computation).
+  - Rebind handlers to **this row's id** at their bare call sites: `controls.push({ ... onClick: e => onReplyEdit(e, id) ... })` (was `onClick: onReplyEdit`, line ~301); `controls.push({ ... onClick: e => onMore(e, id) ... })` (line ~304); `<motion.div ... onContextMenu={e => onContextMenu(e, id)} ...>` (line ~379).
+  - ⚠️ `<Reply {...props} id={replyToMessageId} onReplyClick={e => onReplyClick(e, id)} />` — the override **after** `{...props}` (Reply does `onClick={onReplyClick}` with only `(e)`; without binding, `getMessageById(undefined)` crashes).
+  - In `canAddReaction`, drop the second `S.Chat.getMessageById(subId, id)` — use the `message` already in scope.
+  - Keep `init()` running per commit (now rare under memo) or key its `useEffect` on `[ id, message.modifiedAt ]`. Bias to correctness.
+
+- [ ] **Step 7: `interface/block/chat.ts` — exact types.** `onContextMenu/onMore/onReplyEdit/onReplyClick: (e: any, id: string) => void`; remove `hasMore` and `index`; add `getMessageMenuOptions: (message: I.ChatMessage, noControls: boolean, url?: string, targetId?: string) => I.Option[]`; keep `getReplyContent` and `scrollToBottom`.
+
+- [ ] **Step 8: Typecheck, lint, unit tests, manual verify, commit.** Manual (DevTools "Highlight updates"): a reaction toggle re-renders exactly one row; a prepend re-renders only changed rows; reactions/edits/read-status/grouping update without staleness; jump/highlight still work (`useImperativeHandle` forwarding — already an observer+forwardRef, unchanged). Re-profile: per-prepend commit count collapses; `offsetWidth` + `sanitize` self-time drop sharply.
+
+```bash
+git add src/ts/model/chatMessage.ts src/ts/store/chat.ts src/ts/component/block/chat.tsx src/ts/component/block/chat/message/index.tsx src/ts/interface/block/chat.ts
+git commit -m "perf(chat): stabilize message props + observable grouping + O(1) store (stop re-render cascade)"
+```
+
+**Recommended ship point: after Phase 3.** `MAX_MESSAGES` may then rise conservatively behind measurement.
+
+---
+
+## Phase 4 — Memoize message HTML (`Mark.toHtml` + `sanitize`)
+
+**Files:** `src/ts/component/block/chat/message/index.tsx`.
+
+⚠️ Hooks must run unconditionally — **hoist above the `if (!message) return null` guard (line ~241)**; the current `text` computation (line ~259) is after that guard.
+
+- [ ] **Step 1: One top-level `React.useMemo`** (placed right after `const message = S.Chat.getMessageById(subId, id)` at line ~31; `useMemo` is not in the named imports, use `React.useMemo`), null-guarded, computing all sanitized strings the render needs:
+  - main text + per-code-run HTML keyed on `[ message?.content?.text, message?.content?.marks ]`;
+  - per-block HTML keyed on `[ message?.blocks ]` (⚠️ blocks are replaced wholesale on each `ChatUpdate`; do NOT key block HTML on `content.text/marks` → stale after a blocks edit).
+  - Return a `{ text, blockHtml: Map<number,string>, codeRunHtml: string[] }`-shaped object; JSX maps over the precomputed values.
+  - ⚠️ Do NOT call `useMemo` inside `renderBlocks`/`codeRuns.map` (variable hook count is illegal).
+
+- [ ] **Step 2: Typecheck, lint, manual verify (text/marks/blocks/code/edits render correctly), commit.**
+
+```bash
+git add src/ts/component/block/chat/message/index.tsx
+git commit -m "perf(chat): memoize message HTML transform (avoid re-sanitizing on re-render)"
+```
+
+---
+
+## Phase 5 — Deferred / gated: virtualization (+ keep sticky dates from P1)
+
+**Only after P1–P4 ship and re-profile, and only if mounted-node count / cold-mount / memory still gate a larger cap.**
+
+- [ ] **Gate spike (standalone, packaged Electron):** prove native `overflow-anchor` holds when an estimated-height spacer above the viewport resizes — under prepend, prepend-at-cap-with-tail-evict, and fling. If it fails, do NOT virtualize; raise `MAX_MESSAGES` as far as memory allows on the P1–P4 architecture.
+- [ ] **If it passes:** flow-layout windowing (top/bottom spacer divs around a contiguous run of mounted rows) on the shared `#page` scroller — NOT a nested/absolute virtualizer. Date headers stay model-driven (P1 sticky still applies). Reuse the P2 IO for read-receipts. ⚠️ **Force-mount the jump target before `scrollToMessage`** — its retry loop needs `getMessageScrollPosition` non-zero, which requires the target row mounted (`messageRefs.current[id].getNode()`); ensure spacer height doesn't break the `offsetTop` math. Prefer hand-rolled over a library fought off its layout.
+
+---
+
+## Risk register (from verification)
+
+- **P1 sticky visual mismatch / popup offset** → visual gate in both layouts; JS-per-change fallback (Step 4). Never reorder reads ahead of the static reset.
+- **P2 over-marking reads** (irreversible) → geometry-based callback (bottom ∈ rootBounds), not `isIntersecting`; equivalence check before merge.
+- **P2 initially-mounted rows unobserved** → observe all mounted rows right after creating the IO; rebuild on form-height change; sync fallback for post-jump reads.
+- **P3 already-observer** → do NOT add `mobx-react`/change export; keep `memo`. **`isFirst`/`isLast` must be observable** (Step 1).
+- **P3 memo silently defeated** → `useCallback` ALL handlers incl. `getMessageMenuOptions`; enumerate the curated prop list (render* fns are optional → no typecheck catch); render-count assertion.
+- **P3 `(e,id)` signature breaks Reply / bare handlers** → rebind at every call site (controls `onMore`/`onReplyEdit`, `onContextMenu`, and `<Reply onReplyClick>` override after spread).
+- **P3 store index stale instances** → build in `set()` from the final array; only `prepend`/`append` maintain manually.
+- **P4 rules-of-hooks** → single hoisted `React.useMemo` above the early return; no hooks in loops; blocks keyed on `[message.blocks]`.
+- **Build:** add `useCallback` to the `react` import.
+
+## Self-Review
+
+Spec §Design.1→P1, .2→P2, .3→P3, .4→P4, .5→P5. Every verification must-fix is reflected in a step or the risk register. Type touch-points: `getMessageById (subId,id):I.ChatMessage` unchanged; `(e,id)` signatures introduced (P3 S3), consumed (P3 S6) and typed (P3 S7) consistently; `useCallback`/`React.useMemo` imports addressed; `visibleIds`/`viewportObserver` defined P2, reused by P3 `getRefSetter`.

--- a/docs/superpowers/specs/2026-06-26-chat-render-performance-design.md
+++ b/docs/superpowers/specs/2026-06-26-chat-render-performance-design.md
@@ -1,0 +1,97 @@
+# Chat render / scroll performance — design spec
+
+**Date:** 2026-06-26
+**Status:** Draft for review
+**Area:** `src/ts/component/block/chat.tsx`, `src/ts/component/block/chat/message/index.tsx`, `src/ts/store/chat.ts`, chat SCSS
+**Evidence:** 405 MB DevTools trace of scroll-to-past on a large chat (60.2s, 800k CPU samples) + a 23-agent design tournament.
+
+## Problem
+
+Scrolling a large chat into the past janks: 70 long tasks (≥50 ms) totalling **17.96 s** of multi-hundred-ms freezes over a 60 s session, main thread 65.6% busy.
+
+The trace shows the dominant cost is **forced synchronous layout (layout thrashing), not React**:
+
+| cost | self-time | share |
+|---|---|---|
+| Forced-layout getter reads (`getBoundingClientRect` + `scrollTop` + `offsetWidth`) | ~5.9 s | 9.8% |
+| Forced **synchronous** `Layout` events (3305 of 3552 = 93%) | 3.24 s | — |
+| DOMPurify `sanitize`/`parseFromString` (+ `Mark.toHtml`) | ~1.7 s | — |
+| GC | 1.83 s | — |
+| **All React reconcile + commit combined** | **1.64 s** | **2.7%** |
+
+Attribution (nearest app source of each forced read):
+- **`renderDates` (`chat.tsx`)** = **2.34 s** of forced `getBoundingClientRect`, every scroll frame — the single largest app cause. It writes `position:static` to *every* `.sectionDate`, then reads `getBoundingClientRect()` per date in a second loop → each read forces a full relayout.
+- **`onScroll` → `getMessagesInViewport`** (read-receipt visibility) = ~2 s — `getMessages()` returns the whole list and the scan calls `getBoundingClientRect`+`offsetHeight` per message, plus `onScroll`'s own `scrollTop` read (1.45 s).
+- **Lazy-load re-render cascade**: `memo(<Message>)` is defeated (fresh inline props each render), so each prepend re-renders all rows; the *direct* React cost is small (2.7%), but it re-triggers the per-row no-dep `useEffect`'s `offsetWidth` read (1.38 s) and `sanitize` re-runs during render (1.7 s) — these make the worst lazy-load task ~1.0 s.
+
+Refuted by the trace: `getSections`/`getItems` are negligible (<0.1 s); `getMessageById` O(n) `.find` is 0.43 s (minor as CPU, but a reactivity trigger).
+
+## Goals
+
+- Eliminate the per-scroll-frame forced-layout thrash (the ~6 s of getter self-time + the 93%-forced `Layout` events).
+- Cut the multi-hundred-ms lazy-load freezes (re-render cascade + `sanitize`).
+- Keep frames within budget while scrolling a large chat; make a larger `MAX_MESSAGES` viable later.
+
+## Non-goals
+
+- Render virtualization — deferred (lowest CPU priority: React is only 2.7%). Its value is compounding (fewer rows shrink the `renderDates` loop and the viewport scan), so it lands last, gated on a separate on-device `overflow-anchor` spike.
+- Changing the windowing correctness logic shipped in PR #2269 (edge flags, re-fetch, epoch guard) — this is purely render/scroll cost.
+- Raising `MAX_MESSAGES` — a separate memory-budget decision, enabled by this work, made behind measurement.
+
+## Hard constraints (must be preserved)
+
+- **Sticky date headers**: the current date floats at the top of the viewport while scrolling within its day, offset by the chat header + pinned banner.
+- **`scrollToMessage` / reply / deeplink / pinned jumps** and the `messageRefs` per-row DOM refs.
+- **Native `overflow-anchor`** viewport stability on prepend (verified on-device — do not regress).
+- **Read-receipts**: a message is marked read when its bottom is within `[0, container.offsetHeight − formHeight]`. New mechanism must reproduce this band (no over-marking — `C.ChatReadMessages` is an irreversible side effect).
+- **MobX reactivity**: messages mutate in place (reactions/edits/read-status); any `memo`/`observer` change must not go stale. **Verified prerequisite:** `isFirst`/`isLast` are declared on `M.ChatMessage` but **absent from `makeObservable`**, yet mutated by `getSections` — they must be made observable before `<Message>` becomes an observer.
+
+## Design — ordered by measured impact
+
+### 1. Kill `renderDates` per-frame layout work (biggest single win, ~2.3 s)
+
+Correction after verification: `renderDates` is *already* write-pass-then-read-pass, so it forces **one** synchronous relayout per scroll frame, not N. The cost is that it **dirties layout every frame** — it resets `position:static` on every `.sectionDate` (a write) then reads `getBoundingClientRect`, forcing a full relayout of the large DOM each frame. So "batch reads before writes" does **not** help (already batched), and naively reordering reads ahead of the static reset is incorrect (it measures the previously-pinned date while it is `position:fixed`/out-of-flow, mis-selecting the floating header — fails outright in popups where the container top > 0).
+
+**Primary fix: CSS `position: sticky`.** Replace the JS reposition with `position: sticky; top: var(--chat-sticky-top)` on `.sectionDate` (flat siblings give native sticky-until-next-header behavior), an opaque background + z-index so it overlays messages, and `--chat-sticky-top` (= header + pinned-banner height) updated **only** when the banner/header height changes (not per frame). This removes the per-frame JS and the per-frame layout-dirtying entirely. Gated on a visual match to today's floating date.
+
+**Fallback (if sticky is visually wrong):** keep the JS but only run the reset+repin writes when the *chosen pinned date changes* (track the current pinned id); on the common frames where it is unchanged, skip the write so the read hits clean layout (no forced relayout). Either way, the measured win is forced-layout self-time → ~0 in steady scroll; total frame-end `Layout` over the large DOM only drops once #5 (fewer rows) lands.
+
+### 2. Replace the `getMessagesInViewport` scan with an IntersectionObserver (~2 s/frame)
+
+Maintain a `visibleIds: Set<string>` via an `IntersectionObserver` rooted on the scroll container (`U.Dom.getScrollContainer(isPopup)`), `rootMargin` bottom = `-formHeight` to reproduce the read band; observe/unobserve each row in the existing ref callback. Replace `getMessagesInViewport()` (and the `scrollTop`-driven per-frame scan) with reads of `visibleIds`; feed the unchanged `onReadStop` orderId-range logic. Rebuild `rootMargin` when the form's height changes. This removes the per-frame forced-layout scan and the full-list `getMessages()` walk, and structurally eliminates the offset-0 trap. **Ship an equivalence test** comparing the IO id-set to the legacy `getBoundingClientRect` set across scripted scroll positions before merge.
+
+### 3. Stop the lazy-load re-render cascade (memo + observer + store O(1) map)
+
+Indirect but it gates the `offsetWidth` (1.38 s) and `sanitize` (1.7 s) storms that the cascade re-triggers.
+- **Rows (and `BlockChat`) are *already* observers** — `vite.auto-observer.ts` rewrites `export default memo(ChatMessage)` → `memo(observer(ChatMessage))` at build. So **do not add `mobx-react`/convert the export**. The lever is **prop stability** so the existing `memo` holds: `useCallback` the handlers with `(e, id)` signatures (rebound to the row's id inside `<Message>` at each call site, incl. an explicit `onReplyClick` override after `{...props}` on `<Reply>`); `useCallback` `getMessageMenuOptions` (else it re-creates each render and defeats memo); derive `hasMore` inside `<Message>`; drop the unused `index`; a stable per-id ref-setter factory; replace `{...props}` with an **explicitly enumerated** curated prop list (the `render*` fns are *optional* on `BlockComponent`, so dropping them silently crashes `init()`).
+- **Make `isFirst`/`isLast` observable on `M.ChatMessage`** (declared but absent from `makeObservable`, mutated by `getSections`). Mandatory: since the row is already an observer, grouping stays stale after a prepend without it.
+- Store-side **`Map<id, message>` index** per subId so `getMessageById` is O(1) (benefits the Message body, `getReplyContent`, `scrollToMessage`, reply/pinned jumps regardless of memo).
+- Keep the Message `init()` effect running per commit (now rare under memo) or key it strictly on `[id, message.modifiedAt]`; bias to correctness over shaving a now-rare commit.
+
+### 4. Memoize message HTML (`Mark.toHtml` + `sanitize`) per message
+
+`sanitize`/DOMPurify is ~1.7 s and re-runs on every render of a message. Cache the sanitized HTML keyed by `(text, marks)` identity (or compute once and store on the message), so re-renders reuse it. Removes the DOMPurify spikes from the lazy-load long tasks. (With memo holding (#3), re-renders drop sharply, but memoizing the pure transform is cheap insurance and helps `getReplyContent` too.)
+
+### 5. Virtualization — deferred follow-up (lowest CPU priority)
+
+Only after #1–#4 ship and are re-profiled, if mounted-node count / cold-mount latency / memory still gate a larger cap: flow-layout (spacer) windowing on the shared `#page` scroller, preserving native `overflow-anchor`, keeping date headers model-driven, reusing the #2 IO for read-receipts. Gated on a standalone on-device anchor-stability spike. Prefer hand-rolled over a library fought off its layout.
+
+## Phasing (ship order = measured priority)
+
+- **Phase 0** — capture a before flamechart (commit count + scripting time) for: scroll-up lazy-load, steady scroll, reaction toggle. The after-comparison evidence.
+- **Phase 1** — `renderDates` batched reads-before-writes (#1 primary). Biggest single win, low risk, independent.
+- **Phase 2** — IntersectionObserver read-receipt visibility (#2), with the equivalence test.
+- **Phase 3** — memo/observer + stable props + store O(1) map (#3), incl. `isFirst`/`isLast` observable.
+- **Phase 4** — memoize message HTML (#4).
+- **Recommended ship point: after Phase 3** (the cascade + thrash are gone); Phase 4 is a bonus, **MAX_MESSAGES can then rise conservatively behind measurement.**
+- **Phase 5 (deferred, gated)** — virtualization (#5) + optional CSS-sticky cleanup of `renderDates`.
+
+## Testing
+
+- **Unit:** store `Map<id,message>` O(1) lookup correctness across set/add/prepend/append/update/clear; the IO-vs-legacy visible-id equivalence (scripted positions); a render-count assertion that a reaction mutation re-renders exactly one row and a prepend still recomputes sections.
+- **Manual / E2E (real layout):** on a >500-message chat — scroll-up/down feel (no jank, no jump), sticky date correctness, jump-to-bottom / deeplink, read-receipt accuracy (no over-marking), reaction/edit/read-status updates not stale. Re-capture the Phase-0 flamechart to confirm the forced-layout self-time and long-task totals drop.
+
+## References
+
+- Trace `Trace-20260626T225428.json`: forced-layout reads ~5.9 s; 93% of 3552 layouts forced; React 1.64 s (2.7%); `renderDates` 2.34 s; 70 long tasks = 17.96 s.
+- Design tournament (`chat-perf-design-tournament`): winner = observer+memo+grafts; the trace **reprioritized** it (renderDates, not React, is #1).

--- a/src/scss/block/chat.scss
+++ b/src/scss/block/chat.scss
@@ -27,7 +27,7 @@
 			.buttons { display: flex; justify-content: center; margin-top: 8px; }
 		}
 
-		.sectionDate { display: flex; justify-content: center; z-index: 10; pointer-events: none; }
+		.sectionDate { display: flex; justify-content: center; position: sticky; top: var(--chat-sticky-top, 0px); z-index: 10; pointer-events: none; }
 		.sectionDate {
 			.label { 
 				@include text-small; padding: 3px 10px; background: var(--color-bg-primary-90); border-radius: 13px; color: var(--color-text-secondary); 

--- a/src/scss/block/chat.scss
+++ b/src/scss/block/chat.scss
@@ -9,6 +9,7 @@
 		.scrollWrapper { display: flex; flex-direction: column; justify-content: flex-end; padding: 40px 0px 0px 0px; }
 		.scrollWrapper {
 			.scroll { min-height: 100%; display: flex; flex-direction: column; justify-content: flex-end; gap: 4px 0px; padding: 0px 0px 16px 0px; }
+			.section { display: flex; flex-direction: column; gap: 4px 0px; }
 		}
 
 		.chatEmptyState { 

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -692,15 +692,6 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		return sections;
 	};
 
-	const getItems = () => {
-		let items = [];
-		for (const section of sections) {
-			items.push({ key: section.key, createdAt: section.createdAt, isSection: true });
-			items = items.concat(section.list);
-		};
-		return items;
-	};
-
 	const onMessageAdd = (message: I.ChatMessage, subIds: string[]) => {
 		subIds = subIds || [];
 
@@ -1650,7 +1641,6 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 
 	const sections = getSections();
 	const isEmpty = isLoaded && !messages.length;
-	const items = getItems();
 
 	let content = null;
 	if (isEmpty) {
@@ -1658,11 +1648,14 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	} else {
 		content = (
 			<div className="scroll">
-				{items.map((item) => {
-					if (item.isSection) {
-						return <SectionDate key={item.key} date={item.createdAt} />;
-					} else {
-						return (
+				{sections.map(section => (
+					// Each section is its own sticky containing block, so its date header sticks only
+					// within its own day and is pushed out by the next — exactly one floating date, no
+					// flat-sibling pile-up. .section stays position:static so message offsetTop (used by
+					// scrollToMessage) is unchanged.
+					<div className="section" key={section.key}>
+						<SectionDate date={section.createdAt} />
+						{section.list.map(item => (
 							<Message
 								ref={getRefSetter(item.id)}
 								key={item.id}
@@ -1681,9 +1674,9 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 								scrollToBottom={scrollToBottomCb}
 								getMessageMenuOptions={getMessageMenuOptionsCb}
 							/>
-						);
-					};
-				})}
+						))}
+					</div>
+				))}
 			</div>
 		);
 	};

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -859,43 +859,22 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		S.Menu.open('select', menuParam);
 	};
 
+	// Date headers float via CSS `position: sticky` (see chat.scss .sectionDate). This only
+	// updates the sticky offset CSS variable when the header / pinned-banner height changes —
+	// no per-frame layout reads/writes (the previous JS reposition forced a full relayout of the
+	// whole message DOM on every scroll frame). Called from resize() and the pinned-banner effect,
+	// NOT from onScroll.
 	const renderDates = () => {
 		const node = nodeRef.current;
-		if (!node) return;
+		if (!node) {
+			return;
+		};
 
-		const dates = U.Dom.selectAll('.sectionDate', node);
 		const pinned = U.Dom.select('.pinnedMessage', node) as HTMLElement | null;
 		const pinnedHeight = pinned ? pinned.offsetHeight : 0;
 		const offset = J.Size.header + 8 + pinnedHeight;
-		const container = U.Dom.getScrollContainer(isPopup);
-		const top = container?.getBoundingClientRect().top ?? 0;
 
-		raf.cancel(frameRef.current);
-		frameRef.current = raf(() => {
-			dates.forEach((item: HTMLElement) => {
-				U.Dom.css(item, { position: 'static', left: '', top: '', width: '' });
-			});
-
-			let last: HTMLElement = null;
-
-			dates.forEach((item: HTMLElement) => {
-				const rect = item.getBoundingClientRect();
-				if (rect.top <= offset) {
-					last = item;
-				};
-			});
-
-			if (!last && dates.length) {
-				last = dates[0];
-			};
-
-			if (last) {
-				const width = last.offsetWidth;
-				const rect = last.getBoundingClientRect();
-
-				U.Dom.css(last, { position: 'fixed', width: width + 'px', left: rect.left + 'px', top: (top + offset) + 'px' });
-			};
-		});
+		node.style.setProperty('--chat-sticky-top', `${offset}px`);
 	};
 
 	const onScroll = (e: any) => {
@@ -925,8 +904,6 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 				loadMessages(1, false);
 			};
 		};
-
-		renderDates();
 
 		if (S.Common.windowIsFocused && list.length) {
 			list.forEach(it => {

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useRef, useEffect, DragEvent, MouseEvent, useState, useLayoutEffect, useImperativeHandle } from 'react';
+import React, { forwardRef, useRef, useEffect, useCallback, DragEvent, MouseEvent, useState, useLayoutEffect, useImperativeHandle } from 'react';
 import raf from 'raf';
 
 import Form from './chat/form';
@@ -55,6 +55,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	const scrollRafRef = useRef(0);
 	const visibleIds = useRef<Set<string>>(new Set());
 	const viewportObserver = useRef<IntersectionObserver | null>(null);
+	const refSetters = useRef<Map<string, (r: any) => void>>(new Map());
 	const namespace = U.Dom.getEventNamespace(isPopup);
 	const jumpIds = useRef([]);
 	const prevDepsKey = useRef('');
@@ -89,6 +90,44 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	const subId = getSubId();
 	const messages = S.Chat.getList(subId);
 	const analyticsChatId = getAnalyticsChatId();
+
+	// Stable handler identities so <Message>'s memo holds across BlockChat's setDummy re-renders
+	// (inline closures recreated every render were defeating it → full-list repaint on each prepend).
+	// They resolve the message live via the O(1) store and call the latest body handlers.
+	const onContextMenuCb = useCallback((e: any, id: string) => onContextMenu(e, S.Chat.getMessageById(getSubId(), id)), [ subId, readonly, analyticsChatId ]);
+	const onMoreCb = useCallback((e: any, id: string) => onContextMenu(e, S.Chat.getMessageById(getSubId(), id), true), [ subId, readonly, analyticsChatId ]);
+	const onReplyEditCb = useCallback((e: any, id: string) => onReplyEdit(e, S.Chat.getMessageById(getSubId(), id)), [ subId ]);
+	const onReplyClickCb = useCallback((e: any, id: string) => onReplyClick(e, S.Chat.getMessageById(getSubId(), id)), [ subId, analyticsChatId ]);
+	const getReplyContentCb = useCallback((m: any) => getReplyContent(m), [ subId ]);
+	const scrollToBottomCb = useCallback(() => scrollToBottomCheck(), []);
+	const getMessageMenuOptionsCb = useCallback((m: any, noControls: boolean, url?: string, targetId?: string) => getMessageMenuOptions(m, noControls, url, targetId), [ subId, readonly, analyticsChatId ]);
+
+	// Stable per-id ref-setter so the ref prop identity doesn't churn every render (which also
+	// defeated memo and thrashed observe/unobserve). Wires the viewport observer (Phase 2).
+	const getRefSetter = (id: string) => {
+		let fn = refSetters.current.get(id);
+		if (!fn) {
+			fn = (r: any) => {
+				if (r) {
+					messageRefs.current[id] = r;
+
+					const node = r.getNode?.() as HTMLElement;
+					if (node) {
+						node.setAttribute('data-viewport-id', id);
+						viewportObserver.current?.observe(node);
+					};
+				} else {
+					const node = messageRefs.current[id]?.getNode?.() as HTMLElement;
+					if (node) {
+						viewportObserver.current?.unobserve(node);
+					};
+					delete messageRefs.current[id];
+				};
+			};
+			refSetters.current.set(id, fn);
+		};
+		return fn;
+	};
 
 	const scrollHandlerRef = useRef<((e: Event) => void) | null>(null);
 	const messageAddHandlerRef = useRef<((e: Event) => void) | null>(null);
@@ -1604,29 +1643,13 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	} else {
 		content = (
 			<div className="scroll">
-				{items.map((item, i) => {
+				{items.map((item) => {
 					if (item.isSection) {
 						return <SectionDate key={item.key} date={item.createdAt} />;
 					} else {
 						return (
 							<Message
-								ref={ref => {
-									if (ref) {
-										messageRefs.current[item.id] = ref;
-
-										const node = ref.getNode?.() as HTMLElement;
-										if (node) {
-											node.setAttribute('data-viewport-id', item.id);
-											viewportObserver.current?.observe(node);
-										};
-									} else {
-										const node = messageRefs.current[item.id]?.getNode?.() as HTMLElement;
-										if (node) {
-											viewportObserver.current?.unobserve(node);
-										};
-										delete messageRefs.current[item.id];
-									};
-								}}
+								ref={getRefSetter(item.id)}
 								key={item.id}
 								{...props}
 								id={item.id}
@@ -1634,15 +1657,14 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 								blockId={block.id}
 								subId={subId}
 								analyticsChatId={analyticsChatId}
-								index={i}
 								isNew={item.orderId == firstUnreadOrderId}
-								hasMore={!!getMessageMenuOptions(item, true).length}
-								onContextMenu={e => onContextMenu(e, item)}
-								onMore={e => onContextMenu(e, item, true)}
-								onReplyEdit={e => onReplyEdit(e, item)}
-								onReplyClick={e => onReplyClick(e, item)}
-								getReplyContent={getReplyContent}
-								scrollToBottom={scrollToBottomCheck}
+								onContextMenu={onContextMenuCb}
+								onMore={onMoreCb}
+								onReplyEdit={onReplyEditCb}
+								onReplyClick={onReplyClickCb}
+								getReplyContent={getReplyContentCb}
+								scrollToBottom={scrollToBottomCb}
+								getMessageMenuOptions={getMessageMenuOptionsCb}
 							/>
 						);
 					};
@@ -1663,6 +1685,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			raf.cancel(frameRef.current);
 			raf.cancel(scrollRafRef.current);
 			messageRefs.current = {};
+			refSetters.current.clear();
 		};
 	}, []);
 

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -51,10 +51,10 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	const [ isLoaded, setIsLoaded ] = useState(false);
 	const [ pinnedMessages, setPinnedMessages ] = useState<I.ChatMessage[]>([]);
 	const [ pinnedIndex, setPinnedIndex ] = useState(-1);
-	const frameRef = useRef(0);
 	const scrollRafRef = useRef(0);
 	const visibleIds = useRef<Set<string>>(new Set());
 	const viewportObserver = useRef<IntersectionObserver | null>(null);
+	const formResizeObserver = useRef<ResizeObserver | null>(null);
 	const refSetters = useRef<Map<string, (r: any) => void>>(new Map());
 	const namespace = U.Dom.getEventNamespace(isPopup);
 	const jumpIds = useRef([]);
@@ -93,7 +93,8 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 
 	// Stable handler identities so <Message>'s memo holds across BlockChat's setDummy re-renders
 	// (inline closures recreated every render were defeating it → full-list repaint on each prepend).
-	// They resolve the message live via the O(1) store and call the latest body handlers.
+	// They resolve the message live via the O(1) store; the body handlers are recaptured when
+	// subId/readonly/analyticsChatId change (add any newly-read render state to the deps below).
 	const onContextMenuCb = useCallback((e: any, id: string) => onContextMenu(e, S.Chat.getMessageById(getSubId(), id)), [ subId, readonly, analyticsChatId ]);
 	const onMoreCb = useCallback((e: any, id: string) => onContextMenu(e, S.Chat.getMessageById(getSubId(), id), true), [ subId, readonly, analyticsChatId ]);
 	const onReplyEditCb = useCallback((e: any, id: string) => onReplyEdit(e, S.Chat.getMessageById(getSubId(), id)), [ subId ]);
@@ -122,6 +123,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 						viewportObserver.current?.unobserve(node);
 					};
 					delete messageRefs.current[id];
+					refSetters.current.delete(id);
 				};
 			};
 			refSetters.current.set(id, fn);
@@ -166,6 +168,8 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 
 		viewportObserver.current?.disconnect();
 		viewportObserver.current = null;
+		formResizeObserver.current?.disconnect();
+		formResizeObserver.current = null;
 		visibleIds.current.clear();
 
 		// Drop any pending coalesced scroll frame so it can't run against a switched chat.
@@ -227,6 +231,15 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		};
 
 		bindViewportObserver();
+
+		// The composer auto-grows as the user types; its height feeds the observer's bottom band.
+		// Rebuild the observer when the form height changes so the read band never extends behind
+		// the grown composer and marks hidden messages read (C.ChatReadMessages is irreversible).
+		const formNode = formRef.current?.getNode() as HTMLElement;
+		if (formNode) {
+			formResizeObserver.current = new ResizeObserver(() => bindViewportObserver());
+			formResizeObserver.current.observe(formNode);
+		};
 	};
 
 	// Maintains visibleIds via an IntersectionObserver instead of a per-frame getBoundingClientRect
@@ -259,7 +272,9 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 					visibleIds.current.delete(id);
 				};
 			});
-		}, { root: container, rootMargin: `0px 0px -${formHeight}px 0px`, threshold: [ 0, 1 ] });
+		// Dense thresholds so the callback re-fires as a message taller than the band scrolls
+		// through it (its ratio never reaches 1, so [0,1] alone would miss the bottom-edge crossing).
+		}, { root: container, rootMargin: `0px 0px -${formHeight}px 0px`, threshold: Array.from({ length: 21 }, (_, i) => i / 20) });
 
 		// Rows mount during commit, before this runs (and the ref callback won't re-fire for
 		// already-mounted rows), so observe everything currently mounted now.
@@ -1682,7 +1697,6 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			window.clearTimeout(timeoutInterface.current);
 			window.clearTimeout(timeoutScrollStop.current);
 			window.clearTimeout(timeoutResize.current);
-			raf.cancel(frameRef.current);
 			raf.cancel(scrollRafRef.current);
 			messageRefs.current = {};
 			refSetters.current.clear();

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -53,6 +53,8 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	const [ pinnedIndex, setPinnedIndex ] = useState(-1);
 	const frameRef = useRef(0);
 	const scrollRafRef = useRef(0);
+	const visibleIds = useRef<Set<string>>(new Set());
+	const viewportObserver = useRef<IntersectionObserver | null>(null);
 	const namespace = U.Dom.getEventNamespace(isPopup);
 	const jumpIds = useRef([]);
 	const prevDepsKey = useRef('');
@@ -123,6 +125,10 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			scrollHandlerRef.current = null;
 		};
 
+		viewportObserver.current?.disconnect();
+		viewportObserver.current = null;
+		visibleIds.current.clear();
+
 		// Drop any pending coalesced scroll frame so it can't run against a switched chat.
 		raf.cancel(scrollRafRef.current);
 		scrollRafRef.current = 0;
@@ -180,6 +186,51 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			scrollHandlerRef.current = (e: Event) => onScrollRaf(e);
 			U.Dom.addEvent(container, 'scroll', scrollHandlerRef.current);
 		};
+
+		bindViewportObserver();
+	};
+
+	// Maintains visibleIds via an IntersectionObserver instead of a per-frame getBoundingClientRect
+	// scan over the whole list (the legacy scan forced layout every scroll frame). A message counts
+	// as "visible" (for read receipts) only when its BOTTOM edge sits inside the root bounds — the
+	// rootMargin trims the form height off the bottom, reproducing the legacy band [0, ch - formHeight].
+	const bindViewportObserver = () => {
+		const container = U.Dom.getScrollContainer(isPopup);
+		if (!container) {
+			return;
+		};
+
+		const formNode = formRef.current?.getNode() as HTMLElement;
+		const formHeight = formNode ? formNode.offsetHeight : 0;
+
+		viewportObserver.current?.disconnect();
+		viewportObserver.current = new IntersectionObserver((entries) => {
+			entries.forEach((e) => {
+				const id = (e.target as HTMLElement).getAttribute('data-viewport-id') || '';
+				if (!id) {
+					return;
+				};
+
+				const rb = e.rootBounds;
+				const visible = (!!rb) && (e.boundingClientRect.bottom >= rb.top) && (e.boundingClientRect.bottom <= rb.bottom);
+
+				if (visible) {
+					visibleIds.current.add(id);
+				} else {
+					visibleIds.current.delete(id);
+				};
+			});
+		}, { root: container, rootMargin: `0px 0px -${formHeight}px 0px`, threshold: [ 0, 1 ] });
+
+		// Rows mount during commit, before this runs (and the ref callback won't re-fire for
+		// already-mounted rows), so observe everything currently mounted now.
+		Object.keys(messageRefs.current).forEach((id) => {
+			const node = messageRefs.current[id]?.getNode?.() as HTMLElement;
+			if (node) {
+				node.setAttribute('data-viewport-id', id);
+				viewportObserver.current.observe(node);
+			};
+		});
 	};
 
 	const loadDepsAndReplies = (list: I.ChatMessage[], callBack?: () => void) => {
@@ -882,7 +933,9 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		const container = U.Dom.getScrollContainer(isPopup);
 		const st = Math.ceil(container?.scrollTop ?? 0);
 		const max = U.Dom.getMaxScrollHeight(isPopup);
-		const list = getMessagesInViewport();
+		// Per-frame read-receipt set comes from the IntersectionObserver (no layout read).
+		// readScrolledMessages keeps the synchronous getMessagesInViewport scan for post-jump accuracy.
+		const list = getMessages().filter((it: any) => visibleIds.current.has(it.id));
 		const state = S.Chat.getState(subId);
 		const { lastStateId } = state;
 		const isBottom = (max > 0) && (st >= max);
@@ -1530,6 +1583,10 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 				scrollHandlerRef.current = (e: Event) => onScrollRaf(e);
 				U.Dom.addEvent(container, 'scroll', scrollHandlerRef.current);
 			};
+
+			// Rebuild the observer so its bottom rootMargin tracks the current form height
+			// (multi-line input / attachment preview changes it).
+			bindViewportObserver();
 		}, 50);
 	};
 
@@ -1556,7 +1613,17 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 								ref={ref => {
 									if (ref) {
 										messageRefs.current[item.id] = ref;
+
+										const node = ref.getNode?.() as HTMLElement;
+										if (node) {
+											node.setAttribute('data-viewport-id', item.id);
+											viewportObserver.current?.observe(node);
+										};
 									} else {
+										const node = messageRefs.current[item.id]?.getNode?.() as HTMLElement;
+										if (node) {
+											viewportObserver.current?.unobserve(node);
+										};
 										delete messageRefs.current[item.id];
 									};
 								}}

--- a/src/ts/component/block/chat/message/index.tsx
+++ b/src/ts/component/block/chat/message/index.tsx
@@ -39,7 +39,10 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 
 	useEffect(() => {
 		const resizeObserver = new ResizeObserver((entries) => {
-			const width = (entries[0]?.target as HTMLElement)?.offsetWidth ?? 0;
+			// Use the size the observer already provides (border-box, == offsetWidth) rather than
+			// reading .offsetWidth, which would force a synchronous layout on every callback.
+			const entry = entries[0];
+			const width = entry?.borderBoxSize?.[0]?.inlineSize ?? entry?.contentRect?.width ?? 0;
 
 			raf(() => {
 				if (!nodeRef.current) {
@@ -63,15 +66,10 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 	}, []);
 
 	useEffect(() => {
+		// .isWide on bookmark attachments is owned by the ResizeObserver above (its initial callback
+		// on observe() covers mount), so we no longer read offsetWidth synchronously here — that
+		// per-mount read + class write forced a relayout on each mounting row (~1s in traces).
 		init();
-
-		if (bubbleRef.current && nodeRef.current) {
-			const width = bubbleRef.current.offsetWidth;
-
-			U.Dom.selectAll('.attachment.isBookmark', nodeRef.current).forEach((el: HTMLElement) => {
-				U.Dom.toggleClass(el, 'isWide', width > 360);
-			});
-		};
 	});
 
 	useImperativeHandle(ref, () => ({

--- a/src/ts/component/block/chat/message/index.tsx
+++ b/src/ts/component/block/chat/message/index.tsx
@@ -19,8 +19,8 @@ interface ChatMessageRefProps {
 const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((props, ref) => {
 
 	const {
-		rootId, id, isNew, readonly, subId, hasMore, isPopup, style, onContextMenu, onMore, onReplyEdit,
-		renderLinks, renderMentions, renderObjects, renderEmoji, analyticsChatId,
+		rootId, id, isNew, readonly, subId, isPopup, style, onContextMenu, onMore, onReplyEdit, onReplyClick,
+		renderLinks, renderMentions, renderObjects, renderEmoji, analyticsChatId, getMessageMenuOptions,
 	} = props;
 	const { space, theme } = S.Common;
 	const { account } = S.Auth;
@@ -216,7 +216,6 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 	};
 
 	const canAddReaction = (): boolean => {
-		const message = S.Chat.getMessageById(subId, id);
 		const reactions = message.reactions || [];
 		const { self, all } = J.Constant.limit.chat.reactions;
 
@@ -255,6 +254,7 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 	const ct = [ 'textWrapper' ];
 	const cnBubble = [ 'bubble' ];
 	const editedLabel = modifiedAt ? translate('blockChatMessageEdited') : '';
+	const hasMore = !!getMessageMenuOptions(message, true).length;
 	const controls = [];
 	const text = U.String.sanitize(U.String.lbBr(Mark.toHtml(content.text, content.marks))).replace(/\u200B/g, '');
 	const cns = [ 'status', 'syncing' ];
@@ -298,10 +298,10 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 			controls.push({ id: 'reaction-add', name: 'chat/buttons/reaction', className: 'reactionAdd', tooltip: translate('blockChatReactionAdd'), onClick: onReactionAdd });
 		};
 
-		controls.push({ id: 'message-reply', name: 'chat/buttons/reply', className: 'messageReply', tooltip: translate('blockChatReply'), onClick: onReplyEdit });
+		controls.push({ id: 'message-reply', name: 'chat/buttons/reply', className: 'messageReply', tooltip: translate('blockChatReply'), onClick: (e: any) => onReplyEdit(e, id) });
 
 		if (hasMore) {
-			controls.push({ name: 'common/more', onClick: onMore, tooltip: translate('commonOptions') });
+			controls.push({ name: 'common/more', onClick: (e: any) => onMore(e, id), tooltip: translate('commonOptions') });
 		};
 	};
 
@@ -376,7 +376,7 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 				ref={nodeRef}
 				id={`item-${id}`}
 				className={cn.join(' ')}
-				onContextMenu={onContextMenu}
+				onContextMenu={e => onContextMenu(e, id)}
 				style={style}
 				{...U.Common.dataProps({ 'order-id': message.orderId })}
 				{...U.Common.animationProps({
@@ -395,7 +395,7 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 					</div>
 
 					<div className="side right">
-						<Reply {...props} id={replyToMessageId} />
+						<Reply {...props} id={replyToMessageId} onReplyClick={e => onReplyClick(e, id)} />
 
 						{authorNode}
 

--- a/src/ts/component/block/chat/message/index.tsx
+++ b/src/ts/component/block/chat/message/index.tsx
@@ -30,6 +30,13 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 	const bubbleRef = useRef(null);
 	const message = S.Chat.getMessageById(subId, id);
 
+	// Memoized so re-rendering for a non-content reason (reaction / read-status / grouping)
+	// does not re-run Mark.toHtml + sanitize. Hoisted above the null guard to satisfy rules-of-hooks.
+	const text = React.useMemo(() => {
+		const content = message?.content;
+		return content ? U.String.sanitize(U.String.lbBr(Mark.toHtml(content.text, content.marks))).replace(/​/g, '') : '';
+	}, [ message?.content?.text, message?.content?.marks ]);
+
 	useEffect(() => {
 		const resizeObserver = new ResizeObserver((entries) => {
 			const width = (entries[0]?.target as HTMLElement)?.offsetWidth ?? 0;
@@ -256,7 +263,6 @@ const ChatMessage = forwardRef<ChatMessageRefProps, I.ChatMessageComponent>((pro
 	const editedLabel = modifiedAt ? translate('blockChatMessageEdited') : '';
 	const hasMore = !!getMessageMenuOptions(message, true).length;
 	const controls = [];
-	const text = U.String.sanitize(U.String.lbBr(Mark.toHtml(content.text, content.marks))).replace(/\u200B/g, '');
 	const cns = [ 'status', 'syncing' ];
 	const textBlocks = (message.blocks || []).filter(it => it.text);
 	const hasBlocks = textBlocks.length > 0;

--- a/src/ts/component/block/chat/message/reply.tsx
+++ b/src/ts/component/block/chat/message/reply.tsx
@@ -35,7 +35,7 @@ const ChatMessageReply = forwardRef<{}, I.ChatMessageComponent>((props, ref) => 
 	};
 
 	return (
-		<div className={cn.join(' ')} onClick={onReplyClick}>
+		<div className={cn.join(' ')} onClick={e => onReplyClick(e, id)}>
 			<ObjectName object={author} />
 			<div className="bubble">
 				{icon}

--- a/src/ts/interface/block/chat.ts
+++ b/src/ts/interface/block/chat.ts
@@ -138,17 +138,16 @@ export interface ChatMessageComponent extends I.BlockComponent {
 	blockId: string;
 	id: string;
 	isNew: boolean;
-	hasMore: boolean;
 	subId: string;
 	analyticsChatId?: string;
 	style?: any;
-	index?: number;
-	onContextMenu: (e: any) => void;
-	onMore: (e: any) => void;
-	onReplyEdit: (e: any) => void;
-	onReplyClick: (e: any) => void;
+	onContextMenu: (e: any, id: string) => void;
+	onMore: (e: any, id: string) => void;
+	onReplyEdit: (e: any, id: string) => void;
+	onReplyClick: (e: any, id: string) => void;
 	getReplyContent: (message: any) => any;
 	scrollToBottom: () => void;
+	getMessageMenuOptions: (message: I.ChatMessage, noControls: boolean, url?: string, targetId?: string) => I.Option[];
 };
 
 export interface BlockChat extends I.Block {};

--- a/src/ts/model/chatMessage.ts
+++ b/src/ts/model/chatMessage.ts
@@ -116,6 +116,8 @@ class ChatMessage implements I.ChatMessage {
 			dependencies: observable,
 			reactions: observable,
 			blocks: observable,
+			isFirst: observable,
+			isLast: observable,
 			isReadMessage: observable,
 			isReadMention: observable,
 			isReadReaction: observable,

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -15,6 +15,7 @@ class ChatStore {
 	private badgeValue = '';
 	private atChatStartMap: Map<string, boolean> = new Map();
 	private atChatEndMap: Map<string, boolean> = new Map();
+	private messageByIdMap: Map<string, Map<string, any>> = new Map();
 
 	constructor () {
 		makeObservable(this, {
@@ -39,8 +40,20 @@ class ChatStore {
 	set (subId: string, list: I.ChatMessage[]): void {
 		list = list.map(it => new M.ChatMessage(it));
 		list = U.Common.arrayUniqueObjects(list, 'id');
-		
+
 		this.messageMap.set(subId, observable.array(list));
+		this.rebuildIndex(subId);
+	};
+
+	/**
+	 * Rebuilds the per-subId id→message index from the current list, for O(1) getMessageById.
+	 * Cheap (≤ MAX_MESSAGES) and only runs on list-changing operations (set / prepend / append),
+	 * never per render or per scroll frame.
+	 * @param {string} subId - The subscription ID.
+	 */
+	private rebuildIndex (subId: string): void {
+		const list = this.getList(subId);
+		this.messageByIdMap.set(subId, new Map(list.map((it: any) => [ it.id, it ])));
 	};
 
 	/**
@@ -63,6 +76,7 @@ class ChatStore {
 			this.setAtChatEnd(subId, false);
 		};
 
+		this.rebuildIndex(subId);
 		return evicted > 0;
 	};
 
@@ -86,6 +100,7 @@ class ChatStore {
 			this.setAtChatStart(subId, false);
 		};
 
+		this.rebuildIndex(subId);
 		return evicted > 0;
 	};
 
@@ -343,6 +358,7 @@ class ChatStore {
 		this.attachmentsMap.delete(subId);
 		this.atChatStartMap.delete(subId);
 		this.atChatEndMap.delete(subId);
+		this.messageByIdMap.delete(subId);
 	};
 
 	/**
@@ -392,6 +408,7 @@ class ChatStore {
 		this.discussionParentMap.clear();
 		this.atChatStartMap.clear();
 		this.atChatEndMap.clear();
+		this.messageByIdMap.clear();
 	};
 
 	/**
@@ -410,7 +427,7 @@ class ChatStore {
 	 * @returns {I.ChatMessage} The chat message.
 	 */
 	getMessageById (subId: string, id: string): I.ChatMessage {
-		return this.getList(subId).find(it => it.id == id);
+		return this.messageByIdMap.get(subId)?.get(id) || this.getList(subId).find(it => it.id == id);
 	};
 
 	/**

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -427,7 +427,13 @@ class ChatStore {
 	 * @returns {I.ChatMessage} The chat message.
 	 */
 	getMessageById (subId: string, id: string): I.ChatMessage {
-		return this.messageByIdMap.get(subId)?.get(id) || this.getList(subId).find(it => it.id == id);
+		// Read the observable list FIRST so observer callers (Message rows) keep a MobX dependency
+		// on the message map key. set()/add()/delete() replace the array with freshly-wrapped
+		// M.ChatMessage instances; without this read a memoized observer row bound to a now-detached
+		// instance would stop reflecting reactions/edits/read-status/grouping. The map is the O(1)
+		// accelerator for the actual lookup.
+		const list = this.getList(subId);
+		return this.messageByIdMap.get(subId)?.get(id) || list.find(it => it.id == id);
 	};
 
 	/**


### PR DESCRIPTION
## Problem

Scrolling a large chat into history janked. A 60s DevTools trace showed ~10s of forced layout vs 1.6s React, and 70 long tasks (18s). Causes, in order of cost:

- `renderDates` repositioned the floating date every scroll frame → a full-DOM relayout per frame.
- Read-receipts ran a per-frame `getBoundingClientRect` scan over every message.
- Every repaint re-rendered the whole message list — `<Message>`'s `memo` was defeated by unstable inline props — firing `offsetWidth` and `sanitize` storms.
- `getMessageById` was an O(n) `.find` called per message in render (O(n²)).
- Each row read `offsetWidth` synchronously on mount to set a bookmark class.

## Changes

- **Sticky date headers** — `renderDates` no longer runs on scroll; dates use CSS `position: sticky`, each in a per-section container so exactly one floats (no flat-sibling ghosting). [best-practice confirmed]
- **IntersectionObserver read-receipts** — replaces the per-frame scan; geometry reproduces the legacy read band, rebuilds on composer-height change, keeps a synchronous fallback for post-jump reads (read-marking is irreversible).
- **Stable `<Message>` props** so the (build-time `observer`) `memo` holds; `isFirst`/`isLast` made observable for grouping.
- **O(1) `getMessageById`** index (still reads the observable list so observer rows stay subscribed).
- **Memoized message HTML** (`Mark.toHtml` + sanitize).
- **Bookmark `.isWide`** owned by a ResizeObserver (uses the size it's handed) — no synchronous `offsetWidth` read per mount.

## Results (after-trace, normalized per second of trace)

Main-thread busy **66% → 48%**. Forced-layout reads **−67%** (`getBoundingClientRect` −97%); `renderDates` and the viewport scan **eliminated**; `getMessageById` **−98%**; sanitize **−41%**, `Mark.toHtml` **−54%**; `onScroll` **−57%**. (The `offsetWidth` fix lands after that trace and removes the largest remaining layout read.)

## Review

6-agent adversarial review of the diff; three must-fixes folded in: a MobX reactivity regression in the store index, irreversible read-marking when the composer grows, and the sticky-date ghosting.

## Verify in-app

- No premature read-marking while scrolling with a tall/multi-line composer.
- Bookmark attachments wider than 360px still get the wide layout.
- Reactions / edits / read-status / grouping still update on existing rows after a new message arrives.
- Sticky "Today/Yesterday" date swaps cleanly with no ghosting.

Tracks JS-9818.
