### PR TITLE
fix(space): record last-opened object for chats (JS-9821 follow-up)

### DIFF
--- a/src/ts/component/page/main/chat.tsx
+++ b/src/ts/component/page/main/chat.tsx
@@ -63,6 +63,11 @@ const PageMainChat = forwardRef<I.PageRef, I.PageComponent>((props, ref) => {
 
 			if (object.layout == I.ObjectLayout.Space) {
 				C.ObjectOpen(rootId, '', S.Common.space);
+			} else {
+				// Chat-layout objects skip ObjectOpen (which is what records the last-opened
+				// object), so record here — otherwise switching spaces and back forgets the
+				// open chat and reopens the previously opened page (JS-9821).
+				U.Space.setLastObject(object, S.Common.space);
 			};
 
 			S.Common.setRightSidebarState(isPopup, { rootId });

--- a/src/ts/lib/api/command.ts
+++ b/src/ts/lib/api/command.ts
@@ -1,5 +1,4 @@
 import * as I from 'Interface';
-import Storage from 'Lib/storage';
 
 export const InitialSetParameters = (platform: I.Platform, version: string, workDir: string, logLevel: string, doNotSendLogs: boolean, doNotSaveLogs: boolean, callBack?: (message: any) => void) => {
 	dispatcher.request('InitialSetParameters', {
@@ -1183,16 +1182,10 @@ export const ObjectOpen = (objectId: string, traceId: string, spaceId: string, c
 		if (!message.error.code) {
 			dispatcher.onObjectView(objectId, traceId, message.objectView, true);
 
-			// Save last opened object.
-			// Key it by the space the object actually belongs to (not the globally-current
-			// space, which may have already changed if this is a late response after a
-			// space switch) so it never pollutes another space's bucket (JS-9815).
-			const object = S.Detail.get(objectId, objectId, []);
-			const lastSpaceId = object.spaceId || spaceId;
-
-			if (!object._empty_ && ![ I.ObjectLayout.Dashboard ].includes(object.layout) && !keyboard.isPopup()) {
-				Storage.setLastOpened({ id: object.id, layout: object.layout, spaceId: lastSpaceId }, lastSpaceId);
-			};
+			// Record the last-opened object (popup / empty / dashboard guards and the
+			// per-space keying that avoids polluting another space's bucket after a late
+			// open all live in U.Space.setLastObject — see JS-9815).
+			U.Space.setLastObject(S.Detail.get(objectId, objectId, []), spaceId);
 		};
 
 		callBack?.(message);

--- a/src/ts/lib/util/space.test.ts
+++ b/src/ts/lib/util/space.test.ts
@@ -72,3 +72,81 @@ describe('UtilSpace.getLastObject (per-space validation)', () => {
 	});
 
 });
+
+/**
+ * Regression coverage for the chat last-opened regression (JS-9821 follow-up).
+ *
+ * The space's last-opened object is recorded in exactly one place. Chat-layout
+ * objects skip ObjectOpen (JS-9821), so they must record themselves via this
+ * shared helper — otherwise switching spaces and back reopens the previously
+ * opened page instead of the chat. These cover the recording rules and per-space
+ * keying (extracted from the previously inline ObjectOpen condition).
+ */
+describe('UtilSpace.setLastObject (per-space recording)', () => {
+
+	let store: Record<string, string>;
+
+	beforeEach(() => {
+		store = {};
+
+		vi.stubGlobal('localStorage', {
+			getItem: (k: string) => (k in store ? store[k] : null),
+			setItem: (k: string, v: string) => { store[k] = v; },
+			removeItem: (k: string) => { delete store[k]; },
+		});
+
+		vi.stubGlobal('U', { Common: { getElectron: () => ({}) } });
+		vi.stubGlobal('S', { Common: { space: '' }, Auth: { account: null } });
+		vi.stubGlobal('keyboard', { isPopup: () => false });
+
+		Storage.set('space', {}, true);
+	});
+
+	it('records the object keyed by its own space', () => {
+		(globalThis as any).S.Common.space = 'spaceA';
+		UtilSpace.setLastObject({ id: 'chatA', layout: 22, spaceId: 'spaceA' }); // 22 = Chat
+
+		const stored = Storage.getLastOpened('spaceA');
+		expect(stored.id).toBe('chatA');
+		expect(stored.spaceId).toBe('spaceA');
+		expect(stored.layout).toBe(22);
+	});
+
+	it('falls back to the current space when the object has no spaceId', () => {
+		(globalThis as any).S.Common.space = 'spaceB';
+		UtilSpace.setLastObject({ id: 'chatB', layout: 22 });
+
+		expect(Storage.getLastOpened('spaceB').id).toBe('chatB');
+	});
+
+	it('prefers an explicit spaceId arg over the current space', () => {
+		(globalThis as any).S.Common.space = 'spaceCurrent';
+		UtilSpace.setLastObject({ id: 'chatC', layout: 22 }, 'spaceTarget');
+
+		expect(Storage.getLastOpened('spaceTarget').id).toBe('chatC');
+		expect(Storage.getLastOpened('spaceCurrent').id).toBeUndefined();
+	});
+
+	it('does not record the Dashboard/home layout', () => {
+		(globalThis as any).S.Common.space = 'spaceD';
+		UtilSpace.setLastObject({ id: 'home', layout: 7, spaceId: 'spaceD' }); // 7 = Dashboard
+
+		expect(Storage.getLastOpened('spaceD').id).toBeUndefined();
+	});
+
+	it('does not record when opened in a popup', () => {
+		(globalThis as any).keyboard.isPopup = () => true;
+		(globalThis as any).S.Common.space = 'spaceE';
+		UtilSpace.setLastObject({ id: 'chatE', layout: 22, spaceId: 'spaceE' });
+
+		expect(Storage.getLastOpened('spaceE').id).toBeUndefined();
+	});
+
+	it('does not record an empty object', () => {
+		(globalThis as any).S.Common.space = 'spaceF';
+		UtilSpace.setLastObject({ _empty_: true, id: 'x', layout: 22, spaceId: 'spaceF' });
+
+		expect(Storage.getLastOpened('spaceF').id).toBeUndefined();
+	});
+
+});

--- a/src/ts/lib/util/space.ts
+++ b/src/ts/lib/util/space.ts
@@ -256,6 +256,38 @@ class UtilSpace {
 	};
 
 	/**
+	 * Records `object` as the space's last-opened object, so switching away from
+	 * the space and back reopens it (the write side of getLastObject).
+	 *
+	 * Skipped when:
+	 * - there is no real object (empty/blank detail);
+	 * - it is opened in a popup (transient, not the space's main view);
+	 * - it is the Dashboard/home layout, which is the fallback target itself and
+	 *   not a restorable object.
+	 *
+	 * Keyed by the object's own space (falling back to an explicit spaceId, then
+	 * the current space) so a late open arriving after a space switch can never
+	 * write into another space's bucket (JS-9815).
+	 */
+	setLastObject (object: any, spaceId?: string): void {
+		if (!object || object._empty_) {
+			return;
+		};
+
+		if (keyboard.isPopup()) {
+			return;
+		};
+
+		if ([ I.ObjectLayout.Dashboard ].includes(object.layout)) {
+			return;
+		};
+
+		const space = object.spaceId || spaceId || S.Common.space;
+
+		Storage.setLastOpened({ id: object.id, layout: object.layout, spaceId: space }, space);
+	};
+
+	/**
 	 * Gets the chat dashboard object.
 	 * @returns {I.DashboardObject} The chat dashboard object.
 	 */


### PR DESCRIPTION
## Problem

Regression from #2274 (JS-9821, chat skips \`ObjectOpen\`).

The space's *last-opened object* is persisted in exactly one place — inside the \`ObjectOpen\` success handler (\`command.ts\`). JS-9821 made chat-layout objects open via a lightweight \`ObjectSubscribeIds\` subscription instead of \`ObjectOpen\`, so opening a chat **never records it as the space's last-opened object**.

Result: open a chat → switch to another space → switch back → the space reopens the **previously opened page**, not the chat.

## Fix

Extract the recording logic (which was a dense inline condition) into a clearly-named, documented helper and call it from both open paths:

- **\`U.Space.setLastObject(object, spaceId?)\`** — each guard is now its own early-return (empty object / popup / dashboard layout), and the per-space keying that prevents cross-space pollution (JS-9815) lives in one place.
- \`command.ts\` \`ObjectOpen\` now calls the helper (behavior unchanged; removed the now-dead \`Storage\` import).
- \`page/main/chat.tsx\` calls the helper in the chat-layout branch (Space-layout still records via its \`ObjectOpen\`).

## Tests

Adds 6 unit tests for the recording rules (per-space keying, \`spaceId\` fallback/override, dashboard/popup/empty skips). \`bun run test src/ts/lib/util/space.test.ts\` → 10/10 pass. \`typecheck\` + \`lint\` clean.

## Manual verification

Open a chat → switch space → switch back → should reopen the chat (not the previous page).