### PR TITLE
fix(chat): forward pagination — keep position + keep loading (JS-9822)

### DIFF
--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -1462,7 +1462,13 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	};
 
 	const scrollToBottomCheck = () => {
-		if (isBottom.current) {
+		// Stick to the bottom only when we're actually at the chat's newest (the live tail).
+		// During FORWARD pagination (loading newer batches after the tail was evicted,
+		// isAtChatEnd=false) this must NOT fire — otherwise each appended batch snaps the view to
+		// the batch end, dumping the user at the bottom with nothing below to scroll into, so
+		// pagination can't continue. Keeping it off lets the appended rows sit below the current
+		// position; the view stays put and the user scrolls down through them to load the next page.
+		if (isBottom.current && S.Chat.isAtChatEnd(getSubId())) {
 			scrollToBottom(false);
 		};
 	};

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -54,6 +54,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	const [ pinnedMessages, setPinnedMessages ] = useState<I.ChatMessage[]>([]);
 	const [ pinnedIndex, setPinnedIndex ] = useState(-1);
 	const scrollRafRef = useRef(0);
+	const chainRafRef = useRef(0);
 	const visibleIds = useRef<Set<string>>(new Set());
 	const viewportObserver = useRef<IntersectionObserver | null>(null);
 	const formResizeObserver = useRef<ResizeObserver | null>(null);
@@ -473,6 +474,8 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 						return;
 					};
 
+					let added = false;
+
 					if (messages.length) {
 						const lengthBefore = S.Chat.getList(subId).length;
 
@@ -495,6 +498,8 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 						const evicted = S.Chat[(dir < 0 ? 'prepend' : 'append')](subId, messages);
 						const grew = S.Chat.getList(subId).length > lengthBefore;
 
+						added = grew || evicted;
+
 						// Force a re-render so the new rows commit (either direction) — the
 						// component is not a MobX observer. At the MAX_MESSAGES cap a prepend/append
 						// inserts and evicts the same count, so the length is unchanged even though
@@ -503,7 +508,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 						// anchoring (overflow-anchor) keeps the viewport static when content is
 						// inserted above and preserves momentum; setting scrollTop ourselves would
 						// jump the view (~1 viewport) at load time.
-						if (grew || evicted) {
+						if (added) {
 							setDummy(v => v + 1);
 						};
 					};
@@ -514,6 +519,38 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 						isLoadingPrev.current = false;
 					} else {
 						isLoadingNext.current = false;
+					};
+
+					// Forward analogue of the top-edge fix: a fast scroll (PageDown) can reach the hard
+					// bottom before the network responds, and since the prefetch is scroll-event driven it
+					// won't re-fire once the user stops there — so newer batches stall. Re-check post-render
+					// (raf, so the appended rows are laid out): if we're still within the prefetch band of
+					// the new bottom and the chat end isn't reached, chain the next forward load. Bounded —
+					// each append pushes the bottom ~one batch further, so it stops once ~2 viewports of
+					// newer history are buffered below, or at the chat end, or once the user scrolls away.
+					// Only chain when this page actually added rows (`added`) so a no-progress page can't
+					// spin. The raf carries the epoch guard (drop after a window reset) and is cancelled on
+					// unmount (chainRafRef), since the page container outlives the chat.
+					if ((dir > 0) && added && !S.Chat.isAtChatEnd(subId)) {
+						raf.cancel(chainRafRef.current);
+						chainRafRef.current = raf(() => {
+							if ((loadEpoch.current != epoch) || isLoadingNext.current || S.Chat.isAtChatEnd(subId)) {
+								return;
+							};
+
+							const c = U.Dom.getScrollContainer(isPopup);
+							if (!c) {
+								return;
+							};
+
+							const st = Math.ceil(c.scrollTop ?? 0);
+							const mx = c.scrollHeight - c.clientHeight;
+							const th = c.offsetHeight * 2;
+
+							if ((mx > 0) && (st >= (mx - th))) {
+								loadMessages(1, false);
+							};
+						});
 					};
 
 					callBack?.();
@@ -1719,6 +1756,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			window.clearTimeout(timeoutScrollStop.current);
 			window.clearTimeout(timeoutResize.current);
 			raf.cancel(scrollRafRef.current);
+			raf.cancel(chainRafRef.current);
 			messageRefs.current = {};
 			refSetters.current.clear();
 		};


### PR DESCRIPTION
Forward (load-newer) counterparts to the top-edge fixes from #2276. Reproduce by scrolling a chat up (evicting the newest tail), then scrolling back down.

## Problems

1. **Snaps to the batch end, losing your place.** `scrollToBottomCheck` (stick-to-bottom, meant for the live tail) fires whenever `isBottom.current` is true. During forward pagination `onScroll` re-sets `isBottom=true` at the loaded bottom, so each appended batch snaps the view to the batch end — you land back at the bottom with nothing below to scroll into, so loading can't continue.
2. **Fast scroll (PageDown) to the hard bottom stalls.** The load-newer prefetch is scroll-event driven; once you stop at the bottom it can't re-fire, so newer batches never load.

## Fixes

- **Gate stick-to-bottom on `isAtChatEnd`** — only follow the bottom when at the chat's newest. During pagination the appended rows stay below the current position (default append-below keeps `scrollTop`), so the view stays put and you scroll down through them; reaching the true newest still snaps.
- **Chain the next forward load** after one lands near the bottom, so a fast PageDown that stops at the edge keeps loading. Bounded: stops once ~2 viewports are buffered, at the chat end, or when you scroll away. Epoch-guarded (drops after a window reset), progress-gated (a no-progress page can't spin), and cancelled on unmount (the `#page` container outlives the chat).

The bottom has no `overflow-anchor`-suppressed-at-`scrollTop 0` pin like the top, so these are a stick-to-bottom gate + continuation, not an anchor restore.

## Verify

Scroll up to evict the tail, PageDown back down: position is preserved as newer batches append, loading continues to the true bottom, and it snaps only at the actual newest.