### PR TITLE
perf(widget): stop Last Edited widget re-render & icon refetch on chat reaction (JS-9820)

### DIFF
--- a/src/ts/component/sidebar/page/widget.tsx
+++ b/src/ts/component/sidebar/page/widget.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useRef, useEffect, useState, useCallback, DragEvent } from 'react';
+import React, { forwardRef, useRef, useEffect, useLayoutEffect, useState, useCallback, DragEvent } from 'react';
 import raf from 'raf';
 import { reaction } from 'mobx';
 import { motion, AnimatePresence } from 'motion/react';
@@ -26,6 +26,7 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 	const isDraggingRef = useRef<boolean>(false);
 	const frameRef = useRef<number>(0);
 	const dragEndHandlerRef = useRef<(() => void) | null>(null);
+	const syntheticBlockCacheRef = useRef<Map<string, I.Block>>(new Map());
 
 	if (isLinksView) {
 		cnb.push('isLinksView');
@@ -491,14 +492,31 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 		raf.cancel(frameRef.current);
 	};
 
+	/*
+	 * System sections (Unread/Type/RecentEdit/Bin/personalWidgets/pinned-links) have
+	 * no stored widget block, so one is synthesized. Cache by id so the <Widget>
+	 * `block` prop keeps a stable reference across re-renders — otherwise the child
+	 * observer/memo always breaks and the widget re-renders on every parent render
+	 * (e.g. chat-counter churn). Cleared on space change.
+	 */
+	const getSyntheticWidgetBlock = (id: string): I.Block => {
+		const cache = syntheticBlockCacheRef.current;
+
+		if (!cache.has(id)) {
+			cache.set(id, new M.Block({
+				id,
+				type: I.BlockType.Widget,
+				content: { layout: I.WidgetLayout.Object },
+			}));
+		};
+
+		return cache.get(id);
+	};
+
 	const getWidgets = (sectionId: I.WidgetSection) => {
 		if ((sectionId == I.WidgetSection.Pin) && isLinksView) {
 			return [
-				new M.Block({
-					id: [ space, J.Constant.widgetId.pinned ].join('-'),
-					type: I.BlockType.Widget,
-					content: { layout: I.WidgetLayout.Object }
-				}),
+				getSyntheticWidgetBlock([ space, J.Constant.widgetId.pinned ].join('-')),
 			];
 		};
 
@@ -516,11 +534,7 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 					[I.WidgetSection.Bin]: J.Constant.widgetId.bin,
 				};
 
-				blocks.push(new M.Block({
-					id: [ space, idMap[sectionId] ].join('-'),
-					type: I.BlockType.Widget,
-					content: { layout: I.WidgetLayout.Object }
-				}));
+				blocks.push(getSyntheticWidgetBlock([ space, idMap[sectionId] ].join('-')));
 				break;
 			};
 
@@ -555,11 +569,7 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 						return true;
 					});
 				} else {
-					blocks.push(new M.Block({
-						id: [ space, J.Constant.widgetId.personalWidgets ].join('-'),
-						type: I.BlockType.Widget,
-						content: { layout: I.WidgetLayout.Object }
-					}));
+					blocks.push(getSyntheticWidgetBlock([ space, J.Constant.widgetId.personalWidgets ].join('-')));
 				};
 				break;
 			};
@@ -885,9 +895,51 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 	useEffect(() => {
 		setPreviewId('');
 		initSections();
-		initScroll();
 		getObjectCacheRef.current.clear();
+		syntheticBlockCacheRef.current.clear();
 	}, [ space ]);
+
+	/*
+	 * Restore the persisted scroll position on mount, space switch, and when leaving
+	 * preview (the list and preview reuse the same #body, so without this the list
+	 * snaps to top and onScroll then persists the wrong value). useLayoutEffect runs
+	 * before the post-swap scroll event, so the restore isn't clobbered. Skipped in
+	 * preview. A ResizeObserver re-applies the position while widget content is still
+	 * loading (async), then disconnects once the stored offset becomes reachable.
+	 */
+	useLayoutEffect(() => {
+		if (previewId) {
+			return;
+		};
+
+		const body = bodyRef.current;
+		if (!body) {
+			return;
+		};
+
+		initScroll();
+
+		// Observe the inner content element (not the scroll container, whose own box
+		// doesn't change as content grows) so we catch async widget load.
+		const contentEl = body.firstElementChild;
+		if (!contentEl) {
+			return;
+		};
+
+		const observer = new ResizeObserver(() => {
+			const top = Storage.getScroll('sidebarWidget', '', isPopup);
+
+			if (!top || ((body.scrollHeight - body.clientHeight) >= top)) {
+				if (top) {
+					body.scrollTop = top;
+				};
+				observer.disconnect();
+			};
+		});
+		observer.observe(contentEl);
+
+		return () => observer.disconnect();
+	}, [ space, previewId ]);
 
 	useEffect(() => reaction(() => S.Common.sidebarView, () => forceUpdate()), []);
 

--- a/src/ts/component/sidebar/page/widget.tsx
+++ b/src/ts/component/sidebar/page/widget.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useRef, useEffect, useState, DragEvent } from 'react';
+import React, { forwardRef, useRef, useEffect, useState, useCallback, DragEvent } from 'react';
 import raf from 'raf';
 import { reaction } from 'mobx';
 import { motion, AnimatePresence } from 'motion/react';
@@ -197,6 +197,21 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 			U.Dom.addClass(target, `isOver ${positionRef.current == I.BlockPosition.Top ? 'top' : 'bottom'}`);
 		});
 	};
+
+	/*
+	 * Stable identities for the drag handlers passed to each <Widget>. The handlers
+	 * themselves are recreated every render; without these wrappers a re-render of
+	 * this page (e.g. chat counters churning on a reaction toggle) would hand every
+	 * widget new function props, breaking their observer/memo and re-rendering
+	 * unrelated widgets like "Last edited". The ref always points at the latest
+	 * handler, so behavior is unchanged.
+	 */
+	const dragHandlersRef = useRef({ onDragStart, onDragOver, onDrag });
+	dragHandlersRef.current = { onDragStart, onDragOver, onDrag };
+
+	const onDragStartStable = useCallback((e: DragEvent, block: I.Block) => dragHandlersRef.current.onDragStart(e, block), []);
+	const onDragOverStable = useCallback((e: DragEvent, block: I.Block) => dragHandlersRef.current.onDragOver(e, block), []);
+	const onDragStable = useCallback((e: DragEvent, block: I.Block) => dragHandlersRef.current.onDrag(e, block), []);
 
 	const onDrop = (e: DragEvent): void => {
 		if (!isDraggingRef.current) {
@@ -607,13 +622,42 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 		let object = null;
 		if (U.Menu.isSystemWidget(id)) {
 			object = U.Menu.getSystemWidgets().find(it => it.id == id);
-		} else 
+		} else
 		if (block.content.section == I.WidgetSection.Type) {
 			object = S.Detail.get(U.Subscription.spaceSubId(J.Constant.subId.type), id);
 		} else {
 			object = S.Detail.get(widgets, id);
 		};
 		return object;
+	};
+
+	/*
+	 * Returns a getObject callback with a stable identity per (widget block, isFavorites),
+	 * so passing it to <Widget> doesn't break the child's observer/memo on unrelated
+	 * re-renders. getObjectRef always points at the latest helper; the cached closures
+	 * only capture stable values, so behavior is unchanged.
+	 */
+	const getObjectRef = useRef(getObject);
+	getObjectRef.current = getObject;
+	const getObjectCacheRef = useRef<Map<string, (id: string) => any>>(new Map());
+
+	const getWidgetGetObject = (block: I.Block, isFav: boolean, favRootId: string) => {
+		const key = `${block.id}:${isFav ? 1 : 0}`;
+		const cache = getObjectCacheRef.current;
+
+		if (!cache.has(key)) {
+			cache.set(key, (id: string) => {
+				if (isFav) {
+					if (U.Menu.isSystemWidget(id)) {
+						return U.Menu.getSystemWidgets().find(it => it.id == id);
+					};
+					return S.Detail.get(favRootId, id);
+				};
+				return getObjectRef.current(block, id);
+			});
+		};
+
+		return cache.get(key);
 	};
 
 	if (previewId) {
@@ -816,20 +860,12 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 												rootId={isFavWidgets ? personalRootId : undefined}
 												canEdit={canWrite}
 												canRemove={isSectionPin}
-												onDragStart={isFavWidgets ? undefined : onDragStart}
-												onDragOver={isFavWidgets ? undefined : onDragOver}
-												onDrag={isFavWidgets ? undefined : onDrag}
+												onDragStart={isFavWidgets ? undefined : onDragStartStable}
+												onDragOver={isFavWidgets ? undefined : onDragOverStable}
+												onDrag={isFavWidgets ? undefined : onDragStable}
 												setPreview={isFavWidgets ? undefined : setPreviewId}
 												sidebarDirection={sidebarDirection}
-												getObject={id => {
-													if (isFavWidgets) {
-														if (U.Menu.isSystemWidget(id)) {
-															return U.Menu.getSystemWidgets().find(it => it.id == id);
-														};
-														return S.Detail.get(personalRootId, id);
-													};
-													return getObject(block, id);
-												}}
+												getObject={getWidgetGetObject(block, isFavWidgets, personalRootId)}
 											/>
 										))}
 									</div>
@@ -844,12 +880,13 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 
 	useEffect(() => {
 		initSections();
-		initScroll();
 	});
 
 	useEffect(() => {
 		setPreviewId('');
 		initSections();
+		initScroll();
+		getObjectCacheRef.current.clear();
 	}, [ space ]);
 
 	useEffect(() => reaction(() => S.Common.sidebarView, () => forceUpdate()), []);

--- a/src/ts/component/widget/object.tsx
+++ b/src/ts/component/widget/object.tsx
@@ -6,6 +6,93 @@ import { CSS } from '@dnd-kit/utilities';
 import { IconObject, ObjectName, ChatCounter, Icon } from 'Component';
 import * as I from 'Interface';
 
+interface WidgetObjectItemProps {
+	item: any;
+	canDrag: boolean;
+	canWrite: boolean;
+	realId: string;
+	isUnread: boolean;
+	hasUnreadSection: boolean;
+	isAllowedObject: (type: any) => boolean;
+	onCreate: (e: any, type: any) => void;
+	onContextHandler: (e: any, item: any, withElement: boolean) => void;
+};
+
+/**
+ * Module-level row component. Kept out of WidgetObject's body so its component
+ * identity stays stable across re-renders — otherwise every WidgetObject render
+ * would remount all rows (and their IconObjects), forcing icon images to refetch.
+ */
+const WidgetObjectItem = (props: WidgetObjectItemProps) => {
+	const { item, canDrag, canWrite, realId, isUnread, hasUnreadSection, isAllowedObject, onCreate, onContextHandler } = props;
+	const { attributes, listeners, transform, transition, setNodeRef } = useSortable({ id: item.id, disabled: item._isDisabled || !canDrag });
+	const style = {
+		transform: CSS.Transform.toString(transform),
+		transition,
+	};
+	const isChat = U.Object.isChatLayout(item.layout);
+	const hasDiscussion = !isChat && !!item.discussionId;
+	const counterTargetId = isChat ? item.id : (hasDiscussion ? item.discussionId : '');
+	const showCounter = !!counterTargetId && (!hasUnreadSection || isUnread);
+	const canAdd = canWrite && (realId == J.Constant.widgetId.type) && isAllowedObject(item);
+	const spaceview = U.Space.getSpaceview();
+	const itemCn = [ 'item' ];
+
+	if (isChat && (U.Object.getChatNotificationMode(spaceview, item.id) == I.NotificationMode.Nothing)) {
+		itemCn.push('isMuted');
+	};
+
+	let icon = null;
+	if (item.iconParam) {
+		icon = <Icon {...item.iconParam} />;
+	} else {
+		icon = (
+			<IconObject
+				object={item}
+				canEdit={!item.isReadonly && U.Object.isTaskLayout(item.layout)}
+				iconSize={20}
+			/>
+		);
+	};
+
+	return (
+		<div
+			id={`item-${item.id}`}
+			className={itemCn.join(' ')}
+			ref={setNodeRef}
+			{...attributes}
+			{...listeners}
+			style={style}
+			onClick={e => U.Object.openEvent(e, item)}
+			onAuxClick={e => U.Object.openEvent(e, item)}
+			onContextMenu={e => onContextHandler(e, item, false)}
+		>
+			<div className="side left">
+				{icon}
+				<ObjectName object={item} withPlural={true} />
+			</div>
+			<div className="side right">
+				{showCounter ? (
+					<ChatCounter
+						chatId={counterTargetId}
+						mode={hasDiscussion ? U.Object.getDiscussionNotificationMode(spaceview, item.id) : undefined}
+					/>
+				) : ''}
+				{canAdd ? (
+					<div className="buttons">
+						<Icon
+							name="plus/menu"
+							className="plus"
+							tooltipParam={{ text: translate('commonCreateNewObject') }}
+							onClick={e => onCreate(e, item)}
+						/>
+					</div>
+				) : ''}
+			</div>
+		</div>
+	);
+};
+
 const WidgetObject = forwardRef<{}, I.WidgetComponent>((props, ref) => {
 
 	const { parent, onContext } = props;
@@ -313,75 +400,6 @@ const WidgetObject = forwardRef<{}, I.WidgetComponent>((props, ref) => {
 		};
 	};
 
-	const Item = (item: any) => {
-		const { attributes, listeners, transform, transition, setNodeRef } = useSortable({ id: item.id, disabled: item._isDisabled || !canDrag });
-		const style = {
-			transform: CSS.Transform.toString(transform),
-			transition,
-		};
-		const isChat = U.Object.isChatLayout(item.layout);
-		const hasDiscussion = !isChat && !!item.discussionId;
-		const counterTargetId = isChat ? item.id : (hasDiscussion ? item.discussionId : '');
-		const showCounter = !!counterTargetId && (!hasUnreadSection || isUnread);
-		const canAdd = canWrite && (realId == J.Constant.widgetId.type) && isAllowedObject(item);
-		const spaceview = U.Space.getSpaceview();
-		const itemCn = [ 'item' ];
-
-		if (isChat && (U.Object.getChatNotificationMode(spaceview, item.id) == I.NotificationMode.Nothing)) {
-			itemCn.push('isMuted');
-		};
-
-		let icon = null;
-		if (item.iconParam) {
-			icon = <Icon {...item.iconParam} />;
-		} else {
-			icon = (
-				<IconObject
-					object={item}
-					canEdit={!item.isReadonly && U.Object.isTaskLayout(item.layout)}
-					iconSize={20}
-				/>
-			);
-		};
-
-		return (
-			<div
-				id={`item-${item.id}`}
-				className={itemCn.join(' ')}
-				ref={setNodeRef}
-				{...attributes}
-				{...listeners}
-				style={style}
-				onClick={e => U.Object.openEvent(e, item)}
-				onAuxClick={e => U.Object.openEvent(e, item)}
-				onContextMenu={e => onContextHandler(e, item, false)}
-			>
-				<div className="side left">
-					{icon}
-					<ObjectName object={item} withPlural={true} />
-				</div>
-				<div className="side right">
-					{showCounter ? (
-						<ChatCounter
-							chatId={counterTargetId}
-							mode={hasDiscussion ? U.Object.getDiscussionNotificationMode(spaceview, item.id) : undefined}
-						/>
-					) : ''}
-					{canAdd ? (
-						<div className="buttons">
-							<Icon
-								name="plus/menu"
-								className="plus"
-								tooltipParam={{ text: translate('commonCreateNewObject') }}
-								onClick={e => onCreate(e, item)}
-							/>
-						</div>
-					) : ''}
-				</div>
-			</div>
-		);
-	};
-
 	const items = getItems();
 
 	return (
@@ -399,7 +417,20 @@ const WidgetObject = forwardRef<{}, I.WidgetComponent>((props, ref) => {
 						strategy={verticalListSortingStrategy}
 					>
 						<div ref={nodeRef} className="items">
-							{items.map(item => <Item key={item.id} {...item} />)}
+							{items.map(item => (
+								<WidgetObjectItem
+									key={item.id}
+									item={item}
+									canDrag={canDrag}
+									canWrite={canWrite}
+									realId={realId}
+									isUnread={isUnread}
+									hasUnreadSection={hasUnreadSection}
+									isAllowedObject={isAllowedObject}
+									onCreate={onCreate}
+									onContextHandler={onContextHandler}
+								/>
+							))}
 						</div>
 					</SortableContext>
 				</DndContext>


### PR DESCRIPTION
## Problem
Toggling a reaction on a chat message re-rendered the whole widget sidebar (incl. **Last edited**) and refetched every object icon — confirmed via a DevTools trace (8 toggles → 3 icons refetched 13× each). The chat object never even enters those widgets.

## Root cause
- Widget components are auto-wrapped as MobX observers. `SidebarPageWidget` reads chat counters during render (`getSections → getWidgetChats`), so a reaction toggle re-renders it and hands children unstable props.
- `WidgetObject` defined its row `Item` **inline** → new component type every render → rows + their `IconObject`s remounted → icons refetched.
- Synthetic widget blocks were rebuilt (`new M.Block`) every render, breaking the child observer/memo even once callbacks were stabilized.

## Fix
- Hoist `Item` to a stable module-level `WidgetObjectItem` (no remount → no icon refetch).
- Stabilize `<Widget>` props: ref-to-latest drag handlers, per-block cached `getObject`, and cached synthetic widget blocks → unrelated widgets stop re-rendering on chat churn.
- Move scroll restore into `useLayoutEffect([space, previewId])` + a `ResizeObserver` on the content element (fixes a preview→back scroll-restore regression surfaced during review).

## Verification
- Re-recorded DevTools trace: reaction toggles now produce **0** icon image requests (was 39); no row remounts.
- `typecheck` + `lint` clean. Reviewed by 5 independent agents (4 SHIP; the 1 FIX-FIRST regression is fixed here).

Linear: https://linear.app/anytype/issue/JS-9820