### PR TITLE
JS-9821 perf(chat): skip ObjectOpen for chat objects, open via subscription

### DIFF
--- a/src/ts/component/page/main/chat.tsx
+++ b/src/ts/component/page/main/chat.tsx
@@ -42,14 +42,27 @@ const PageMainChat = forwardRef<I.PageRef, I.PageComponent>((props, ref) => {
 
 	const open = () => {
 		idRef.current = rootId;
-		C.ObjectOpen(rootId, '', S.Common.space, (message: any) => {
+
+		// A chat object's change-tree IS its full message history, so ObjectOpen would build and
+		// validate the entire CRDT tree before anything renders — seconds of blocking for a big chat.
+		// The chat <Block> renders messages on its own via ChatSubscribeLastMessages (served from the
+		// backend's materialized store, no tree needed), so here we only need the object's details.
+		// Load them with a lightweight subscription instead of opening the object. Space-layout objects
+		// also route to this page and still need the full open (small tree; lifecycle relies on it).
+		const keys = J.Relation.default.concat([ 'chatId', 'analyticsChatId' ]);
+
+		U.Subscription.subscribeIds({ subId: rootId, ids: [ rootId ], keys, noDeps: false }, (message: any) => {
 			if (!U.Common.checkErrorOnOpen(rootId, message.error.code)) {
 				return;
 			};
 
-			const object = S.Detail.get(rootId, rootId, [ 'analyticsChatId' ]);
+			const object = S.Detail.get(rootId, rootId, [ 'analyticsChatId', 'layout' ]);
 			if (object.isDeleted) {
 				return;
+			};
+
+			if (object.layout == I.ObjectLayout.Space) {
+				C.ObjectOpen(rootId, '', S.Common.space);
 			};
 
 			S.Common.setRightSidebarState(isPopup, { rootId });
@@ -63,7 +76,11 @@ const PageMainChat = forwardRef<I.PageRef, I.PageComponent>((props, ref) => {
 	};
 
 	const close = () => {
-		Action.pageClose(isPopup, idRef.current, true);
+		// Only send ObjectClose for objects we actually opened (Space layout); chat objects were
+		// never opened, only subscribed — pageClose still tears down that subscription via destroyList.
+		const object = S.Detail.get(idRef.current, idRef.current, [ 'layout' ]);
+
+		Action.pageClose(isPopup, idRef.current, object.layout == I.ObjectLayout.Space);
 		idRef.current = '';
 	};
 


### PR DESCRIPTION
## What
Stop calling `ObjectOpen` for chat-layout objects; open the chat page from a lightweight detail subscription instead.

## Why
Opening a large chat blocked ~8s. `ObjectOpen` forces the middleware to build + validate the chat's entire CRDT change-tree (its full message history) before anything renders. A Chrome trace showed the renderer main thread idle ~8s waiting on the `ObjectOpen` RPC.

## How
In `component/page/main/chat.tsx`:
- `open()`: for chat-layout objects (`Chat` / `ChatOld` / `Discussion`), replace `C.ObjectOpen` with `U.Subscription.subscribeIds({ subId: rootId, ids: [rootId], keys: [...default, chatId, analyticsChatId] })`. Details land in the `rootId` context the page + chat block read from. The chat `<Block>` already subscribes to messages via `ChatSubscribeLastMessages` and re-runs `init()` reactively once `chatId` / `analyticsChatId` populate — so messages render without the tree build. `Space`-layout objects (which also route here) keep `ObjectOpen`, decided in the callback.
- `close()`: send `ObjectClose` only for `Space` layout; chats were never opened, only subscribed (torn down by `pageClose`'s `destroyList`).

Mirrors how Android opens chats (no `ObjectOpen`; details via `ObjectSubscribeIds`, permissions from the space participant subscription).

## Backend follow-up
After this change the ~8s cost relocated to `ChatGetPinnedMessages` / `ChatGetMessagesByIds` (they went through the tree build). Fixed in anytype-heart by **GO-7340** (anyproto/anytype-heart#3185) — those reads become anystore-only.

## Deferred (this repo)
Re-fetch pinned / reply targets when the chat settles after warm-up (cold-start self-correction); de-dup the ~6× `ChatReadMessages` on open.

JS-9821
