### PR TITLE
Prevent concurrent text loss in empty blocks (virtual last block + BlockReplace fork)

### DIFF
--- a/src/json/constant.ts
+++ b/src/json/constant.ts
@@ -190,6 +190,7 @@ export default {
 		type:			 'type',
 		header:			 'header',
 		chat:			 'chat',
+		virtualLast:	 'virtualLastBlock',
 	},
 
 	widgetId: {

--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -6,6 +6,7 @@ import { Select, Marker, IconObject, Icon, Editable } from 'Component';
 import * as I from 'Interface';
 import Storage from 'Lib/storage';
 import { focus } from 'Lib/focus';
+import { virtualBlock } from 'Lib/virtualBlock';
 
 // Prism language plugins expect `Prism` on the global scope
 (window as any).Prism = Prism;
@@ -397,9 +398,9 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 		});
 
 		if (newBlock.type && (!isInsideTable && !block.isTextCode())) {
-			C.BlockCreate(rootId, id, I.BlockPosition.Top, newBlock, () => {
+			C.BlockCreate(rootId, virtualBlock.resolve(id), I.BlockPosition.Top, newBlock, () => {
 				setValue('');
-				
+
 				focus.set(block.id, { from: 0, to: 0 });
 				focus.apply();
 			});
@@ -428,11 +429,14 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 						setValue('');
 
 						U.Data.blockSetText(rootId, block.id, '', [], true, () => {
+							// Runs after a queued materialization of the virtual placeholder — resolve the id
+							const blockId = virtualBlock.resolve(block.id);
+
 							C.BlockListSetFields(rootId, [
-								{ blockId: block.id, fields: { ...block.fields, lang } }
+								{ blockId, fields: { ...block.fields, lang } }
 							], () => {
-								C.BlockListTurnInto(rootId, [ block.id ], I.TextStyle.Code, () => {
-									focus.set(block.id, { from: 0, to: 0 });
+								C.BlockListTurnInto(rootId, [ blockId ], I.TextStyle.Code, () => {
+									focus.set(blockId, { from: 0, to: 0 });
 									focus.apply();
 								});
 							});
@@ -983,14 +987,17 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 				setValue(value);
 
 				U.Data.blockSetText(rootId, id, value, marksRef.current, true, () => {
+					// Runs after a queued materialization of the virtual placeholder — resolve the id
+					const blockId = virtualBlock.resolve(id);
+
 					const finishTurnInto = () => {
-						C.BlockListTurnInto(rootId, [ id ], newStyle, () => {
-							focus.set(block.id, { from: 0, to: 0 });
+						C.BlockListTurnInto(rootId, [ blockId ], newStyle, () => {
+							focus.set(blockId, { from: 0, to: 0 });
 							focus.apply();
 						});
 
 						if ([ I.TextStyle.Toggle, I.TextStyle.ToggleHeader1, I.TextStyle.ToggleHeader2, I.TextStyle.ToggleHeader3 ].includes(newStyle)) {
-							S.Block.toggle(rootId, id, true);
+							S.Block.toggle(rootId, blockId, true);
 						};
 					};
 
@@ -998,7 +1005,7 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 						const lang = match[2] || Storage.get('codeLang') || J.Constant.default.codeLang;
 
 						C.BlockListSetFields(rootId, [
-							{ blockId: block.id, fields: { ...block.fields, lang } }
+							{ blockId, fields: { ...block.fields, lang } }
 						], finishTurnInto);
 					} else {
 						finishTurnInto();
@@ -1068,13 +1075,21 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 			};
 		};
 
-		// Debounce the gRPC save so rapid typing doesn't saturate the main thread
-		// with synchronous middleware round-trips. The contenteditable DOM already
-		// reflects the user's input natively — we only need to persist periodically.
 		window.clearTimeout(timeoutText.current);
-		timeoutText.current = window.setTimeout(() => {
+
+		if (!keyboard.isComposition && virtualBlock.shouldFork(rootId, block, value)) {
+			// First content into an empty block forks the block identity via
+			// BlockReplace — fire the save immediately so the fork happens on the
+			// first keystroke; further keyups are buffered against the fork
 			setText(marksRef.current, false);
-		}, 300);
+		} else {
+			// Debounce the gRPC save so rapid typing doesn't saturate the main thread
+			// with synchronous middleware round-trips. The contenteditable DOM already
+			// reflects the user's input natively — we only need to persist periodically.
+			timeoutText.current = window.setTimeout(() => {
+				setText(marksRef.current, false);
+			}, 300);
+		};
 
 		onKeyUp(e, value, marksRef.current, range, props);
 
@@ -1084,12 +1099,17 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 	};
 
 	const onMention = (d: number) => {
-		const range = getRange();
+		// This instance may already be unmounted when a queued trigger runs after
+		// an id fork/materialization — the swap left the correct range in the
+		// focus state
+		const range = getRange() || focus.state.range;
 		if (!range) {
 			return;
 		};
 
-		const element = `#block-${U.Common.esc(block.id)}`;
+		// May run after a queued materialization of the virtual placeholder
+		const blockId = virtualBlock.resolve(block.id);
+		const element = `#block-${U.Common.esc(blockId)}`;
 
 		let value = getTextValue();
 
@@ -1118,7 +1138,7 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 				noFlipY: false,
 				data: {
 					rootId,
-					blockId: block.id,
+					blockId,
 					marks: marksRef.current,
 					skipIds: [ rootId ],
 					canAdd: true,
@@ -1141,10 +1161,14 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 	};
 
 	const onEmojiSearch = () => {
-		const range = getRange();
+		// See onMention: the instance may be unmounted when a queued trigger runs
+		const range = getRange() || focus.state.range;
 		if (!range) {
 			return;
 		};
+
+		// May run after a queued materialization of the virtual placeholder
+		const blockId = virtualBlock.resolve(block.id);
 
 		let value = getTextValue();
 
@@ -1155,7 +1179,7 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 		S.Menu.open('blockEmoji', {
 			classNameWrap: 'fromBlock',
-			element: `#block-${U.Common.esc(block.id)}`,
+			element: `#block-${U.Common.esc(blockId)}`,
 			recalcRect: () => {
 				const rect = U.Dom.getSelectionRect();
 				return rect ? { ...rect, y: rect.y + window.scrollY } : null;
@@ -1168,7 +1192,7 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 			noFlipY: false,
 			data: {
 				rootId,
-				blockId: block.id,
+				blockId,
 				marks: marksRef.current,
 				onChange: (native: string, marks: I.Mark[], from: number, to: number) => {
 					if (S.Menu.isAnimating('blockEmoji')) {
@@ -1188,11 +1212,12 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 	const onSmile = () => {
 		const range = getRange();
+		const blockId = virtualBlock.resolve(block.id);
 
 		let value = getTextValue();
 
 		S.Menu.open('smile', {
-			element: `#block-${U.Common.esc(block.id)}`,
+			element: `#block-${U.Common.esc(blockId)}`,
 			classNameWrap: 'fromBlock',
 			recalcRect: () => {
 				const rect = U.Dom.getSelectionRect();
@@ -1206,7 +1231,7 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 				value: (iconEmoji || iconImage || ''),
 				noHead: true,
 				rootId,
-				blockId: block.id,
+				blockId,
 				onSelect: (icon: string) => {
 					const to = range.from + 1;
 

--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -1,13 +1,14 @@
 import React, { forwardRef, useRef, useEffect, useState } from 'react';
 import raf from 'raf';
 import { throttle } from 'lodash';
-import { Icon, DropTarget, EditorControls, CommentSection } from 'Component';
+import { Icon, DropTarget, EditorControls, CommentSection, Block } from 'Component';
 import PageHeadEditor from 'Component/page/elements/head/editor';
 import Children from 'Component/page/elements/children';
 import TableOfContents from 'Component/page/elements/tableOfContents';
 import * as I from 'Interface';
 import Storage from 'Lib/storage';
 import { focus } from 'Lib/focus';
+import { virtualBlock } from 'Lib/virtualBlock';
 import { useScrollRestore } from 'Hook';
 import { computeRestoreScrollTop } from 'Lib/util/scrollAnchor';
 
@@ -226,6 +227,7 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 	};
 
 	const close = () => {
+		virtualBlock.deactivate();
 		Action.pageClose(isPopup, idRef.current, true);
 		Storage.setFocus(idRef.current, focus.state);
 		idRef.current = '';
@@ -938,19 +940,20 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 		});
 
 		if (!ret && ids.length && !keyboard.isSpecial(e) && !e.metaKey && !e.ctrlKey && !readonly) {
+			// Carry the typed character in the create itself — the block must never
+			// exist in an empty state (empty synced blocks are shared last-writer-wins
+			// registers, see Lib/virtualBlock)
+			const key = e.key;
 			const param = {
 				type: I.BlockType.Text,
-				style: I.TextStyle.Paragraph,
+				content: { style: I.TextStyle.Paragraph, text: key },
 			};
 
 			C.BlockCreate(rootId, ids[ids.length - 1], I.BlockPosition.Bottom, param, (message: any) => {
-				const key = e.key;
 				const blockId = message.blockId;
+				const length = key.length;
 
-				C.BlockListDelete(rootId, ids);
-				U.Data.blockSetText(rootId, blockId, key, [], true, () => {
-					const length = key.length;
-
+				C.BlockListDelete(rootId, ids, () => {
 					focus.set(blockId, { from: length, to: length });
 					focus.apply();
 					focus.scroll(isPopup, blockId);
@@ -968,6 +971,11 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 		const block = S.Block.getLeaf(rootId, focused);
 
 		if (!block) {
+			// The trailing virtual placeholder has no store block — handle the few
+			// keys that must act on an empty placeholder explicitly, ignore the rest
+			if (virtualBlock.isVirginFocused(rootId)) {
+				onVirtualKeyDown(e);
+			};
 			return;
 		};
 
@@ -2114,6 +2122,11 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 	
 	const onMenuAdd = (blockId: string, text: string, range: I.TextRange, marks: I.Mark[]) => {
 		const { rootId } = props;
+
+		// A "/" typed as the first character of the virtual placeholder queues this
+		// call until the block is materialized — resolve to the real id
+		blockId = virtualBlock.resolve(blockId);
+
 		const block = S.Block.getLeaf(rootId, blockId);
 		const rect = U.Dom.getSelectionRect();
 
@@ -2254,7 +2267,18 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 		data.anytype = data.anytype || {};
 		data.anytype.range = data.anytype.range || { from: 0, to: 0 };
 
-		const { focused, range } = focus.state;
+		let { focused, range } = focus.state;
+
+		// Pasting into the virgin virtual placeholder: no block exists yet — paste
+		// at the document bottom (empty target id appends), same as dropping onto
+		// the trailing drop zone. The pasted blocks carry their content, so no
+		// empty block is ever created
+		if (virtualBlock.isVirtualId(focused)) {
+			focused = '';
+			range = { from: 0, to: 0 };
+			virtualBlock.deactivate();
+		};
+
 		const block = S.Block.getLeaf(rootId, focused);
 		const selection = S.Common.getRef('selectionProvider');
 		const trimmedText = data.text.trim();
@@ -2890,8 +2914,6 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 		};
 
 		let last = S.Block.getFirstBlock(rootId, -1, it => it.canCreateBlock());
-		let create = false;
-		let length = 0;
 
 		if (last) {
 			const parent = S.Block.getParentLeaf(rootId, last.id);
@@ -2901,24 +2923,77 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 			};
 		};
 
-		if (!last) {
-			create = true;
-		} else {
-			if (!last.isText() || last.isTextCode() || last.isTextCallout()) {
-				create = true;
-			} else {
-				length = last.getLength();
-				if (length) {
-					create = true;
-				};
-			};
-		};
+		// Only focus-reuse a trailing empty text block created by this session.
+		// Converging into a foreign empty block (from an old client or another
+		// user) makes concurrent typing collide on the same block id and lose
+		// text — render the client-side virtual placeholder below it instead.
+		const reuse = last && last.isText() && !last.isTextCode() && !last.isTextCallout() && !last.getLength() && S.Block.isSessionCreated(last.id);
 
-		if (create) {
-			blockCreate('', I.BlockPosition.Bottom, { type: I.BlockType.Text });
+		if (reuse) {
+			focusSet(last.id, 0, 0, true);
 		} else {
-			focusSet(last.id, length, length, true);
+			virtualBlock.activate(rootId, isPopup);
+			focusSet(J.Constant.blockId.virtualLast, 0, 0, true);
 		};
+	};
+
+	// Key handling for the empty (not yet materialized) virtual placeholder —
+	// it has no store block, so the regular block flows can't act on it
+	const onVirtualKeyDown = (e: any) => {
+		// Enter on the empty placeholder creates a real empty block above it,
+		// mirroring Enter on a real empty trailing block (explicit editing action)
+		keyboard.shortcut('enter', e, () => {
+			if (isEnterProcessing.current) {
+				return;
+			};
+
+			isEnterProcessing.current = true;
+
+			C.BlockCreate(rootId, '', I.BlockPosition.Bottom, { type: I.BlockType.Text, content: { style: I.TextStyle.Paragraph } }, (message: any) => {
+				window.setTimeout(() => { isEnterProcessing.current = false; }, 30);
+
+				if (message.error.code) {
+					return;
+				};
+
+				analytics.event('CreateBlock', { middleTime: message.middleTime, type: I.BlockType.Text, style: I.TextStyle.Paragraph });
+				focusSet(J.Constant.blockId.virtualLast, 0, 0, true);
+			});
+		});
+
+		// Nothing was created — leaving the placeholder just stops rendering it
+		keyboard.shortcut('backspace, arrowup, arrowleft', e, () => {
+			if (virtualBlock.isCreating) {
+				return;
+			};
+
+			const last = S.Block.getFirstBlock(rootId, -1, it => it.isFocusable());
+
+			virtualBlock.deactivate();
+
+			if (last) {
+				const length = last.getLength();
+				focusSet(last.id, length, length, true);
+			} else {
+				focus.clear(true);
+			};
+		});
+
+		keyboard.shortcut('selectAll', e, () => {
+			onSelectAll();
+		});
+	};
+
+	const onVirtualBlur = () => {
+		// Focus left the placeholder with nothing typed: nothing was created,
+		// nothing to clean up. A materialized placeholder finishes its swap on its own
+		if (!virtualBlock.realId && !virtualBlock.isCreating) {
+			virtualBlock.deactivate();
+		};
+	};
+
+	const onVirtualUpdate = () => {
+		virtualBlock.checkMaterialize();
 	};
 	
 	const resizePage = (callBack?: () => void) => {
@@ -3049,10 +3124,10 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 						getWrapperWidth={getWrapperWidth}
 					/>
 
-					<Children 
+					<Children
 						{...props}
 						onKeyDown={onKeyDownBlock}
-						onKeyUp={onKeyUpBlock}  
+						onKeyUp={onKeyUpBlock}
 						onMenuAdd={onMenuAdd}
 						onCopy={onCopy}
 						onPaste={onPasteEvent}
@@ -3060,6 +3135,26 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 						blockRemove={blockRemove}
 						getWrapperWidth={getWrapperWidth}
 					/>
+
+					{virtualBlock.isRendered(rootId, isPopup) && !readonly ? (
+						<Block
+							key="block-virtualLast"
+							{...props}
+							block={virtualBlock.getBlock()}
+							onKeyDown={onKeyDownBlock}
+							onKeyUp={onKeyUpBlock}
+							onMenuAdd={onMenuAdd}
+							onCopy={onCopy}
+							onPaste={onPasteEvent}
+							onUpdate={onVirtualUpdate}
+							onBlur={onVirtualBlur}
+							readonly={readonly}
+							blockRemove={blockRemove}
+							getWrapperWidth={getWrapperWidth}
+							isSelectionDisabled={true}
+							isContextMenuDisabled={true}
+						/>
+					) : ''}
 				</div>
 
 				<DropTarget rootId={rootId} id="blockLast" dropType={I.DropType.Block} canDropMiddle={false}>

--- a/src/ts/component/page/elements/children.tsx
+++ b/src/ts/component/page/elements/children.tsx
@@ -1,12 +1,17 @@
 import React, { forwardRef } from 'react';
 import { Block } from 'Component';
 import * as I from 'Interface';
+import { virtualBlock } from 'Lib/virtualBlock';
 
 const Children = forwardRef<{}, I.BlockComponent>((props, ref) => {
 
 	const { rootId } = props;
+	// A block materialized from the trailing virtual placeholder is still rendered
+	// by the placeholder slot until the swap completes — skip it here to avoid
+	// rendering it twice
+	const holdId = virtualBlock.getHoldId(rootId);
 	const childrenIds = S.Block.getChildrenIds(rootId, rootId);
-	const children = S.Block.getChildren(rootId, rootId, it => !it.isLayoutHeader());
+	const children = S.Block.getChildren(rootId, rootId, it => !it.isLayoutHeader() && (it.id != holdId));
 	const length = childrenIds.length;
 
 	return (

--- a/src/ts/lib/api/command.ts
+++ b/src/ts/lib/api/command.ts
@@ -309,7 +309,27 @@ export const BlockCreate = (contextId: string, targetId: string, position: I.Blo
 		targetId,
 		position: position as number,
 		block: Mapper.To.Block(block),
-	}, callBack);
+	}, (message: any) => {
+		if (!message.error.code && message.blockId) {
+			S.Block.addSessionCreated(message.blockId);
+		};
+
+		callBack?.(message);
+	});
+};
+
+export const BlockReplace = (contextId: string, blockId: string, block: any, callBack?: (message: any) => void) => {
+	dispatcher.request('BlockReplace', {
+		contextId,
+		blockId,
+		block: Mapper.To.Block(block),
+	}, (message: any) => {
+		if (!message.error.code && message.blockId) {
+			S.Block.addSessionCreated(message.blockId);
+		};
+
+		callBack?.(message);
+	});
 };
 
 export const BlockDataviewCreateFromExistingObject = (contextId: string, blockId: string, targetObjectId: string, callBack?: (message: any) => void) => {
@@ -430,7 +450,13 @@ export const BlockSplit = (contextId: string, blockId: string, range: I.TextRang
 		range: Mapper.To.Range(range),
 		style: style as number,
 		mode: mode as number,
-	}, callBack);
+	}, (message: any) => {
+		if (!message.error.code && message.blockId) {
+			S.Block.addSessionCreated(message.blockId);
+		};
+
+		callBack?.(message);
+	});
 };
 
 export const BlockBookmarkFetch = (contextId: string, blockId: string, url: string, templateId: string, callBack?: (message: any) => void) => {

--- a/src/ts/lib/api/response.ts
+++ b/src/ts/lib/api/response.ts
@@ -403,6 +403,12 @@ export const BlockSplit = (response: any) => {
 	};
 };
 
+export const BlockReplace = (response: any) => {
+	return {
+		blockId: response.blockId,
+	};
+};
+
 export const BlockCopy = (response: any) => {
 	return {
 		textSlot: response.textSlot,

--- a/src/ts/lib/focus.ts
+++ b/src/ts/lib/focus.ts
@@ -1,5 +1,6 @@
 import { setRange } from 'selection-ranges';
 import * as I from 'Interface';
+import { virtualBlock } from './virtualBlock';
 
 /**
  * Focus manages the focus state and text selection within the application.
@@ -37,8 +38,12 @@ class Focus {
 			return;
 		};
 
+		// Stale callbacks may still reference the virtual trailing placeholder
+		// after it has been materialized — resolve to the real block id
+		id = virtualBlock.resolve(String(id || ''));
+
 		this.state = {
-			focused: String(id || ''),
+			focused: id,
 			range: {
 				from: Math.max(0, Number(range.from) || 0),
 				to: Math.max(0, Number(range.to) || 0),
@@ -46,7 +51,11 @@ class Focus {
 		};
 		this.backup = U.Common.objectCopy(this.state);
 
-		C.BlockSetCarriage(keyboard.getRootId(), id, range);
+		// The virtual placeholder has no middleware-side block — focusing it must
+		// not produce any middleware calls
+		if (!virtualBlock.isVirtualId(id)) {
+			C.BlockSetCarriage(keyboard.getRootId(), id, range);
+		};
 		return this;
 	};
 

--- a/src/ts/lib/util/data.ts
+++ b/src/ts/lib/util/data.ts
@@ -4,6 +4,7 @@ import * as I from 'Interface';
 import * as M from 'Model';
 import Storage from 'Lib/storage';
 import { focus } from 'Lib/focus';
+import { virtualBlock } from 'Lib/virtualBlock';
 
 const TYPE_KEYS = {
 	default: [
@@ -498,13 +499,50 @@ class UtilData {
 	 * @param {(message: any) => void} [callBack] - Optional callback after setting text.
 	 */
 	blockSetText(rootId: string, blockId: string, text: string, marks: I.Mark[], update: boolean, callBack?: (message: any) => void) {
+		text = String(text || '');
+		marks = marks || [];
+
+		// The virtual trailing placeholder is not in the store and has no
+		// middleware-side block: the first non-empty write materializes it via a
+		// single BlockCreate carrying the content, later writes are redirected to
+		// the created block
+		if (virtualBlock.isVirtualId(blockId)) {
+			virtualBlock.setText(rootId, text, marks, update, callBack);
+			return;
+		};
+
+		// Stale callbacks may still write to an id whose identity was forked
+		blockId = virtualBlock.resolve(blockId);
+
+		// A fork for this block is in flight — buffer the write, it lands on the
+		// new id when the fork completes
+		if (virtualBlock.isForkPending(blockId)) {
+			virtualBlock.forkSetText(blockId, text, marks, callBack);
+			return;
+		};
+
 		const block = S.Block.getLeaf(rootId, blockId);
 		if (!block) {
 			return;
 		};
 
-		text = String(text || '');
-		marks = marks || [];
+		// First content into an empty text block forks the block identity: one
+		// BlockReplace carries the content on a fresh id, so two clients filling
+		// the same empty block concurrently end up with two blocks (both texts
+		// survive) instead of one block with one text lost to last-writer-wins
+		if (virtualBlock.shouldFork(rootId, block, text)) {
+			virtualBlock.fork(rootId, block, text, marks, callBack);
+			return;
+		};
+
+		// Skip no-op writes: merely placing or removing the cursor (blur flushes,
+		// shortcut save-keys) must not emit a text write — block text is
+		// whole-value last-writer-wins, so re-sending unchanged content can still
+		// destroy a concurrent peer edit on merge
+		if ((String(block.content.text || '') === text) && U.Common.compareJSON(block.content.marks || [], marks)) {
+			callBack?.({ error: { code: 0 } });
+			return;
+		};
 
 		if (update) {
 			S.Block.updateContent(rootId, blockId, { text, marks });
@@ -523,6 +561,8 @@ class UtilData {
 	 * @param {(message: any) => void} [callBack] - Optional callback after insertion.
 	 */
 	blockInsertText(rootId: string, blockId: string, needle: string, from: number, to: number, callBack?: (message: any) => void) {
+		blockId = virtualBlock.resolve(blockId);
+
 		const block = S.Block.getLeaf(rootId, blockId);
 		if (!block) {
 			return;
@@ -1264,7 +1304,7 @@ class UtilData {
 	 * @param {I.Block} block - The block.
 	 */
 	setRtl(rootId: string, block: I.Block, value: boolean, callBack?: (message: any) => void) {
-		if (!block) {
+		if (!block || virtualBlock.isVirtualId(block.id)) {
 			callBack?.({});
 			return;
 		};

--- a/src/ts/lib/virtualBlock.test.ts
+++ b/src/ts/lib/virtualBlock.test.ts
@@ -1,0 +1,450 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('react-dom', () => ({
+	flushSync: (fn: any) => fn(),
+}));
+
+import * as I from 'Interface';
+import * as M from 'Model';
+import { virtualBlock } from './virtualBlock';
+import { focus } from './focus';
+
+/**
+ * State-machine coverage for the trailing virtual placeholder ("click to type").
+ *
+ * The invariants under test mirror the data-loss fix acceptance criteria:
+ * - Clicking (activate + focus) produces ZERO middleware calls.
+ * - The first real input produces exactly one BlockCreate whose block model
+ *   already carries the content.
+ * - Nothing is ever created from an empty placeholder (blur, Enter chains, etc.
+ *   route through setText with empty text).
+ * - Writes and callbacks issued against the virtual id while the create is in
+ *   flight are queued and land on the real block id.
+ */
+
+const g = globalThis as any;
+
+const ROOT_ID = 'root';
+const VIRTUAL_ID = 'virtualLastBlock';
+
+let createCalls: any[];
+let replaceCalls: any[];
+let compositionListeners: any[];
+let storeBlocks: Map<string, any>;
+let storeChildren: Map<string, string[]>;
+let insideTable: Set<string>;
+
+const completeCreate = (blockId: string, error?: number) => {
+	const call = createCalls[createCalls.length - 1];
+	call.cb({ blockId, middleTime: 1, error: { code: error || 0 } });
+};
+
+const makeBlock = (id: string, param?: any) => {
+	const block = new M.Block({
+		id,
+		type: I.BlockType.Text,
+		childrenIds: [],
+		fields: {},
+		...param,
+		content: { style: I.TextStyle.Paragraph, text: '', marks: [], ...(param?.content || {}) },
+	});
+
+	storeBlocks.set(id, block);
+	return block;
+};
+
+// Simulates the middleware response: events remove the old block and add the
+// new one (carrying the sent content) before the callback runs
+const completeReplace = (newId: string, error?: number) => {
+	const call = replaceCalls[replaceCalls.length - 1];
+
+	if (!error) {
+		storeBlocks.delete(call.blockId);
+		makeBlock(newId, { content: { text: call.param.content.text, marks: call.param.content.marks } });
+	};
+
+	call.cb({ blockId: error ? '' : newId, middleTime: 1, error: { code: error || 0 } });
+};
+
+beforeEach(() => {
+	createCalls = [];
+	replaceCalls = [];
+	compositionListeners = [];
+	storeBlocks = new Map();
+	storeChildren = new Map();
+	insideTable = new Set();
+
+	g.J = { Constant: { blockId: { virtualLast: VIRTUAL_ID } } };
+
+	g.S = {
+		Block: {
+			getLeaf: (rootId: string, id: string) => storeBlocks.get(id) || null,
+			getChildrenIds: (rootId: string, id: string) => storeChildren.get(id) || [],
+			checkIsInsideTable: (rootId: string, id: string) => insideTable.has(id),
+			addSessionCreated: vi.fn(),
+			updateContent: vi.fn(),
+		},
+	};
+
+	g.U = {
+		Common: {
+			compareJSON: (o1: any, o2: any) => JSON.stringify(o1) === JSON.stringify(o2),
+			objectCopy: (o: any) => JSON.parse(JSON.stringify(o ?? {})),
+			esc: (s: string) => String(s || ''),
+		},
+		Data: {
+			blockSetText: vi.fn((rootId: string, blockId: string, text: string, marks: any[], update: boolean, cb?: any) => {
+				cb?.({ error: { code: 0 } });
+			}),
+		},
+		Dom: {
+			select: () => null,
+			selectAll: () => [],
+			get: () => null,
+			hasClass: () => false,
+			addClass: () => {},
+			removeClass: () => {},
+			clearSelection: () => {},
+		},
+	};
+
+	g.C = {
+		BlockCreate: vi.fn((rootId: string, targetId: string, position: number, param: any, cb: any) => {
+			createCalls.push({ rootId, targetId, position, param, cb });
+		}),
+		BlockReplace: vi.fn((rootId: string, blockId: string, param: any, cb: any) => {
+			replaceCalls.push({ rootId, blockId, param, cb });
+		}),
+		BlockSetCarriage: vi.fn(),
+	};
+
+	g.keyboard = {
+		isComposition: false,
+		getRootId: () => ROOT_ID,
+		setFocus: () => {},
+	};
+
+	g.analytics = { event: vi.fn() };
+
+	g.window.addEventListener = (type: string, handler: any) => {
+		if (type == 'compositionend') {
+			compositionListeners.push(handler);
+		};
+	};
+	g.window.removeEventListener = () => {};
+	g.window.setTimeout = (fn: any) => {
+		fn();
+		return 0;
+	};
+
+	focus.state = { focused: '', range: { from: 0, to: 0 } };
+	virtualBlock.deactivate();
+});
+
+describe('virtualBlock', () => {
+
+	it('activating and focusing the placeholder produces zero middleware calls', () => {
+		virtualBlock.activate(ROOT_ID, false);
+		focus.set(VIRTUAL_ID, { from: 0, to: 0 });
+
+		expect(focus.state.focused).toBe(VIRTUAL_ID);
+		expect(g.C.BlockSetCarriage).not.toHaveBeenCalled();
+		expect(g.C.BlockCreate).not.toHaveBeenCalled();
+	});
+
+	it('renders a text block for the active editor only', () => {
+		virtualBlock.activate(ROOT_ID, false);
+
+		expect(virtualBlock.isRendered(ROOT_ID, false)).toBe(true);
+		expect(virtualBlock.isRendered(ROOT_ID, true)).toBe(false);
+		expect(virtualBlock.isRendered('other', false)).toBe(false);
+
+		const block = virtualBlock.getBlock();
+
+		expect(block.id).toBe(VIRTUAL_ID);
+		expect(block.isText()).toBe(true);
+	});
+
+	it('empty text writes on a virgin placeholder create nothing', () => {
+		const cb = vi.fn();
+
+		virtualBlock.activate(ROOT_ID, false);
+		virtualBlock.setText(ROOT_ID, '', [], true, cb);
+
+		expect(g.C.BlockCreate).not.toHaveBeenCalled();
+		expect(cb).toHaveBeenCalled();
+	});
+
+	it('first input creates exactly one block already carrying the content', () => {
+		virtualBlock.activate(ROOT_ID, false);
+		focus.set(VIRTUAL_ID, { from: 0, to: 0 });
+
+		virtualBlock.setText(ROOT_ID, 'h', [], true);
+
+		expect(createCalls.length).toBe(1);
+		expect(createCalls[0].rootId).toBe(ROOT_ID);
+		expect(createCalls[0].targetId).toBe('');
+		expect(createCalls[0].param.content.text).toBe('h');
+
+		completeCreate('real1');
+
+		expect(virtualBlock.realId).toBe('real1');
+		expect(virtualBlock.resolve(VIRTUAL_ID)).toBe('real1');
+		expect(virtualBlock.isActive).toBe(false);
+		expect(virtualBlock.isSwapped).toBe(true);
+		expect(focus.state.focused).toBe('real1');
+		expect(focus.state.range).toEqual({ from: 1, to: 1 });
+		expect(g.analytics.event).toHaveBeenCalledWith('CreateBlock', expect.anything());
+
+		// No BlockTextSetText was needed — the create carried the content
+		expect(g.U.Data.blockSetText).not.toHaveBeenCalled();
+	});
+
+	it('echoes of already-sent content are not re-sent after materialization', () => {
+		const cb = vi.fn();
+
+		virtualBlock.activate(ROOT_ID, false);
+		virtualBlock.setText(ROOT_ID, 'h', [], true);
+		completeCreate('real1');
+
+		// The debounced keyup save re-sends exactly what BlockCreate carried
+		virtualBlock.setText(ROOT_ID, 'h', [], false, cb);
+
+		expect(g.U.Data.blockSetText).not.toHaveBeenCalled();
+		expect(cb).toHaveBeenCalled();
+
+		// New content goes through as a regular redirected write
+		virtualBlock.setText(ROOT_ID, 'hi', [], true);
+
+		expect(g.U.Data.blockSetText).toHaveBeenCalledWith(ROOT_ID, 'real1', 'hi', [], true, undefined);
+		expect(createCalls.length).toBe(1);
+	});
+
+	it('writes and callbacks issued while the create is in flight land on the real block', () => {
+		const cb1 = vi.fn();
+		const cb2 = vi.fn();
+
+		virtualBlock.activate(ROOT_ID, false);
+		virtualBlock.setText(ROOT_ID, 'h', [], true, cb1);
+		virtualBlock.setText(ROOT_ID, 'he', [], true, cb2);
+
+		expect(createCalls.length).toBe(1);
+		expect(cb1).not.toHaveBeenCalled();
+		expect(cb2).not.toHaveBeenCalled();
+
+		completeCreate('real1');
+
+		expect(g.U.Data.blockSetText).toHaveBeenCalledWith(ROOT_ID, 'real1', 'he', [], true);
+		expect(cb1).toHaveBeenCalledWith(expect.objectContaining({ blockId: 'real1' }));
+		expect(cb2).toHaveBeenCalledWith(expect.objectContaining({ blockId: 'real1' }));
+	});
+
+	it('defers the visual swap while an IME composition is active', () => {
+		g.keyboard.isComposition = true;
+
+		virtualBlock.activate(ROOT_ID, false);
+		virtualBlock.setText(ROOT_ID, 'か', [], true);
+		completeCreate('real1');
+
+		// Created but still rendered by the placeholder slot: Children must skip it
+		expect(virtualBlock.realId).toBe('real1');
+		expect(virtualBlock.isSwapped).toBe(false);
+		expect(virtualBlock.isActive).toBe(true);
+		expect(virtualBlock.getHoldId(ROOT_ID)).toBe('real1');
+		expect(compositionListeners.length).toBe(1);
+
+		g.keyboard.isComposition = false;
+		compositionListeners[0]();
+
+		expect(virtualBlock.isSwapped).toBe(true);
+		expect(virtualBlock.getHoldId(ROOT_ID)).toBe('');
+	});
+
+	it('a failed create keeps the placeholder alive and retries on the next write', () => {
+		virtualBlock.activate(ROOT_ID, false);
+		virtualBlock.setText(ROOT_ID, 'h', [], true);
+		completeCreate('', 1);
+
+		expect(virtualBlock.realId).toBe('');
+		expect(virtualBlock.isActive).toBe(true);
+
+		virtualBlock.setText(ROOT_ID, 'he', [], true);
+
+		expect(createCalls.length).toBe(2);
+		expect(createCalls[1].param.content.text).toBe('he');
+	});
+
+	it('re-activation while a create is in flight persists the orphaned text', () => {
+		virtualBlock.activate(ROOT_ID, false);
+		virtualBlock.setText(ROOT_ID, 'h', [], true);
+		virtualBlock.setText(ROOT_ID, 'hel', [], true);
+
+		virtualBlock.activate(ROOT_ID, false);
+		completeCreate('real1');
+
+		// The stale create must not attach to the new placeholder…
+		expect(virtualBlock.realId).toBe('');
+		// …but the text typed after the create was sent is not lost
+		expect(g.U.Data.blockSetText).toHaveBeenCalledWith(ROOT_ID, 'real1', 'hel', [], true);
+	});
+
+	it('stale focus calls against the virtual id resolve to the real block', () => {
+		virtualBlock.activate(ROOT_ID, false);
+		virtualBlock.setText(ROOT_ID, 'h', [], true);
+		completeCreate('real1');
+
+		g.C.BlockSetCarriage.mockClear();
+		focus.set(VIRTUAL_ID, { from: 1, to: 1 });
+
+		expect(focus.state.focused).toBe('real1');
+		expect(g.C.BlockSetCarriage).toHaveBeenCalledWith(ROOT_ID, 'real1', { from: 1, to: 1 });
+	});
+
+	it('deactivation fully resets the placeholder state', () => {
+		virtualBlock.activate(ROOT_ID, false);
+		virtualBlock.setText(ROOT_ID, 'h', [], true);
+		completeCreate('real1');
+
+		virtualBlock.deactivate();
+
+		expect(virtualBlock.isActive).toBe(false);
+		expect(virtualBlock.realId).toBe('');
+		expect(virtualBlock.resolve(VIRTUAL_ID)).toBe(VIRTUAL_ID);
+		expect(virtualBlock.getBlock()).toBe(null);
+	});
+
+});
+
+describe('virtualBlock: empty-block identity fork (BlockReplace)', () => {
+
+	it('only empty, childless, non-system text blocks outside tables are eligible', () => {
+		const empty = makeBlock('f-empty');
+		const filled = makeBlock('f-filled', { content: { text: 'hi' } });
+		const title = makeBlock('f-title', { content: { style: I.TextStyle.Title } });
+		const description = makeBlock('f-desc', { content: { style: I.TextStyle.Description } });
+		const parent = makeBlock('f-parent', { content: { style: I.TextStyle.Toggle } });
+		const cell = makeBlock('f-cell');
+
+		storeChildren.set('f-parent', [ 'f-child' ]);
+		insideTable.add('f-cell');
+
+		expect(virtualBlock.shouldFork(ROOT_ID, empty, 'h')).toBe(true);
+		expect(virtualBlock.shouldFork(ROOT_ID, empty, '')).toBe(false);
+		expect(virtualBlock.shouldFork(ROOT_ID, filled, 'h')).toBe(false);
+		expect(virtualBlock.shouldFork(ROOT_ID, title, 'h')).toBe(false);
+		expect(virtualBlock.shouldFork(ROOT_ID, description, 'h')).toBe(false);
+		expect(virtualBlock.shouldFork(ROOT_ID, parent, 'h')).toBe(false);
+		expect(virtualBlock.shouldFork(ROOT_ID, cell, 'h')).toBe(false);
+	});
+
+	it('first content sends exactly one BlockReplace carrying the content and the prior properties', () => {
+		const block = makeBlock('f-old1', {
+			bgColor: 'red',
+			content: { style: I.TextStyle.Checkbox, checked: true, color: 'blue' },
+		});
+
+		focus.state = { focused: 'f-old1', range: { from: 0, to: 0 } };
+		virtualBlock.fork(ROOT_ID, block, 'h', [], undefined);
+
+		expect(replaceCalls.length).toBe(1);
+		expect(replaceCalls[0].rootId).toBe(ROOT_ID);
+		expect(replaceCalls[0].blockId).toBe('f-old1');
+		expect(replaceCalls[0].param.content.text).toBe('h');
+		expect(replaceCalls[0].param.content.style).toBe(I.TextStyle.Checkbox);
+		expect(replaceCalls[0].param.content.checked).toBe(true);
+		expect(replaceCalls[0].param.content.color).toBe('blue');
+		expect(replaceCalls[0].param.bgColor).toBe('red');
+
+		completeReplace('f-new1');
+
+		// No BlockTextSetText was needed — the replace carried the content
+		expect(g.U.Data.blockSetText).not.toHaveBeenCalled();
+		expect(virtualBlock.isForkPending('f-old1')).toBe(false);
+		expect(virtualBlock.resolve('f-old1')).toBe('f-new1');
+		expect(focus.state.focused).toBe('f-new1');
+		expect(focus.state.range).toEqual({ from: 1, to: 1 });
+	});
+
+	it('writes and callbacks issued while the fork is in flight land on the new id', () => {
+		const cb1 = vi.fn();
+		const cb2 = vi.fn();
+		const block = makeBlock('f-old2');
+
+		virtualBlock.fork(ROOT_ID, block, 'h', [], cb1);
+
+		expect(virtualBlock.isForkPending('f-old2')).toBe(true);
+
+		virtualBlock.forkSetText('f-old2', 'he', [], cb2);
+		completeReplace('f-new2');
+
+		expect(replaceCalls.length).toBe(1);
+		expect(g.U.Data.blockSetText).toHaveBeenCalledWith(ROOT_ID, 'f-new2', 'he', [], true);
+		expect(cb1).toHaveBeenCalledWith(expect.objectContaining({ blockId: 'f-new2' }));
+		expect(cb2).toHaveBeenCalledWith(expect.objectContaining({ blockId: 'f-new2' }));
+	});
+
+	it('undo restores the old identity: the fork mapping stops resolving', () => {
+		const block = makeBlock('f-old3');
+
+		virtualBlock.fork(ROOT_ID, block, 'h', [], undefined);
+		completeReplace('f-new3');
+
+		expect(virtualBlock.resolve('f-old3')).toBe('f-new3');
+
+		// Undo: old block comes back, new one is removed
+		storeBlocks.delete('f-new3');
+		makeBlock('f-old3');
+
+		expect(virtualBlock.resolve('f-old3')).toBe('f-old3');
+	});
+
+	it('a rejected replace falls back to a plain write and disables forking for the block', () => {
+		const cb = vi.fn();
+		const block = makeBlock('f-old4');
+
+		virtualBlock.fork(ROOT_ID, block, 'h', [], cb);
+		completeReplace('', 1);
+
+		expect(g.U.Data.blockSetText).toHaveBeenCalledWith(ROOT_ID, 'f-old4', 'h', [], true, expect.any(Function));
+		expect(cb).toHaveBeenCalled();
+		expect(virtualBlock.isForkPending('f-old4')).toBe(false);
+		expect(virtualBlock.shouldFork(ROOT_ID, block, 'x')).toBe(false);
+	});
+
+	it('holds the fork during IME composition and sends the final text after it ends', () => {
+		g.keyboard.isComposition = true;
+
+		const block = makeBlock('f-old5');
+
+		virtualBlock.fork(ROOT_ID, block, 'か', [], undefined);
+
+		expect(replaceCalls.length).toBe(0);
+		expect(compositionListeners.length).toBe(1);
+
+		virtualBlock.forkSetText('f-old5', 'かき', []);
+
+		g.keyboard.isComposition = false;
+		compositionListeners[0]();
+
+		expect(replaceCalls.length).toBe(1);
+		expect(replaceCalls[0].param.content.text).toBe('かき');
+	});
+
+	it('a fork emptied while held sends nothing', () => {
+		g.keyboard.isComposition = true;
+
+		const cb = vi.fn();
+		const block = makeBlock('f-old6');
+
+		virtualBlock.fork(ROOT_ID, block, 'か', [], cb);
+		virtualBlock.forkSetText('f-old6', '', []);
+
+		g.keyboard.isComposition = false;
+		compositionListeners[0]();
+
+		expect(replaceCalls.length).toBe(0);
+		expect(virtualBlock.isForkPending('f-old6')).toBe(false);
+		expect(cb).toHaveBeenCalled();
+	});
+
+});

--- a/src/ts/lib/virtualBlock.ts
+++ b/src/ts/lib/virtualBlock.ts
@@ -1,0 +1,654 @@
+import { observable, action, makeObservable, runInAction } from 'mobx';
+import { flushSync } from 'react-dom';
+import { getRange } from 'selection-ranges';
+import * as I from 'Interface';
+import * as M from 'Model';
+import { focus } from './focus';
+
+interface Fork {
+	rootId: string;
+	newId: string;
+	sentText: string;
+	sentMarks: I.Mark[];
+	pending: { text: string; marks: I.Mark[]; };
+	cbQueue: ((message: any) => void)[];
+};
+
+const FORK_HISTORY_LIMIT = 64;
+
+/**
+ * VirtualBlock owns block-identity indirection for the two flows that protect
+ * concurrent editing from the whole-value last-writer-wins text CRDT:
+ *
+ * 1. The trailing "click to type" placeholder. Clicking the empty area below
+ *    the document content must not create a block: an empty block synced to
+ *    peers becomes a shared caret target, and two clients typing into the same
+ *    block id silently destroy each other's text. The editor renders a purely
+ *    presentational text block with a constant virtual id that exists only in
+ *    this client's React tree — it is never added to the block store and never
+ *    synced. The first real input materializes it: a single BlockCreate carries
+ *    the initial content, and further writes are redirected to the returned id.
+ *
+ * 2. Identity forking for existing empty blocks (BlockReplace). Any existing
+ *    empty text block (a blank line from Enter, a legacy trailing block, the
+ *    first block of a fresh note) is the same shared register: two users
+ *    filling it concurrently merge to one text. The first content put into an
+ *    empty block therefore never calls BlockTextSetText — it calls BlockReplace
+ *    with a block model carrying the content plus everything the empty block
+ *    already had (style, checked, color, background, align, fields). Replace is
+ *    remove(old) + create(new) in one atomic change, so two users filling the
+ *    same empty block produce two independent creates (both survive) and two
+ *    idempotent removes: two blocks, both texts intact.
+ *
+ * Both flows share the same mechanics: writes are intercepted at
+ * U.Data.blockSetText, callbacks issued against the old id while the request is
+ * in flight are queued and run after the swap, resolve() maps stale ids to the
+ * live one, and the visual swap happens in a single synchronous task
+ * (flushSync + focus.apply) so no keystrokes are lost. Swaps are deferred while
+ * an IME composition is active to avoid destroying the composition DOM.
+ */
+class VirtualBlock {
+
+	rootId = '';
+	isPopup = false;
+	isActive = false;
+	realId = '';
+	isSwapped = false;
+	isCreating = false;
+
+	private generation = 0;
+	private block: I.Block = null;
+	private sentText = '';
+	private sentMarks: I.Mark[] = [];
+	private pending: { text: string; marks: I.Mark[]; } = null;
+	private cbQueue: ((message: any) => void)[] = [];
+	private orphans: Map<number, { text: string; marks: I.Mark[]; }> = new Map();
+	private compositionHandler: (() => void) = null;
+
+	private forks: Map<string, Fork> = new Map();
+	private noFork: Set<string> = new Set();
+
+	constructor () {
+		makeObservable(this, {
+			isActive: observable,
+			realId: observable,
+			isSwapped: observable,
+			activate: action,
+			deactivate: action,
+		});
+	};
+
+	get id (): string {
+		return J.Constant.blockId.virtualLast;
+	};
+
+	isVirtualId (id: string): boolean {
+		return id == this.id;
+	};
+
+	/**
+	 * Maps stale ids to the live block id: the virtual placeholder id to its
+	 * materialized block, and forked ids to their replacements. Fork mappings
+	 * are only followed while the old block is actually gone — undo restores
+	 * the old identity and must win.
+	 */
+	resolve (id: string): string {
+		if (this.isVirtualId(id) && this.realId) {
+			id = this.realId;
+		};
+
+		let guard = 0;
+		while (guard++ < 10) {
+			const fork = this.forks.get(id);
+
+			if (!fork || !fork.newId) {
+				break;
+			};
+			if (S.Block.getLeaf(fork.rootId, id) || !S.Block.getLeaf(fork.rootId, fork.newId)) {
+				break;
+			};
+
+			id = fork.newId;
+		};
+
+		return id;
+	};
+
+	/**
+	 * Id of the materialized block that is still represented by the placeholder
+	 * (creation finished but the swap is deferred, e.g. during IME composition).
+	 * Children must skip it to avoid rendering the block twice.
+	 */
+	getHoldId (rootId: string): string {
+		return ((this.rootId == rootId) && this.realId && !this.isSwapped) ? this.realId : '';
+	};
+
+	isRendered (rootId: string, isPopup: boolean): boolean {
+		return this.isActive && (this.rootId == rootId) && (this.isPopup == isPopup);
+	};
+
+	/** True while the placeholder is focused and no real block exists yet */
+	isVirginFocused (rootId: string): boolean {
+		return this.isActive && (this.rootId == rootId) && !this.realId && (focus.state.focused == this.id);
+	};
+
+	getBlock (): I.Block {
+		return this.block;
+	};
+
+	activate (rootId: string, isPopup: boolean) {
+		// A create may still be in flight from the previous activation — stash its
+		// latest unsent text so the orphaned callback can persist it (see materialize)
+		if (this.isCreating && this.pending) {
+			this.orphans.set(this.generation, this.pending);
+		};
+
+		this.generation++;
+		this.rootId = rootId;
+		this.isPopup = isPopup;
+		this.isActive = true;
+		this.realId = '';
+		this.isSwapped = false;
+		this.isCreating = false;
+		this.sentText = '';
+		this.sentMarks = [];
+		this.pending = null;
+		this.cbQueue = [];
+		this.unbindComposition();
+
+		this.block = new M.Block({
+			id: this.id,
+			type: I.BlockType.Text,
+			childrenIds: [],
+			fields: {},
+			content: { style: I.TextStyle.Paragraph, text: '', marks: [] },
+		});
+	};
+
+	deactivate () {
+		if (this.isCreating && this.pending) {
+			this.orphans.set(this.generation, this.pending);
+		};
+
+		this.generation++;
+		this.rootId = '';
+		this.isActive = false;
+		this.realId = '';
+		this.isSwapped = false;
+		this.isCreating = false;
+		this.sentText = '';
+		this.sentMarks = [];
+		this.pending = null;
+		this.cbQueue = [];
+		this.block = null;
+		this.unbindComposition();
+	};
+
+	/**
+	 * Intercepted text write for the virtual id (called from U.Data.blockSetText).
+	 * Empty text on a virgin placeholder is a no-op — nothing is ever created
+	 * from focus/blur alone.
+	 */
+	setText (rootId: string, text: string, marks: I.Mark[], update: boolean, callBack?: (message: any) => void) {
+		marks = marks || [];
+
+		if (this.realId) {
+			// Skip echoes of content the middleware already has (e.g. the debounced
+			// keyup save re-sending exactly what BlockCreate carried)
+			if ((text === this.sentText) && U.Common.compareJSON(marks, this.sentMarks)) {
+				callBack?.({ blockId: this.realId, error: { code: 0 } });
+				return;
+			};
+
+			this.sentText = text;
+			this.sentMarks = marks;
+
+			U.Data.blockSetText(rootId, this.realId, text, marks, update, callBack);
+			return;
+		};
+
+		if (this.isCreating) {
+			this.pending = { text, marks };
+			if (callBack) {
+				this.cbQueue.push(callBack);
+			};
+			return;
+		};
+
+		if (!text) {
+			callBack?.({ error: { code: 0 } });
+			return;
+		};
+
+		if (callBack) {
+			this.cbQueue.push(callBack);
+		};
+		this.materialize(text, marks);
+	};
+
+	/**
+	 * Materialization trigger for input that doesn't go through blockSetText
+	 * (first keystroke, IME update, text drop, spellcheck replace). Reads the
+	 * current DOM content of the placeholder editable.
+	 */
+	checkMaterialize () {
+		if (!this.isActive || this.realId || this.isCreating) {
+			return;
+		};
+
+		const data = this.readDom(this.id);
+		if (!data || !data.text) {
+			return;
+		};
+
+		this.materialize(data.text, data.marks);
+	};
+
+	private materialize (text: string, marks: I.Mark[]) {
+		const rootId = this.rootId;
+		const generation = this.generation;
+		const param = {
+			type: I.BlockType.Text,
+			content: { style: I.TextStyle.Paragraph, text, marks },
+		};
+
+		this.isCreating = true;
+		this.sentText = text;
+		this.sentMarks = marks;
+
+		C.BlockCreate(rootId, '', I.BlockPosition.Bottom, param, (message: any) => {
+			// The placeholder was re-activated or closed while the request was in
+			// flight — the block still lands in the document; persist any text that
+			// was typed after the request was sent, then stand down
+			if (generation != this.generation) {
+				const orphan = this.orphans.get(generation);
+
+				this.orphans.delete(generation);
+
+				if (orphan && !message.error.code && message.blockId) {
+					U.Data.blockSetText(rootId, message.blockId, orphan.text, orphan.marks, true);
+				};
+				return;
+			};
+
+			this.isCreating = false;
+
+			if (message.error.code || !message.blockId) {
+				// Keep the placeholder alive — the DOM still holds the user's text
+				// and the next input retries the create
+				this.drainQueue(message);
+				return;
+			};
+
+			runInAction(() => {
+				this.realId = message.blockId;
+			});
+
+			analytics.event('CreateBlock', {
+				middleTime: message.middleTime,
+				type: I.BlockType.Text,
+				style: I.TextStyle.Paragraph,
+				params: {},
+			});
+
+			if (keyboard.isComposition) {
+				this.bindComposition();
+			} else {
+				this.finish();
+			};
+		});
+	};
+
+	/**
+	 * Swaps the placeholder for the real block: syncs any text typed while the
+	 * create was in flight, unmounts the virtual editable and applies focus to
+	 * the real one in the same task so no keystrokes are lost.
+	 */
+	private finish () {
+		const rootId = this.rootId;
+		const realId = this.realId;
+
+		if (!realId || this.isSwapped) {
+			return;
+		};
+
+		const dom = this.readDom(this.id);
+		const latest = dom || this.pending;
+
+		this.pending = null;
+
+		if (latest && ((latest.text !== this.sentText) || !U.Common.compareJSON(latest.marks, this.sentMarks))) {
+			this.sentText = latest.text;
+			this.sentMarks = latest.marks;
+
+			U.Data.blockSetText(rootId, realId, latest.text, latest.marks, true);
+		};
+
+		const hadFocus = [ this.id, realId ].includes(focus.state.focused);
+		const range = this.readRange(this.id) || { from: this.sentText.length, to: this.sentText.length };
+
+		flushSync(() => {
+			runInAction(() => {
+				this.isActive = false;
+				this.isSwapped = true;
+			});
+		});
+
+		if (hadFocus) {
+			focus.set(realId, range);
+			focus.apply();
+		};
+
+		this.drainQueue({ blockId: realId, error: { code: 0 } });
+	};
+
+	private drainQueue (message: any) {
+		const queue = this.cbQueue;
+
+		this.cbQueue = [];
+		this.runQueue(queue, message);
+	};
+
+	// ---------------------------------------------------------------------------
+	// Identity forking for existing empty blocks (BlockReplace)
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Whether the first content put into this block must fork its identity via
+	 * BlockReplace instead of BlockTextSetText.
+	 */
+	shouldFork (rootId: string, block: I.Block, text: string): boolean {
+		if (!text || !block || !block.isText()) {
+			return false;
+		};
+
+		// Title/description are detail-backed and have fixed ids — the middleware
+		// rejects replacing them
+		if (block.isTextTitle() || block.isTextDescription()) {
+			return false;
+		};
+
+		// Only blocks whose synced text is currently empty are shared registers
+		if (block.getLength()) {
+			return false;
+		};
+
+		// A previous BlockReplace was rejected for this block — degrade to SetText
+		if (this.noFork.has(block.id)) {
+			return false;
+		};
+
+		// Replacing a block with children would orphan them
+		if (S.Block.getChildrenIds(rootId, block.id).length) {
+			return false;
+		};
+
+		// Table cells have structurally derived ids and cannot change identity
+		if (S.Block.checkIsInsideTable(rootId, block.id)) {
+			return false;
+		};
+
+		return true;
+	};
+
+	/** True while a fork for this id is held (composition) or in flight */
+	isForkPending (id: string): boolean {
+		const fork = this.forks.get(id);
+		return !!fork && !fork.newId;
+	};
+
+	/** Latest-wins buffering of writes that arrive while the fork is pending */
+	forkSetText (id: string, text: string, marks: I.Mark[], callBack?: (message: any) => void) {
+		const fork = this.forks.get(id);
+		if (!fork) {
+			return;
+		};
+
+		fork.pending = { text, marks: marks || [] };
+
+		if (callBack) {
+			fork.cbQueue.push(callBack);
+		};
+	};
+
+	/**
+	 * Forks the identity of an empty block: one BlockReplace carrying the new
+	 * content plus everything the empty block already had. Held while an IME
+	 * composition is active — replacing mid-composition would destroy the
+	 * composition DOM.
+	 */
+	fork (rootId: string, block: I.Block, text: string, marks: I.Mark[], callBack?: (message: any) => void) {
+		const oldId = block.id;
+		const fork: Fork = {
+			rootId,
+			newId: '',
+			sentText: text,
+			sentMarks: marks || [],
+			pending: null,
+			cbQueue: callBack ? [ callBack ] : [],
+		};
+
+		this.forks.set(oldId, fork);
+
+		if (keyboard.isComposition) {
+			fork.pending = { text, marks: marks || [] };
+			this.bindForkComposition(oldId);
+			return;
+		};
+
+		this.sendFork(oldId);
+	};
+
+	private sendFork (oldId: string) {
+		const fork = this.forks.get(oldId);
+		if (!fork || fork.newId) {
+			return;
+		};
+
+		const block = S.Block.getLeaf(fork.rootId, oldId);
+
+		if (fork.pending) {
+			fork.sentText = fork.pending.text;
+			fork.sentMarks = fork.pending.marks;
+			fork.pending = null;
+		};
+
+		// The block disappeared meanwhile, or was emptied again while the fork was
+		// held — nothing to fork
+		if (!block || !fork.sentText) {
+			this.forks.delete(oldId);
+			this.runQueue(fork.cbQueue, { error: { code: 0 } });
+			return;
+		};
+
+		const param = {
+			type: I.BlockType.Text,
+			bgColor: block.bgColor,
+			hAlign: block.hAlign,
+			vAlign: block.vAlign,
+			fields: block.fields,
+			content: {
+				style: block.content.style,
+				checked: block.content.checked,
+				color: block.content.color,
+				iconEmoji: block.content.iconEmoji,
+				iconImage: block.content.iconImage,
+				text: fork.sentText,
+				marks: fork.sentMarks,
+			},
+		};
+
+		C.BlockReplace(fork.rootId, oldId, param, (message: any) => {
+			if (this.forks.get(oldId) !== fork) {
+				return;
+			};
+
+			if (message.error.code || !message.blockId) {
+				// Fall back to the plain write so the user's text still persists;
+				// noFork prevents an immediate re-attempt loop for this block
+				this.noFork.add(oldId);
+				this.forks.delete(oldId);
+
+				const latest = fork.pending || { text: fork.sentText, marks: fork.sentMarks };
+
+				U.Data.blockSetText(fork.rootId, oldId, latest.text, latest.marks, true, (msg: any) => {
+					this.runQueue(fork.cbQueue, msg);
+				});
+				return;
+			};
+
+			fork.newId = message.blockId;
+			this.finishFork(oldId, fork);
+		});
+	};
+
+	/**
+	 * The response events already removed the old block and added the new one
+	 * with the sent content. Sync anything typed while the request was in
+	 * flight, then commit the re-render and move focus in the same task so no
+	 * keystrokes land between the two editables.
+	 */
+	private finishFork (oldId: string, fork: Fork) {
+		const dom = this.readDom(oldId);
+		const latest = dom || fork.pending;
+
+		fork.pending = null;
+
+		if (latest && ((latest.text !== fork.sentText) || !U.Common.compareJSON(latest.marks, fork.sentMarks))) {
+			fork.sentText = latest.text;
+			fork.sentMarks = latest.marks;
+
+			U.Data.blockSetText(fork.rootId, fork.newId, latest.text, latest.marks, true);
+		};
+
+		const hadFocus = focus.state.focused == oldId;
+		const range = this.readRange(oldId) || { from: fork.sentText.length, to: fork.sentText.length };
+
+		if (hadFocus) {
+			focus.set(fork.newId, range);
+		};
+
+		flushSync(() => {});
+
+		if (hadFocus) {
+			focus.apply();
+		};
+
+		const queue = fork.cbQueue;
+
+		fork.cbQueue = [];
+		this.runQueue(queue, { blockId: fork.newId, error: { code: 0 } });
+		this.pruneForks();
+	};
+
+	private bindForkComposition (oldId: string) {
+		const handler = () => {
+			window.removeEventListener('compositionend', handler);
+
+			// Let the block's own compositionend handlers settle the DOM first
+			window.setTimeout(() => this.sendFork(oldId), 0);
+		};
+
+		window.addEventListener('compositionend', handler);
+	};
+
+	/** Completed fork mappings are kept for stale closures, but bounded */
+	private pruneForks () {
+		if (this.forks.size <= FORK_HISTORY_LIMIT) {
+			return;
+		};
+
+		for (const [ id, fork ] of this.forks) {
+			if (fork.newId) {
+				this.forks.delete(id);
+			};
+			if (this.forks.size <= FORK_HISTORY_LIMIT) {
+				break;
+			};
+		};
+	};
+
+	// ---------------------------------------------------------------------------
+	// Shared helpers
+	// ---------------------------------------------------------------------------
+
+	private runQueue (queue: ((message: any) => void)[], message: any) {
+		for (const cb of queue) {
+			try {
+				cb(message);
+			} catch (e) {
+				console.error('[VirtualBlock] queued callback error', e);
+			};
+		};
+	};
+
+	private getNode (id: string): HTMLElement {
+		return U.Dom.select(`.focusable.c${U.Common.esc(id)}`);
+	};
+
+	private readDom (id: string): { text: string; marks: I.Mark[]; } {
+		const node = this.getNode(id);
+		if (!node) {
+			return null;
+		};
+
+		const parsed = Mark.fromHtml(node.innerHTML || '', []);
+
+		let text = String(parsed.text || '');
+		if (text == '\n') {
+			text = '';
+		};
+
+		return { text, marks: parsed.marks || [] };
+	};
+
+	private readRange (id: string): I.TextRange {
+		const node = this.getNode(id);
+		if (!node) {
+			return null;
+		};
+
+		const range = getRange(node);
+		if (!range) {
+			return null;
+		};
+
+		if (Mark.hasZws(node)) {
+			return {
+				from: Mark.domToModel(range.start, node),
+				to: Mark.domToModel(range.end, node),
+			};
+		};
+
+		return { from: range.start, to: range.end };
+	};
+
+	private bindComposition () {
+		if (this.compositionHandler) {
+			return;
+		};
+
+		// Runs after the block's own compositionend handlers (window bubbles last),
+		// so the editable DOM is settled when the swap reads it
+		const handler = () => {
+			this.unbindComposition();
+
+			if (this.realId && !this.isSwapped) {
+				this.finish();
+			};
+		};
+
+		this.compositionHandler = handler;
+		window.addEventListener('compositionend', handler);
+	};
+
+	private unbindComposition () {
+		if (this.compositionHandler) {
+			window.removeEventListener('compositionend', this.compositionHandler);
+			this.compositionHandler = null;
+		};
+	};
+
+};
+
+export const virtualBlock = new VirtualBlock();

--- a/src/ts/store/block.ts
+++ b/src/ts/store/block.ts
@@ -40,6 +40,12 @@ class BlockStore {
 	public deferredNumberUpdates: Set<string> = new Set();
 	public deferredMarkupUpdates: Set<string> = new Set();
 
+	// Ids of blocks created by this session (BlockCreate/BlockSplit initiated
+	// locally). The trailing "click to type" flow only focus-reuses an empty
+	// last block from this set — converging into a foreign empty block loses
+	// text when two clients type into it concurrently (last-writer-wins)
+	public sessionCreatedIds: Set<string> = new Set();
+
 	constructor() {
 		makeObservable(this, {
 			profileId: observable,
@@ -132,6 +138,25 @@ class BlockStore {
 		});
 
 		this.blockMap.set(rootId, map);
+	};
+
+	/**
+	 * Marks a block id as created by this session.
+	 * @param {string} id - The block ID.
+	 */
+	addSessionCreated (id: string) {
+		if (id) {
+			this.sessionCreatedIds.add(id);
+		};
+	};
+
+	/**
+	 * Checks whether a block id was created by this session.
+	 * @param {string} id - The block ID.
+	 * @returns {boolean} Whether the block was created locally.
+	 */
+	isSessionCreated (id: string): boolean {
+		return this.sessionCreatedIds.has(id);
 	};
 
 	/**


### PR DESCRIPTION
Fixes [JS-9826](https://linear.app/anytype/issue/JS-9826/prevent-concurrent-text-loss-in-empty-blocks-virtual-last-block)

## Problem

Block text is whole-value last-writer-wins in the CRDT, keyed by block id. Any synced **empty** text block (the trailing block auto-created by "click below content", a blank line from Enter, the first block of a fresh note) is a shared register that multiple clients' carets converge on. When two users put text into the same empty block concurrently — very common after offline periods — one user's text is silently destroyed on merge. This is our most frequent data-loss conflict.

## Solution

All text writes funnel through `U.Data.blockSetText`, which is the single interception point; a new `Lib/virtualBlock` service owns the block-id indirection (stale-id resolution, in-flight write buffering, focus-preserving swaps).

### 1. Virtual trailing placeholder
Clicking the empty area below the document content no longer creates a block. A purely client-side placeholder is rendered instead — it looks and behaves exactly like an empty paragraph (real `BlockText` on a constant virtual id) but is never in the block store and produces **zero middleware calls**. The first real input materializes it with a single `BlockCreate` already carrying the text/marks. Focus-reuse of an existing trailing empty block only happens if it was created by this session (tracked via `BlockCreate`/`BlockSplit`/`BlockReplace` responses); a foreign empty last block gets the placeholder rendered below it and is never auto-deleted (delete wins over a concurrent write).

### 2. Identity fork when filling any existing empty text block
The first content put into an existing empty text block never calls `BlockTextSetText`. It calls `BlockReplace` (atomic remove+create, returns a fresh id) with a model carrying the resulting text/marks **plus everything the empty block already had**: style, checked, color, background, align, fields. Two clients filling the same empty block produce two independent creates (both survive the structural merge) and two idempotent removes — two blocks, both texts intact. Excluded: blocks with children (would orphan them), title/description, table cells (structurally derived ids); paste keeps the existing flow. Undo restores the old identity cleanly (fork mappings are only followed while the old block is actually gone), and a rejected replace falls back to a plain write so text is never lost.

### 3. No text writes on mere cursor placement
Blur flushes and shortcut save-keys used to send `BlockTextSetText` with the block's unchanged text — for empty and filled blocks alike — and each of those is an LWW write that can stomp a concurrent peer edit on merge. Writes whose text and marks are identical to the store content are now skipped centrally (callbacks still run, so chained flows are unaffected).

## Mechanics shared by 1 & 2
- Writes/callbacks issued against the old id while the create/replace is in flight are buffered (latest-wins) and land on the new id; slash/mention/markdown triggers resolve stale ids at run time.
- The visual swap reads the live editable DOM (text + caret), syncs any delta, then commits the re-render and applies focus in one synchronous task (`flushSync`) — no lost keystrokes, caret survives.
- Swaps/forks are deferred while an IME composition is active so the composition DOM is never rebuilt.

## Acceptance
- Clicking the empty area below content → zero middleware calls.
- Typing "h" into the trailing placeholder → exactly one `BlockCreate` carrying "h".
- Typing "h" into an existing empty block → exactly one `BlockReplace` carrying "h" + prior style; caret survives the id swap; no `BlockTextSetText` for the old id.
- Clicking into/out of blocks without editing → no `BlockTextSetText` calls (only `BlockSetCarriage`).
- Two clients typing into the same empty block while offline → two blocks after sync, both texts survive.

## Testing
- 18 unit tests for the service state machine (`src/ts/lib/virtualBlock.test.ts`): zero-calls-on-click, single content-carrying create/replace, property preservation, in-flight buffering, IME deferral, undo identity restore, error fallback, session tracking.
- `bun run typecheck`, `bun run lint`, dev build — clean; full vitest suite at the pre-existing develop baseline.
- Manual smoke pass still recommended: type/IME/markdown/slash/mention flows at the doc bottom and into empty blocks, plus a two-client offline merge.