### PR TITLE
perf(store): cheaper detail storage and cached Detail.get()

### DIFF
--- a/docs/src/ts/store/README.md
+++ b/docs/src/ts/store/README.md
@@ -9,7 +9,7 @@ Reactive state stores using MobX. Each store manages a specific domain. Accessed
 | `common.ts` | `S.Common` | Global app state: space, theme, language, config, sidebar states, date format |
 | `auth.ts` | `S.Auth` | Authentication: account, wallet phrase, membership, PIN |
 | `block.ts` | `S.Block` | Document block trees: block CRUD, tree traversal, children management |
-| `detail.ts` | `S.Detail` | Object details/properties: get/set details, relations, layout info |
+| `detail.ts` | `S.Detail` | Object details/properties: get/set details, relations, layout info. Stores raw values in shallow observable maps (per-relation-key reactivity); `get()` results are cached per-args in reactive contexts via self-evicting computeds |
 | `record.ts` | `S.Record` | Dataview records: views, sorts, filters, groups, types, relations |
 | `menu.ts` | `S.Menu` | Menu state: open/close/update menus, sub-menu management |
 | `popup.ts` | `S.Popup` | Popup state: open/close/update popups, dimmer control |

--- a/src/ts/store/detail.ts
+++ b/src/ts/store/detail.ts
@@ -265,10 +265,18 @@ class DetailStore {
 			return this.build(rootId, id, withKeys, forceKeys, skipLayoutFormat);
 		};
 
-		const cacheKey = [ rootId, id, (withKeys ? withKeys.join(',') : '*'), Number(forceKeys), (skipLayoutFormat || []).join(',') ].join('\n');
+		const cacheKey = [ rootId, id, (withKeys ? withKeys.join(',') : '*'), (forceKeys ? 1 : 0), (skipLayoutFormat || []).join(',') ].join('\n');
 
 		let entry = this.getCache.get(cacheKey);
 		if (!entry) {
+			// Safety bound: entries created inside a suspended computed (evaluated in a
+			// batch with no observers) never fire onBecomeUnobserved and would accumulate.
+			// Clearing is safe — live observers keep their computed instances working,
+			// and the next get() simply creates a fresh entry.
+			if (this.getCache.size >= 10000) {
+				this.getCache.clear();
+			};
+
 			entry = computed(() => this.build(rootId, id, withKeys, forceKeys, skipLayoutFormat));
 			onBecomeUnobserved(entry, () => this.getCache.delete(cacheKey));
 			this.getCache.set(cacheKey, entry);

--- a/src/ts/store/detail.ts
+++ b/src/ts/store/detail.ts
@@ -1,12 +1,6 @@
-import { observable, action, makeObservable, set } from 'mobx';
+import { observable, action, computed, makeObservable, onBecomeUnobserved, _isComputingDerivation, IComputedValue } from 'mobx';
 import { memoize } from 'lodash';
 import * as I from 'Interface';
-
-interface Detail {
-	relationKey: string;
-	value: unknown;
-	isDeleted: boolean;
-};
 
 interface Item {
 	id: string;
@@ -50,11 +44,21 @@ keyMap[I.ObjectLayout.Space] = keyMap[I.ObjectLayout.SpaceView];
  * relations, etc. The store provides layout-aware mappers that add convenience
  * properties (e.g., isOwner, isWriter for Participants).
  *
- * Structure: Map<rootId, Map<objectId, Map<relationKey, Detail>>>
+ * Structure: Map<rootId, Map<objectId, ObservableMap<relationKey, value>>>
+ * The per-object detail map is a shallow observable map: values are stored raw
+ * (per-key reactivity comes from the map entries), so a write allocates one map
+ * entry per relation instead of a makeObservable-instrumented wrapper object.
  */
 class DetailStore {
 
-	private map: Map<string, Map<string, Map<string, Detail>>> = new Map();
+	private map: Map<string, Map<string, Map<string, any>>> = new Map();
+
+	/**
+	 * Per-(rootId, id, args) computed cache for get(): inside reactive contexts the
+	 * built + mapped object is cached between renders and recomputed only when the
+	 * underlying observables change. Entries evict themselves when unobserved.
+	 */
+	private getCache: Map<string, IComputedValue<any>> = new Map();
 
 	constructor() {
 		makeObservable<DetailStore, 'map'>(this, {
@@ -86,16 +90,15 @@ class DetailStore {
 		return v;
 	};
 
-	private createListItem (k: string, v: any): Detail {
-		const el = { relationKey: k, value: this.sanitizeValue(v), isDeleted: false };
+	private createDetailMap (details: any): Map<string, any> {
+		const detailMap = observable.map(new Map(), { deep: false });
 
-		makeObservable(el, { 
-			value: observable, 
-			isDeleted: observable,
-		});
+		for (const k in details) {
+			detailMap.set(k, this.sanitizeValue(details[k]));
+		};
 
-		return el;
-	}; 
+		return detailMap;
+	};
 
 	/**
 	 * Adds details to the detail store.
@@ -111,13 +114,7 @@ class DetailStore {
 		const map = observable.map(new Map());
 
 		for (const item of items) {
-			const detailMap = new Map<string, Detail>();
-
-			for (const k in item.details) {
-				detailMap.set(k, this.createListItem(k, item.details[k]));
-			};
-
-			map.set(item.id, detailMap);
+			map.set(item.id, this.createDetailMap(item.details));
 		};
 
 		this.map.set(rootId, map);
@@ -155,22 +152,12 @@ class DetailStore {
 
 		let detailMap = map.get(item.id);
 		if (!detailMap) {
-			detailMap = new Map<string, Detail>();
+			detailMap = observable.map(new Map(), { deep: false });
 			createList = true;
 		};
 
 		for (const k in item.details) {
-			if (clear) {
-				detailMap.set(k, this.createListItem(k, item.details[k]));
-				continue;
-			};
-
-			const el = detailMap.get(k);
-			if (el) {
-				set(el, { value: this.sanitizeValue(item.details[k]), isDeleted: false });
-			} else {
-				detailMap.set(k, this.createListItem(k, item.details[k]));
-			};
+			detailMap.set(k, this.sanitizeValue(item.details[k]));
 		};
 
 		if (createList) {
@@ -272,21 +259,52 @@ class DetailStore {
 	 * @returns {any} The object.
 	 */
 	public get (rootId: string, id: string, withKeys?: string[], forceKeys?: boolean, skipLayoutFormat?: I.ObjectLayout[]): any {
+		// Outside a reactive context a computed would not cache between calls anyway,
+		// so build directly (also avoids cache entries nothing would ever evict).
+		if (!_isComputingDerivation()) {
+			return this.build(rootId, id, withKeys, forceKeys, skipLayoutFormat);
+		};
+
+		const cacheKey = [ rootId, id, (withKeys ? withKeys.join(',') : '*'), Number(forceKeys), (skipLayoutFormat || []).join(',') ].join('\n');
+
+		let entry = this.getCache.get(cacheKey);
+		if (!entry) {
+			entry = computed(() => this.build(rootId, id, withKeys, forceKeys, skipLayoutFormat));
+			onBecomeUnobserved(entry, () => this.getCache.delete(cacheKey));
+			this.getCache.set(cacheKey, entry);
+		};
+
+		// Shallow copy: callers can safely overwrite top-level properties of the
+		// result, same as with the previously returned per-call fresh object.
+		return Object.assign({}, entry.get());
+	};
+
+	/**
+	 * Builds the mapped object from stored details. Reads only the requested keys,
+	 * so reactive callers subscribe to exactly the relation entries they use.
+	 * @private
+	 */
+	private build (rootId: string, id: string, withKeys?: string[], forceKeys?: boolean, skipLayoutFormat?: I.ObjectLayout[]): any {
 		const detailMap = this.map.get(rootId)?.get(id);
 
-		if (!detailMap || detailMap.size == 0) {
+		if (!detailMap || (detailMap.size == 0)) {
 			return { id, _empty_: true };
 		};
-		
+
 		const object = { id };
-		const keys = withKeys ? this.computeKeySet(withKeys, forceKeys) : null;
 
-		for (const [ relationKey, item ] of detailMap.entries()) {
-			if (item.isDeleted || (withKeys && !keys.has(item.relationKey))) {
-				continue;
+		if (withKeys) {
+			const keys = this.computeKeySet(withKeys, forceKeys);
+
+			for (const key of keys) {
+				if (detailMap.has(key)) {
+					object[key] = detailMap.get(key);
+				};
 			};
-
-			object[item.relationKey] = item.value;
+		} else {
+			for (const [ key, value ] of detailMap.entries()) {
+				object[key] = value;
+			};
 		};
 
 		return this.mapper(object, skipLayoutFormat);


### PR DESCRIPTION
## What

Follow-up to #2282. Tracing a subscription record end-to-end showed the expensive copies live **downstream of protobuf decode**, in `S.Detail`:

- Every relation of every record was stored as a `{relationKey, value, isDeleted}` wrapper with its own `makeObservable` call (2 boxed observables each) and **deep-wrapped values** (arrays/objects proxied) — ~1,500 MobX-instrumented objects for a 50-record × 30-relation page.
- `S.Detail.get()` rebuilt the plain object and re-ran the layout mapper (`mapCommon` + `mapType`/`mapSpaceView`/… coercions, `translate()` calls) from scratch on **every call from ~246 call sites**, at render rate (`S.Record.getRecords` alone calls it once per row per render). It also iterated **all** stored relations even when 3 keys were requested.

## Changes

**Storage** — one shallow `observable.map` per object holding raw values:
- One map entry per relation instead of wrapper object + 2 boxes + deep value proxies. Per-key reactivity granularity is unchanged (MobX map entries are tracked per key).
- Drops the dead `Detail.isDeleted` flag — nothing anywhere ever set it to `true`.

**`get()`** — requested-keys iteration + per-args computed cache:
- With `withKeys`, iterates the requested key set: O(requested) instead of O(total stored), and reactive callers subscribe to exactly the entries they use. Absent keys are tracked via `has()`, so an object/relation appearing later invalidates correctly (previously new-key adds relied on map-level key tracking).
- In reactive contexts (observer renders, autoruns, computeds) results are cached in per-`(rootId, id, args)` computeds that self-evict via `onBecomeUnobserved` — cached between renders, recomputed only when an underlying observable actually changes. Outside reactive contexts it builds directly (a computed wouldn't cache there anyway, and no cache entries leak).
- Callers receive a shallow copy — the old fresh-object-per-call top-level mutation semantics are preserved, and caller mutations can't corrupt the cache.
- `translate()` and date formatting read observable `S.Common` state (`config` → computed, `showRelativeDates`/`dateFormat` → computed), so language/format switches invalidate cached objects automatically.

## Numbers (differential harness, old implementation vs new, 2,000 records × 34 relations)

| | old | new |
|---|---|---|
| `set()` write | 118ms | **11ms** |
| heap growth on that write | ~118MB | **~0MB** |
| 60 re-renders of a 100-row list reading 5 keys | 184ms | **80ms** |
| 6,000 `get()` calls inside a live reaction | 24ms | **4.6ms** |

## Verification

- Differential test vs the old implementation: output equivalence across layouts (page/note/participant), `withKeys`/`forceKeys`/`skipLayoutFormat` combos, amend/clear updates, key/object deletes, `getKeys`.
- Reactivity semantics: relevant-key updates trigger subscribers, unrelated-key updates don't (same as before), keySet-included key additions trigger, other-object updates don't, cache is shared per args and evicts to zero after disposal, non-reactive gets create no cache entries, `_empty_` → populated invalidates.
- Typecheck, lint pass; vitest shows the identical 101 pre-existing failures as clean `develop` (verified baseline), zero new.

## Behavioral notes (intentional)

- Result **property order** changes from store-insertion order (arbitrary middleware response order) to requested-keys-then-defaults order. Key sets and values are identical.
- Stored values are no longer deep MobX proxies — `get()` returns plain arrays/objects. All legitimate updates flow through `S.Detail.set/update` (middleware events), which replace values and notify; in-place mutation of a stored value from a component was never a supported pattern.