### PR TITLE
fix(chat): race conditions in event handling (JS-9827)

### DIFF
--- a/src/json/text.json
+++ b/src/json/text.json
@@ -2273,6 +2273,8 @@
 	"toastFileLimitReached": "Your local storage exceeds syncing limit. Locally stored files won't be synced",
 
 	"toastChatAttachmentsLimitReached": "You can upload only %s %s at a time",
+	"toastChatUploadFailed": "Some attachments failed to upload. The message was not sent",
+	"toastChatSendFailed": "The message could not be sent. Please try again",
 	"toastWidget": "Widget <b>%s</b> has been added",
 	"toastJoinSpace": "You have joined <b>%s</b>",
 

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -56,6 +56,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	const [ pinnedIndex, setPinnedIndex ] = useState(-1);
 	const scrollRafRef = useRef(0);
 	const chainRafRef = useRef(0);
+	const messageAddRafRef = useRef(0);
 	const visibleIds = useRef<Set<string>>(new Set());
 	const viewportObserver = useRef<IntersectionObserver | null>(null);
 	const formResizeObserver = useRef<ResizeObserver | null>(null);
@@ -621,6 +622,11 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		isLoadingNext.current = false;
 		loadEpoch.current++;
 
+		// Guards the two-fetch chain: a second jump (or any window reset) while these are in
+		// flight bumps loadEpoch, and the stale pair must not rebuild the window afterwards —
+		// the LAST response would win regardless of which jump the user actually made.
+		const epoch = loadEpoch.current;
+
 		let list = [];
 		let beforeOk = false;
 		let afterOk = false;
@@ -628,6 +634,10 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		let afterLength = 0;
 
 		C.ChatGetMessages(chatId, orderId, '', limit, true, (message: any) => {
+			if (loadEpoch.current != epoch) {
+				return;
+			};
+
 			if (!message.error.code) {
 				beforeOk = true;
 				beforeLength = message.messages.length;
@@ -637,6 +647,10 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			};
 
 			C.ChatGetMessages(chatId, '', orderId, limit, false, (message: any) => {
+				if (loadEpoch.current != epoch) {
+					return;
+				};
+
 				if (!message.error.code) {
 					afterOk = true;
 					afterLength = message.messages.length;
@@ -646,6 +660,10 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 				};
 
 				loadDepsAndReplies(list, () => {
+					if (loadEpoch.current != epoch) {
+						return;
+					};
+
 					// Merge so status events seen during the fetch survive; no trailing keep —
 					// this is a jump into history, the window must stay contiguous around orderId.
 					S.Chat.setFromSnapshot(subId, list, false);
@@ -810,11 +828,22 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	const onMessageAdd = (message: I.ChatMessage, subIds: string[]) => {
 		subIds = subIds || [];
 
-		const subId = getSubId();
-
-		if (subIds.includes(subId)) {
-			loadDepsAndReplies(S.Chat.getList(subId).concat(message), () => scrollToBottomCheck());
+		if (!subIds.includes(getSubId())) {
+			return;
 		};
+
+		// Coalesce to one pass per frame: catch-up bursts fire one event per message, and an
+		// uncoalesced pass re-scans the whole window (O(events × window)) and can re-subscribe
+		// deps per event. The store already holds every added message when the frame runs,
+		// so a single pass over the current list covers the burst.
+		if (messageAddRafRef.current) {
+			return;
+		};
+
+		messageAddRafRef.current = raf(() => {
+			messageAddRafRef.current = 0;
+			loadDepsAndReplies(S.Chat.getList(getSubId()), () => scrollToBottomCheck());
+		});
 	};
 
 	const onMessageDelete = (id: string, subIds: string[]) => {
@@ -1898,6 +1927,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			window.clearTimeout(timeoutResize.current);
 			raf.cancel(scrollRafRef.current);
 			raf.cancel(chainRafRef.current);
+			raf.cancel(messageAddRafRef.current);
 			messageRefs.current = {};
 			refSetters.current.clear();
 		};
@@ -1964,10 +1994,13 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		};
 	}, [ space, chatId ]);
 
+	// analyticsChatId is deliberately NOT a dependency: it resolves asynchronously after a
+	// cold open and nothing in rebind()/init() reads it (analytics events capture it at
+	// call time) — keying on it re-ran a full second init per cold open.
 	useEffect(() => {
 		rebind();
 		init();
-	}, [ rootId, space, chatId, analyticsChatId ]);
+	}, [ rootId, space, chatId ]);
 
 	useLayoutEffect(() => {
 		scrollToBottomCheck();

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -44,6 +44,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	const timeoutResize = useRef(0);
 	const top = useRef(0);
 	const scrolledItems = useRef(new Set());
+	const readTarget = useRef<{ chatId: string; subId: string } | null>(null);
 	const isBottom = useRef(false);
 	const isAutoLoadDisabled = useRef(false);
 	const lastSubIdRef = useRef('');
@@ -68,6 +69,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	const isLoadingPrev = useRef(false);
 	const isLoadingNext = useRef(false);
 	const loadEpoch = useRef(0);
+	const initSeq = useRef(0);
 	const object = S.Detail.get(rootId, rootId, []);
 
 	const getChatId = () => {
@@ -137,11 +139,18 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	const scrollHandlerRef = useRef<((e: Event) => void) | null>(null);
 	const messageAddHandlerRef = useRef<((e: Event) => void) | null>(null);
 	const messageUpdateHandlerRef = useRef<((e: Event) => void) | null>(null);
+	const messageDeleteHandlerRef = useRef<((e: Event) => void) | null>(null);
 	const reactionUpdateHandlerRef = useRef<((e: Event) => void) | null>(null);
 	const pinnedStatusUpdateHandlerRef = useRef<((e: Event) => void) | null>(null);
 	const focusHandlerRef = useRef<((e: Event) => void) | null>(null);
 
 	const unbind = () => {
+		// Flush pending read receipts before teardown (chat switch / unmount) — the debounced
+		// range request is the only server-side read, so it must fire before the items detach.
+		// onReadStop targets readTarget, so the flush hits the chat the items belong to.
+		window.clearTimeout(timeoutScrollStop.current);
+		onReadStop();
+
 		if (messageAddHandlerRef.current) {
 			U.Dom.removeEvent(window, 'messageAdd', messageAddHandlerRef.current);
 			messageAddHandlerRef.current = null;
@@ -149,6 +158,10 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		if (messageUpdateHandlerRef.current) {
 			U.Dom.removeEvent(window, 'messageUpdate', messageUpdateHandlerRef.current);
 			messageUpdateHandlerRef.current = null;
+		};
+		if (messageDeleteHandlerRef.current) {
+			U.Dom.removeEvent(window, 'messageDelete', messageDeleteHandlerRef.current);
+			messageDeleteHandlerRef.current = null;
 		};
 		if (reactionUpdateHandlerRef.current) {
 			U.Dom.removeEvent(window, 'reactionUpdate', reactionUpdateHandlerRef.current);
@@ -191,6 +204,10 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			const detail = (e as CustomEvent).detail || {};
 			onMessageAdd(detail.message, detail.subIds);
 		};
+		messageDeleteHandlerRef.current = (e: Event) => {
+			const detail = (e as CustomEvent).detail || {};
+			onMessageDelete(detail.id, detail.subIds);
+		};
 		reactionUpdateHandlerRef.current = () => scrollToBottomCheck();
 		pinnedStatusUpdateHandlerRef.current = (e: Event) => {
 			const detail = (e as CustomEvent).detail || {};
@@ -222,6 +239,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		U.Dom.addEvents(window, [
 			['messageAdd', messageAddHandlerRef.current],
 			['messageUpdate', messageUpdateHandlerRef.current],
+			['messageDelete', messageDeleteHandlerRef.current],
 			['reactionUpdate', reactionUpdateHandlerRef.current],
 			['pinnedStatusUpdate', pinnedStatusUpdateHandlerRef.current],
 			['focus', focusHandlerRef.current],
@@ -318,6 +336,11 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		const chatId = getChatId();
 		const subId = getSubId();
 
+		// Store writes below target the captured subId (correct for that chat's cache even
+		// after a switch), but component state (setLoaded/setDummy) belongs to the chat the
+		// component currently shows — skip it when a newer init() superseded this flow.
+		const seq = initSeq.current;
+
 		if (!chatId) {
 			return;
 		};
@@ -334,7 +357,18 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 
 			const messages = message.messages || [];
 			if (!messages.length) {
-				setLoaded(true);
+				// An empty snapshot on a clear load must still drop a stale cached window
+				// (e.g. every message was deleted while the chat was closed).
+				if (clear && S.Chat.getList(subId).length) {
+					S.Chat.set(subId, []);
+					S.Chat.setAtChatStart(subId, true);
+					S.Chat.setAtChatEnd(subId, true);
+				};
+
+				if (seq == initSeq.current) {
+					setLoaded(true);
+				};
+
 				callBack?.();
 				return;
 			};
@@ -344,15 +378,19 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			// already-loaded messages' attachments (see loadMessages / onMessageAdd).
 			loadDepsAndReplies(clear ? messages : S.Chat.getList(subId).concat(messages), () => {
 				if (clear) {
-					S.Chat.set(subId, messages);
+					// Merge, not overwrite: events processed while deps were loading (live adds,
+					// read/sync status, deletes) are newer than this snapshot and must survive.
+					S.Chat.setFromSnapshot(subId, messages, true);
 					S.Chat.setAtChatEnd(subId, true);
 					S.Chat.setAtChatStart(subId, reachedEdge(messages.length, J.Constant.limit.chat.messages));
 				};
 
-				if (messages.length < J.Constant.limit.chat.messages) {
-					setLoaded(true);
-				} else {
-					setDummy(v => v + 1);
+				if (seq == initSeq.current) {
+					if (messages.length < J.Constant.limit.chat.messages) {
+						setLoaded(true);
+					} else {
+						setDummy(v => v + 1);
+					};
 				};
 
 				callBack?.();
@@ -380,7 +418,15 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			isLoadingNext.current = false;
 			loadEpoch.current++;
 
+			// A newer init() means this reset belongs to a superseded chat context: applying
+			// setIsBottom/scroll callbacks now would hijack the newly-shown chat's viewport.
+			const seq = initSeq.current;
+
 			subscribeMessages(clear, () => {
+				if (seq != initSeq.current) {
+					return;
+				};
+
 				setIsBottom(true);
 				callBack?.();
 			});
@@ -500,11 +546,12 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 
 						added = grew || evicted;
 
-						// Force a re-render so the new rows commit (either direction) — the
-						// component is not a MobX observer. At the MAX_MESSAGES cap a prepend/append
-						// inserts and evicts the same count, so the length is unchanged even though
-						// the content changed — repaint on `evicted` too, otherwise older history
-						// freezes at the cap. We deliberately do NOT touch scrollTop: native scroll
+						// Bump `dummy` so the [dummy] layout effect restores the captured top anchor
+						// after a prepend-at-top. (The component IS reactive — vite.auto-observer
+						// wraps default exports in observer() — but the anchor restore is keyed to
+						// `dummy`.) At the MAX_MESSAGES cap a prepend/append inserts and evicts the
+						// same count, so repaint on `evicted` too, otherwise older history freezes
+						// at the cap. We deliberately do NOT touch scrollTop: native scroll
 						// anchoring (overflow-anchor) keeps the viewport static when content is
 						// inserted above and preserves momentum; setting scrollTop ourselves would
 						// jump the view (~1 viewport) at load time.
@@ -599,7 +646,9 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 				};
 
 				loadDepsAndReplies(list, () => {
-					S.Chat.set(subId, list);
+					// Merge so status events seen during the fetch survive; no trailing keep —
+					// this is a jump into history, the window must stay contiguous around orderId.
+					S.Chat.setFromSnapshot(subId, list, false);
 
 					// Derive edges from the actual page lengths, but only for a fetch that
 					// SUCCEEDED — a transient error (length 0) must not be read as "reached the
@@ -725,9 +774,13 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			section.list.push(item);
 		});
 
-		// Message groups by author/time
+		// Message groups by author/time. Sort by orderId FIRST: grouping flags describe
+		// adjacency in display order, so computing them on an unsorted list would attach
+		// isFirst/isLast to the wrong neighbours.
 		sections.forEach(section => {
 			const length = section.list.length;
+
+			section.list.sort((c1, c2) => U.Data.sortByOrderId(c1, c2));
 
 			for (let i = 0; i < length; ++i) {
 				const prev = section.list[i - 1];
@@ -747,7 +800,6 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 
 			section.list[0].isFirst = true;
 			section.list[length - 1].isLast = true;
-			section.list.sort((c1, c2) => U.Data.sortByOrderId(c1, c2));
 		});
 
 		sections.sort((c1, c2) => U.Data.sortByNumericKey('createdAt', c1, c2, I.SortType.Asc));
@@ -763,6 +815,18 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		if (subIds.includes(subId)) {
 			loadDepsAndReplies(S.Chat.getList(subId).concat(message), () => scrollToBottomCheck());
 		};
+	};
+
+	const onMessageDelete = (id: string, subIds: string[]) => {
+		if (!id || !(subIds || []).includes(getSubId())) {
+			return;
+		};
+
+		// pinnedMessages is component state fed by pin events and loadPinnedMessages —
+		// without this, a deleted pinned message would linger in the banner. Keep the
+		// previous reference when the id isn't pinned so the state update is a no-op.
+		setPinnedMessages(prev => (prev.some(it => it.id == id) ? prev.filter(it => it.id != id) : prev));
+		jumpIds.current = jumpIds.current.filter(it => it != id);
 	};
 
 	const onPinnedStatusUpdate = (message: I.ChatMessage, isPinned: boolean, subIds: string[]) => {
@@ -782,11 +846,19 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	};
 
 	const loadPinnedMessages = () => {
+		// init() resets pinnedMessages before this runs, so early returns and errors leave
+		// the banner empty instead of showing the previous chat's pins.
+		const seq = initSeq.current;
+
 		if (!chatId || U.Space.getSpaceview().isOneToOne) {
 			return;
 		};
 
 		C.ChatGetPinnedMessages(chatId, (message: any) => {
+			if (seq != initSeq.current) {
+				return;
+			};
+
 			if (!message.error.code) {
 				setPinnedMessages(message.messages || []);
 			};
@@ -1044,8 +1116,6 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		// Per-frame read-receipt set comes from the IntersectionObserver (no layout read).
 		// readScrolledMessages keeps the synchronous getMessagesInViewport scan for post-jump accuracy.
 		const list = getMessages().filter((it: any) => visibleIds.current.has(it.id));
-		const state = S.Chat.getState(subId);
-		const { lastStateId } = state;
 		const isBottom = (max > 0) && (st >= max);
 
 		setIsBottom(isBottom);
@@ -1069,16 +1139,32 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		};
 
 		if (S.Common.windowIsFocused && list.length) {
+			// Record the target with the collected ids: the debounced onReadStop can fire after
+			// a chat switch (flush in unbind), when getChatId() already resolves to the NEW chat.
+			readTarget.current = { chatId: getChatId(), subId };
+
+			// Local marks only (instant unread indicators); the debounced onReadStop sends ONE
+			// consolidated range request instead of one RPC per message per scroll frame.
+			const unreadMessageIds = [];
+			const unreadMentionIds = [];
+
 			list.forEach(it => {
 				scrolledItems.current.add(it.id);
 
 				if (!it.isReadMessage) {
-					readMessage(it.id, it.orderId, lastStateId, I.ChatReadType.Message);
+					unreadMessageIds.push(it.id);
 				};
 				if (!it.isReadMention && it.hasMention) {
-					readMessage(it.id, it.orderId, lastStateId, I.ChatReadType.Mention);
+					unreadMentionIds.push(it.id);
 				};
 			});
+
+			if (unreadMessageIds.length) {
+				S.Chat.setReadMessageStatus(subId, unreadMessageIds, true);
+			};
+			if (unreadMentionIds.length) {
+				S.Chat.setReadMentionStatus(subId, unreadMentionIds, true);
+			};
 		};
 
 		window.clearTimeout(timeoutScrollStop.current);
@@ -1123,40 +1209,50 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			return;
 		};
 
-		const chatId = getChatId();
-		const subId = getSubId();
+		// Use the target captured when the items were collected — on a chat switch the
+		// flush from unbind() runs after getChatId() already resolves to the new chat.
+		const target = readTarget.current;
+		const chatId = target?.chatId || getChatId();
+		const subId = target?.subId || getSubId();
 		const ids: string[] = [ ...scrolledItems.current ] as string[];
-		const first = S.Chat.getMessageById(subId, ids[0]);
-		const last = S.Chat.getMessageById(subId, ids[ids.length - 1]);
 		const state = S.Chat.getState(subId);
 		const { lastStateId } = state;
 
-		if (S.Common.windowIsFocused) {
-			if (first && last) {
-				C.ChatReadMessages(chatId, first.orderId, last.orderId, lastStateId, I.ChatReadType.Message);
-				C.ChatReadMessages(chatId, first.orderId, last.orderId, lastStateId, I.ChatReadType.Mention);
+		// No focus check here: collection already gates on windowIsFocused, so every id was
+		// legitimately seen — a blur inside the debounce window must not drop the receipts.
+
+		// scrolledItems insertion order follows viewport visitation (descending on an upward
+		// scroll) and ids may have been evicted — derive the range as min/max orderId over
+		// the messages still in the window; an inverted range would read nothing.
+		let minOrderId = '';
+		let maxOrderId = '';
+
+		ids.forEach(id => {
+			const message = S.Chat.getMessageById(subId, id);
+			if (!message) {
+				return;
 			};
+
+			if (!minOrderId || (message.orderId < minOrderId)) {
+				minOrderId = message.orderId;
+			};
+			if (message.orderId > maxOrderId) {
+				maxOrderId = message.orderId;
+			};
+		});
+
+		if (minOrderId && maxOrderId) {
+			C.ChatReadMessages(chatId, minOrderId, maxOrderId, lastStateId, I.ChatReadType.Message);
+			C.ChatReadMessages(chatId, minOrderId, maxOrderId, lastStateId, I.ChatReadType.Mention);
 
 			// Read reactions: only if the message with the unread reaction is within the visible range
-			if (state.reactionOrderId && first && last) {
-				const minOrderId = ids.reduce((min, id) => {
-					const msg = S.Chat.getMessageById(subId, id);
-					return (msg && (!min || (msg.orderId <= min))) ? msg.orderId : min;
-				}, '');
-
-				const maxOrderId = ids.reduce((max, id) => {
-					const msg = S.Chat.getMessageById(subId, id);
-					return (msg && (msg.orderId >= max)) ? msg.orderId : max;
-				}, '');
-
-				if ((state.reactionOrderId >= minOrderId) && (state.reactionOrderId <= maxOrderId)) {
-					C.ChatReadReactions(chatId, maxOrderId);
-				};
+			if (state.reactionOrderId && (state.reactionOrderId >= minOrderId) && (state.reactionOrderId <= maxOrderId)) {
+				C.ChatReadReactions(chatId, maxOrderId);
 			};
-
-			S.Chat.setReadMessageStatus(subId, ids, true);
-			S.Chat.setReadMentionStatus(subId, ids, true);
 		};
+
+		S.Chat.setReadMessageStatus(subId, ids, true);
+		S.Chat.setReadMentionStatus(subId, ids, true);
 
 		scrolledItems.current.clear();
 	};
@@ -1277,7 +1373,14 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	};
 
 	const readScrolledMessages = () => {
+		// Collection is the single focus gate: messages count as seen only while the window
+		// is focused. onReadStop then always flushes whatever was collected.
+		if (!S.Common.windowIsFocused) {
+			return;
+		};
+
 		scrolledItems.current = new Set(getMessagesInViewport().map(it => it.id));
+		readTarget.current = { chatId: getChatId(), subId: getSubId() };
 		onReadStop();
 	};
 
@@ -1501,6 +1604,15 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 
 	const reloadAndScrollToBottom = () => {
 		jumpIds.current = [];
+
+		// With the live tail already in the window the sent message arrives via its own
+		// ChatAdd event — a full re-subscribe would only race a stale snapshot against
+		// fresher events (and cost two extra round-trips per send).
+		if (S.Chat.isAtChatEnd(getSubId())) {
+			scrollToBottom(true);
+			return;
+		};
+
 		loadMessages(1, true, () => scrollToBottom(true));
 	};
 
@@ -1629,13 +1741,24 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	};
 
 	const init = () => {
+		// Guards the async chain below: a rapid chat switch re-runs init() and the stale
+		// flow must stop — otherwise two flows double-subscribe, fight over the scroll
+		// position and race setFirstUnreadOrderId (loadEpoch only covers pagination).
+		const seq = ++initSeq.current;
+
 		setLoaded(false);
 		setIsBottom(false);
 		setFirstUnreadOrderId('');
+		setPinnedMessages([]);
+		setPinnedIndex(-1);
 		isLoadingPrev.current = false;
 		isLoadingNext.current = false;
 		loadEpoch.current++;
 		loadState(() => {
+			if (seq != initSeq.current) {
+				return;
+			};
+
 			loadPinnedMessages();
 			const subId = getSubId();
 			const match = keyboard.getMatch(isPopup);
@@ -1644,6 +1767,10 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			const cb1 = (orderId: string) => {
 				if (orderId) {
 					loadMessagesByOrderId(orderId, () => {
+						if (seq != initSeq.current) {
+							return;
+						};
+
 						const target = S.Chat.getMessageByOrderId(subId, orderId);
 						if (target) {
 							setFirstUnreadOrderId(target.orderId);
@@ -1656,6 +1783,10 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 				};
 			};
 			const cb2 = () => {
+				if (seq != initSeq.current) {
+					return;
+				};
+
 				scrollToBottom(false);
 			};
 
@@ -1668,6 +1799,10 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 
 			if (initialMessageId) {
 				C.ChatGetMessagesByIds(chatId, [ initialMessageId ], (message: any) => {
+					if (seq != initSeq.current) {
+						return;
+					};
+
 					if (message.error.code) {
 						return;
 					};
@@ -1809,6 +1944,25 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			scrollToBottom(false);
 		};
 	}, [ rootId, space, chatId, analyticsChatId ]);
+
+	// Own the backend message subscription: the last holder of the subId unsubscribes on
+	// teardown (chat switch / unmount). The local message cache is intentionally KEPT for
+	// instant re-open — init() re-subscribes and merges a fresh snapshot over it.
+	useEffect(() => {
+		if (!chatId) {
+			return;
+		};
+
+		const subId = getSubId();
+
+		S.Chat.retainSub(subId);
+
+		return () => {
+			if (!S.Chat.releaseSub(subId)) {
+				C.ChatUnsubscribe(chatId, subId);
+			};
+		};
+	}, [ space, chatId ]);
 
 	useEffect(() => {
 		rebind();

--- a/src/ts/component/block/chat/form.tsx
+++ b/src/ts/component/block/chat/form.tsx
@@ -996,15 +996,41 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 		const bl = bookmarks.length;
 		const bookmark = S.Record.getBookmarkType();
 
+		// tmp attachment id → created object id. Results are collected here instead of
+		// mutating the attachments array in place: the user can remove attachments while
+		// uploads are in flight, so the final list is resolved from the CURRENT store
+		// state in callBack, not from a stale send-time snapshot.
+		const created = new Map<string, string>();
+
+		let failed = false;
+
 		U.Dom.addClass(send, 'isLoading');
 		isSending.current = true;
 
 		raf(() => {
 			U.Dom.addClass(send, 'anim');
 		});
-		
+
+		// Abort without clear(): the composer keeps its text and attachments so the user can retry.
+		const abort = (text: string) => {
+			isSending.current = false;
+			U.Dom.removeClass(send, 'isLoading');
+			U.Dom.removeClass(send, 'anim');
+
+			Preview.toastShow({ icon: 'notice', text });
+		};
+
 		const callBack = () => {
-			const newAttachments = attachments.filter(it => !it.isTmp).map(it => ({ target: it.id, type: getAttachmentType(it.layout) }));
+			if (failed) {
+				abort(translate('toastChatUploadFailed'));
+				return;
+			};
+
+			// Resolve against the current store list so attachments removed during the
+			// upload don't come back into the message.
+			const newAttachments = S.Chat.getAttachments(attachmentsSubId)
+				.map(it => ({ target: (it.isTmp ? created.get(it.id) : it.id), type: getAttachmentType(it.layout) }))
+				.filter(it => it.target);
 			const parsed = getMarksFromHtml();
 			const text = trim(parsed.text);
 			const match = parsed.text.match(/^\r?\n+/);
@@ -1024,7 +1050,12 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 					update.content.marks = coded.marks;
 					update.blocks = [];
 
-					C.ChatEditMessageContent(rootId, editingId.current, update, () => {
+					C.ChatEditMessageContent(rootId, editingId.current, update, (response: any) => {
+						if (response.error.code) {
+							abort(translate('toastChatSendFailed'));
+							return;
+						};
+
 						scrollToMessage(editingId.current, true);
 						clear();
 					});
@@ -1054,7 +1085,12 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 					messageType = message.content?.text.length ? 'Mixed' : 'Attachment';
 				};
 
-				C.ChatAddMessage(rootId, message, () => {
+				C.ChatAddMessage(rootId, message, (response: any) => {
+					if (response.error.code) {
+						abort(translate('toastChatSendFailed'));
+						return;
+					};
+
 					reloadAndScrollToBottom();
 					clear();
 
@@ -1074,15 +1110,10 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 				C.FileUpload(S.Common.space, '', item.path, I.FileType.None, {}, false, '', 0, rootId, '', (message: any) => {
 					n++;
 
-					if (message.objectId) {
-						const idx = attachments.findIndex(it => it.id == item.id);
-						const newItem = { id: message.objectId, type: getAttachmentType(item.layout) };
-
-						if (idx >= 0) {
-							attachments[idx] = newItem;
-						} else {
-							attachments.push(newItem);
-						};
+					if (message.error.code || !message.objectId) {
+						failed = true;
+					} else {
+						created.set(item.id, message.objectId);
 					};
 
 					if (n == fl) {
@@ -1103,15 +1134,10 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 				C.ObjectCreateBookmark({ source: item.source, createdInContext: rootId, createdInContextRef: '' }, S.Common.space, bookmark.defaultTemplateId, (message: any) => {
 					n++;
 
-					if (message.objectId) {
-						const idx = attachments.findIndex(it => it.id == item.id);
-						const newItem = { id: message.objectId, type: getAttachmentType(item.layout) };
-
-						if (idx >= 0) {
-							attachments[idx] = newItem;
-						} else {
-							attachments.push(newItem);
-						};
+					if (message.error.code || !message.objectId) {
+						failed = true;
+					} else {
+						created.set(item.id, message.objectId);
 					};
 
 					if (n == bl) {

--- a/src/ts/lib/action.ts
+++ b/src/ts/lib/action.ts
@@ -23,19 +23,12 @@ class Action {
 		};
 
 		const blocks = S.Block.getBlocks(rootId);
-		const object = S.Detail.get(rootId, rootId);
 
-		if (object.layout == I.ObjectLayout.Space) {
-			this.dbClearChat(object.chatId, J.Constant.blockId.chat);
-		};
-
+		// Chat message subscriptions are NOT torn down here: BlockChat owns its subscription
+		// lifecycle (refcounted retainSub/releaseSub + ChatUnsubscribe on unmount).
 		for (const block of blocks) {
 			if (block.isDataview()) {
 				this.dbClearBlock(rootId, block.id);
-			} else 
-			if (block.isChat()) {
-				this.dbClearChat(object.chatId, block.id);
-				this.dbClearChat(object.id, block.id);
 			};
 		};
 
@@ -91,22 +84,6 @@ class Action {
 		S.Detail.clear(subId);
 
 		U.Subscription.destroyList(groupIds.concat([ subId ]), true);
-	};
-
-	/**
-	 * Clears all data related to a chat block.
-	 * @param {string} chatId - The chat object ID.
-	 * @param {string} blockId - The block ID.
-	 */
-	dbClearChat (chatId: string, blockId: string) {	
-		if (!chatId || !blockId) {
-			return;
-		};
-
-		const subId = S.Record.getSubId(chatId, blockId);
-
-		C.ChatUnsubscribe(chatId, subId);
-		S.Chat.clear(subId);
 	};
 
 	/**

--- a/src/ts/lib/api/dispatcher.ts
+++ b/src/ts/lib/api/dispatcher.ts
@@ -1130,7 +1130,6 @@ class Dispatcher {
 				case 'ChatAdd': {
 					const { orderId, dependencies } = mapped;
 					const message = new M.ChatMessage({ ...mapped.message, dependencies, chatId: rootId });
-					const notification = S.Chat.getMessageSimpleText(spaceId, message, !spaceview?.isOneToOne);
 					const discussionParentId = S.Chat.getDiscussionParentId(spaceId, rootId);
 					const isDiscussion = !!discussionParentId;
 
@@ -1189,9 +1188,13 @@ class Dispatcher {
 						};
 					});
 
-					if (showNotification && notification && !windowIsFocused && S.Common.isActiveTab && (message.creator != account.id)) {
+					if (showNotification && !windowIsFocused && S.Common.isActiveTab && (message.creator != account.id)) {
+						// Built only on the notification path: sanitize + emoji-insert over
+						// text/marks is pure waste for the focused-window case — i.e. every
+						// live message while the user is in the chat.
+						const notification = S.Chat.getMessageSimpleText(spaceId, message, !spaceview?.isOneToOne);
 						const title = [];
-						let canNotify = true;
+						let canNotify = !!notification;
 						let openPayload: any = { id: rootId, layout: I.ObjectLayout.Chat, spaceId };
 
 						if (spaceview) {
@@ -1823,6 +1826,12 @@ class Dispatcher {
 							.filter((msg: any) => msg.objectCleanupSuggestion?.objectIds?.length)
 							.flatMap((msg: any) => msg.objectCleanupSuggestion.objectIds)
 					);
+
+					// Drain buffered stream events first: they arrived BEFORE this response, so
+					// applying the embedded events ahead of them would invert causal order (e.g.
+					// an update for a message whose ChatAdd is still buffered would be dropped,
+					// and the add would then land without it).
+					this.flushEvents();
 
 					runInAction(() => this.event(message.event, true, true));
 				};

--- a/src/ts/lib/api/dispatcher.ts
+++ b/src/ts/lib/api/dispatcher.ts
@@ -9,6 +9,7 @@ import { ServiceClient } from './service';
 import { unaryInterceptors, streamInterceptors } from './grpc-devtools';
 import * as I from 'Interface';
 import * as M from 'Model';
+import { liveAddIndex } from 'Lib/util/chatWindow';
 
 const SORT_IDS = [
 	'BlockAdd',
@@ -94,8 +95,13 @@ class Dispatcher {
 			if (!this.flushScheduled) {
 				this.flushScheduled = true;
 
-				if (S.Common.isActiveTab) {
+				if (S.Common.isActiveTab && (document.visibilityState == 'visible')) {
 					this.rafId = requestAnimationFrame(() => this.flushEvents());
+
+					// Backstop: rAF stalls in hidden/occluded windows (isActiveTab tracks the
+					// tab strip, not window visibility) — without it, buffered events pile up
+					// until restore, freezing notifications and the badge while minimized.
+					this.flushTimerId = window.setTimeout(() => this.flushEvents(), 250);
 				} else {
 					this.flushTimerId = window.setTimeout(() => this.flushEvents(), 100);
 				};
@@ -167,6 +173,14 @@ class Dispatcher {
 	 * so MobX reactions fire only once at the end of the batch.
 	 */
 	flushEvents () {
+		// Both a rAF and a backstop timeout can be armed at once — cancel the one that didn't fire.
+		if (this.rafId) {
+			cancelAnimationFrame(this.rafId);
+		};
+		if (this.flushTimerId) {
+			window.clearTimeout(this.flushTimerId);
+		};
+
 		this.flushScheduled = false;
 		this.rafId = 0;
 		this.flushTimerId = 0;
@@ -1142,9 +1156,12 @@ class Dispatcher {
 					chatSubIds.forEach(subId => {
 						const list = S.Chat.getList(subId);
 
-						let idx = list.findIndex(it => it.orderId == orderId);
+						// Sorted insertion by orderId (lexicographic): a late-arriving older message
+						// (offline peer sync) must land at its ordered position, not at the tail.
+						// -1 means it belongs before the loaded window — backward pagination owns it.
+						const idx = liveAddIndex(list, orderId, S.Chat.isAtChatStart(subId));
 						if (idx < 0) {
-							idx = list.length;
+							return;
 						};
 
 						S.Chat.add(subId, idx, message);
@@ -1238,6 +1255,7 @@ class Dispatcher {
 							};
 						} else {
 							S.Chat.update(subId, mapped.message);
+							S.Chat.markTouched(subId, mapped.message.id);
 						};
 					});
 
@@ -1328,6 +1346,8 @@ class Dispatcher {
 							S.Chat.delete(subId, mapped.id);
 						};
 					});
+
+					U.Dom.eventDispatch(window, 'messageDelete', { id: mapped.id, subIds: mapped.subIds });
 					break;
 				};
 
@@ -1362,6 +1382,7 @@ class Dispatcher {
 									notificationMessage = message;
 								};
 								set(message, { reactions: mapped.reactions });
+								S.Chat.markTouched(subId, mapped.id);
 							};
 						};
 					});
@@ -1427,6 +1448,7 @@ class Dispatcher {
 						const message = S.Chat.getMessageById(subId, mapped.message?.id);
 						if (message) {
 							set(message, { isPinned: mapped.isPinned });
+							S.Chat.markTouched(subId, mapped.message?.id);
 						};
 					});
 

--- a/src/ts/lib/api/response.ts
+++ b/src/ts/lib/api/response.ts
@@ -697,7 +697,9 @@ export const ChatGetMessagesByIds = (response: any) => {
 export const ChatSubscribeLastMessages = (response: any) => {
 	return {
 		messages: (response.messages || []).map(Mapper.From.ChatMessage),
-		state: Mapper.From.ChatState(response.chatState || {}),
+		// null when absent so `if (message.state)` guards actually work — a state mapped
+		// from {} carries zeroed counters and no order, which would clobber real state.
+		state: response.chatState ? Mapper.From.ChatState(response.chatState) : null,
 	};
 };
 

--- a/src/ts/lib/util/chatWindow.test.ts
+++ b/src/ts/lib/util/chatWindow.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { evictedCount, reachedEdge, shouldRefetchForward, shouldSuppressLiveAdd } from './chatWindow';
+import { evictedCount, reachedEdge, shouldRefetchForward, shouldSuppressLiveAdd, liveAddIndex, mergeWindowSnapshot } from './chatWindow';
+
+const msg = (id: string, orderId: string, flags: any = {}) => ({
+	id,
+	orderId,
+	isReadMessage: false,
+	isReadMention: false,
+	isReadReaction: false,
+	isSynced: false,
+	...flags,
+});
 
 describe('chatWindow', () => {
 	it('evictedCount returns overflow past max, else 0', () => {
@@ -26,5 +36,108 @@ describe('chatWindow', () => {
 		expect(shouldSuppressLiveAdd(true, '!z', '!m')).toBe(false);
 		expect(shouldSuppressLiveAdd(false, '!a', '!m')).toBe(false);
 		expect(shouldSuppressLiveAdd(false, '!z', '')).toBe(false);
+	});
+
+	describe('liveAddIndex', () => {
+		const window = [ '!b', '!d', '!f' ].map(orderId => ({ orderId }));
+
+		it('appends a newer message at the tail', () => {
+			expect(liveAddIndex(window, '!z', true)).toBe(3);
+		});
+
+		it('inserts an out-of-order older message at its sorted position', () => {
+			expect(liveAddIndex(window, '!c', true)).toBe(1);
+			expect(liveAddIndex(window, '!e', true)).toBe(2);
+		});
+
+		it('inserts before the head only when the window is at the chat start', () => {
+			expect(liveAddIndex(window, '!a', true)).toBe(0);
+		});
+
+		it('skips a message older than the window head while older history exists', () => {
+			expect(liveAddIndex(window, '!a', false)).toBe(-1);
+		});
+
+		it('inserts into an empty window at 0', () => {
+			expect(liveAddIndex([], '!a', false)).toBe(0);
+			expect(liveAddIndex([], '!a', true)).toBe(0);
+		});
+	});
+
+	describe('mergeWindowSnapshot', () => {
+		const none = new Set<string>();
+
+		it('returns the snapshot as-is over an empty window', () => {
+			const snapshot = [ msg('1', '!a'), msg('2', '!b') ];
+			expect(mergeWindowSnapshot([], snapshot, none, none, true)).toEqual(snapshot);
+		});
+
+		it('keeps monotonic flags set by events during the load (true wins)', () => {
+			const current = [ msg('1', '!a', { isReadMessage: true, isSynced: true }) ];
+			const snapshot = [ msg('1', '!a') ];
+			const [ merged ] = mergeWindowSnapshot(current, snapshot, none, none, true);
+
+			expect(merged.isReadMessage).toBe(true);
+			expect(merged.isSynced).toBe(true);
+		});
+
+		it('takes snapshot content for untouched messages present in both', () => {
+			const current = [ { ...msg('1', '!a'), text: 'old' } ];
+			const snapshot = [ { ...msg('1', '!a'), text: 'edited' } ];
+			const [ merged ] = mergeWindowSnapshot(current, snapshot, none, none, true);
+
+			expect(merged.text).toBe('edited');
+		});
+
+		it('keeps the current instance for messages touched by events during the load', () => {
+			const current = [ { ...msg('1', '!a'), text: 'edited live' } ];
+			const snapshot = [ { ...msg('1', '!a'), text: 'stale' } ];
+			const touched = new Set([ '1' ]);
+			const [ merged ] = mergeWindowSnapshot(current, snapshot, none, touched, true);
+
+			expect(merged.text).toBe('edited live');
+		});
+
+		it('ignores touched ids that are not in the current window', () => {
+			const snapshot = [ msg('1', '!a') ];
+			const touched = new Set([ '1' ]);
+
+			expect(mergeWindowSnapshot([], snapshot, none, touched, true)).toEqual(snapshot);
+		});
+
+		it('does not resurrect messages deleted during the load', () => {
+			const snapshot = [ msg('1', '!a'), msg('2', '!b') ];
+			const deleted = new Set([ '2' ]);
+
+			expect(mergeWindowSnapshot([], snapshot, deleted, none, true).map(it => it.id)).toEqual([ '1' ]);
+		});
+
+		it('preserves live adds newer than the snapshot tail when keepTrailing is set', () => {
+			const current = [ msg('1', '!a'), msg('3', '!c') ];
+			const snapshot = [ msg('1', '!a'), msg('2', '!b') ];
+
+			expect(mergeWindowSnapshot(current, snapshot, none, none, true).map(it => it.id)).toEqual([ '1', '2', '3' ]);
+		});
+
+		it('drops current messages outside the snapshot on a history jump (no keepTrailing)', () => {
+			const current = [ msg('1', '!a'), msg('9', '!z') ];
+			const snapshot = [ msg('4', '!d'), msg('5', '!e') ];
+
+			expect(mergeWindowSnapshot(current, snapshot, none, none, false).map(it => it.id)).toEqual([ '4', '5' ]);
+		});
+
+		it('does not keep trailing messages that were deleted during the load', () => {
+			const current = [ msg('1', '!a'), msg('3', '!c') ];
+			const snapshot = [ msg('1', '!a') ];
+			const deleted = new Set([ '3' ]);
+
+			expect(mergeWindowSnapshot(current, snapshot, deleted, none, true).map(it => it.id)).toEqual([ '1' ]);
+		});
+
+		it('keeps all current messages as trailing when the snapshot is empty and keepTrailing is set', () => {
+			const current = [ msg('1', '!a') ];
+
+			expect(mergeWindowSnapshot(current, [], none, none, true).map(it => it.id)).toEqual([ '1' ]);
+		});
 	});
 });

--- a/src/ts/lib/util/chatWindow.test.ts
+++ b/src/ts/lib/util/chatWindow.test.ts
@@ -98,6 +98,17 @@ describe('chatWindow', () => {
 			expect(merged.text).toBe('edited live');
 		});
 
+		it('touched messages still gain monotonic flags from the snapshot', () => {
+			const current = [ { ...msg('1', '!a'), text: 'edited live' } ];
+			const snapshot = [ { ...msg('1', '!a', { isReadMessage: true, isSynced: true }), text: 'stale' } ];
+			const touched = new Set([ '1' ]);
+			const [ merged ] = mergeWindowSnapshot(current, snapshot, none, touched, true);
+
+			expect(merged.text).toBe('edited live');
+			expect(merged.isReadMessage).toBe(true);
+			expect(merged.isSynced).toBe(true);
+		});
+
 		it('ignores touched ids that are not in the current window', () => {
 			const snapshot = [ msg('1', '!a') ];
 			const touched = new Set([ '1' ]);

--- a/src/ts/lib/util/chatWindow.ts
+++ b/src/ts/lib/util/chatWindow.ts
@@ -34,3 +34,82 @@ export const shouldRefetchForward = (atChatEnd: boolean, isBottom: boolean, isLo
 export const shouldSuppressLiveAdd = (atChatEnd: boolean, messageOrderId: string, lastWindowOrderId: string): boolean => {
 	return (!atChatEnd) && (!!lastWindowOrderId) && (messageOrderId > lastWindowOrderId);
 };
+
+/**
+ * Merge a freshly-fetched window snapshot with the current window. The snapshot was taken
+ * on the backend when the request was served, but it is applied only after async dependency
+ * loading — events processed in between (live adds, read/sync status, deletes, edits) are
+ * newer than the snapshot and must survive the overwrite.
+ *
+ * - Read/sync flags are effectively monotonic (there is no mark-unread UI): true wins.
+ * - Ids deleted by events are filtered out (no resurrection of deleted messages).
+ * - Ids touched by content-bearing events (edit / reactions / pin) keep the current
+ *   instance — the snapshot predates the event. A touch older than the snapshot is
+ *   harmless: the backend had already applied it when the snapshot was taken, so both
+ *   sides carry the same content.
+ * - With keepTrailing, current messages newer than the snapshot tail are preserved (live
+ *   adds during the load). Only valid when the snapshot represents the chat tail; a jump
+ *   into history must NOT keep them, or the window would stop being contiguous.
+ */
+export const mergeWindowSnapshot = (current: any[], snapshot: any[], deletedIds: Set<string>, touchedIds: Set<string>, keepTrailing: boolean): any[] => {
+	const filtered = (snapshot || []).filter(it => !deletedIds.has(it.id));
+	const byId = new Map((current || []).map(it => [ it.id, it ]));
+
+	const out = filtered.map(it => {
+		const cur = byId.get(it.id);
+		if (!cur) {
+			return it;
+		};
+
+		if (touchedIds.has(it.id)) {
+			return cur;
+		};
+
+		return {
+			...it,
+			isReadMessage: it.isReadMessage || cur.isReadMessage,
+			isReadMention: it.isReadMention || cur.isReadMention,
+			isReadReaction: it.isReadReaction || cur.isReadReaction,
+			isSynced: it.isSynced || cur.isSynced,
+		};
+	});
+
+	if (keepTrailing && current && current.length) {
+		const ids = new Set(filtered.map(it => it.id));
+		const maxOrderId = filtered.length ? filtered[filtered.length - 1].orderId : '';
+		const trailing = current.filter(it => (!ids.has(it.id)) && (!deletedIds.has(it.id)) && ((!maxOrderId) || (it.orderId > maxOrderId)));
+
+		out.push(...trailing);
+	};
+
+	return out;
+};
+
+/**
+ * Insertion index for a live-added message so the window stays sorted by orderId.
+ * A late-arriving older message (offline peer sync) must land at its ordered position,
+ * not at the tail — an unsorted window corrupts pagination cursors, the live-add
+ * suppression compare, and author-grouping. Takes the message list directly (no
+ * projected orderId array) — this runs per subId per ChatAdd event, and events burst
+ * on reconnect catch-up.
+ *
+ * Returns -1 when the message is older than the window head while older history exists:
+ * it belongs outside the loaded window and backward pagination owns fetching it.
+ */
+export const liveAddIndex = (list: { orderId: string }[], messageOrderId: string, atChatStart: boolean): number => {
+	if (!list.length) {
+		return 0;
+	};
+
+	const idx = list.findIndex(it => it.orderId > messageOrderId);
+
+	if (idx < 0) {
+		return list.length;
+	};
+
+	if ((idx == 0) && (!atChatStart)) {
+		return -1;
+	};
+
+	return idx;
+};

--- a/src/ts/lib/util/chatWindow.ts
+++ b/src/ts/lib/util/chatWindow.ts
@@ -61,8 +61,16 @@ export const mergeWindowSnapshot = (current: any[], snapshot: any[], deletedIds:
 			return it;
 		};
 
+		// Touched: current content is fresher, but the snapshot can still carry newer
+		// monotonic flags (e.g. read on another device while the edit event was local).
 		if (touchedIds.has(it.id)) {
-			return cur;
+			return {
+				...cur,
+				isReadMessage: cur.isReadMessage || it.isReadMessage,
+				isReadMention: cur.isReadMention || it.isReadMention,
+				isReadReaction: cur.isReadReaction || it.isReadReaction,
+				isSynced: cur.isSynced || it.isSynced,
+			};
 		};
 
 		return {
@@ -101,15 +109,28 @@ export const liveAddIndex = (list: { orderId: string }[], messageOrderId: string
 		return 0;
 	};
 
-	const idx = list.findIndex(it => it.orderId > messageOrderId);
-
-	if (idx < 0) {
+	// Tail fast-path: live traffic is almost always newest-last (O(1)); the binary search
+	// below covers late-arriving older messages — the window is sorted by orderId.
+	if (list[list.length - 1].orderId < messageOrderId) {
 		return list.length;
 	};
 
-	if ((idx == 0) && (!atChatStart)) {
+	let lo = 0;
+	let hi = list.length;
+
+	while (lo < hi) {
+		const mid = (lo + hi) >> 1;
+
+		if (list[mid].orderId > messageOrderId) {
+			hi = mid;
+		} else {
+			lo = mid + 1;
+		};
+	};
+
+	if ((lo == 0) && (!atChatStart)) {
 		return -1;
 	};
 
-	return idx;
+	return lo;
 };

--- a/src/ts/lib/util/data.ts
+++ b/src/ts/lib/util/data.ts
@@ -446,7 +446,9 @@ class UtilData {
 				const spaceSubId = S.Chat.getSpaceSubId(spaceId);
 				const chatSubId = S.Chat.getChatSubId(J.Constant.subId.chatPreview, spaceId, chatId);
 
-				S.Chat.setState(chatSubId, state);
+				if (state) {
+					S.Chat.setState(chatSubId, state);
+				};
 
 				if (message) {
 					message.chatId = chatId;

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -1,9 +1,13 @@
 import { observable, action, makeObservable, set, autorun } from 'mobx';
 import * as I from 'Interface';
 import * as M from 'Model';
-import { evictedCount, shouldSuppressLiveAdd } from 'Lib/util/chatWindow';
+import { evictedCount, shouldSuppressLiveAdd, mergeWindowSnapshot } from 'Lib/util/chatWindow';
 
 const MAX_MESSAGES = 500;
+// How long a journaled message id (deleted, or touched by a content-bearing event) is
+// remembered so a stale window snapshot applied after async dependency loading cannot
+// resurrect a deleted message or revert a fresher edit (see setFromSnapshot).
+const JOURNAL_TTL = 60000;
 
 class ChatStore {
 
@@ -16,6 +20,9 @@ class ChatStore {
 	private atChatStartMap: Map<string, boolean> = new Map();
 	private atChatEndMap: Map<string, boolean> = new Map();
 	private messageByIdMap: Map<string, Map<string, any>> = new Map();
+	private deletedMap: Map<string, Map<string, number>> = new Map();
+	private touchedMap: Map<string, Map<string, number>> = new Map();
+	private subRefs: Map<string, number> = new Map();
 
 	constructor () {
 		makeObservable(this, {
@@ -111,6 +118,12 @@ class ChatStore {
 	 * @param {I.ChatMessage} param - The chat message to add.
 	 */
 	add (subId: string, idx: number, param: I.ChatMessage): void {
+		// First message for a subId: set() creates the observable list in the map.
+		if (!this.messageMap.has(subId)) {
+			this.set(subId, [ param ]);
+			return;
+		};
+
 		const list = this.getList(subId);
 		const item = this.getMessageById(subId, param.id);
 
@@ -130,7 +143,11 @@ class ChatStore {
 			};
 		};
 
-		list.splice(idx, 0, param);
+		// Splice in place instead of set(): set() re-wraps the WHOLE window in M.ChatMessage
+		// (makeObservable per message), which turns reconnect catch-up bursts — one add event
+		// per message at up to MAX_MESSAGES window size — into main-thread jank. Mirrors
+		// prepend/append, which also mutate in place.
+		list.splice(idx, 0, new M.ChatMessage(param));
 
 		// Tail insert behaves like append: trim the oldest head if over the cap.
 		if (isTail) {
@@ -141,7 +158,7 @@ class ChatStore {
 			};
 		};
 
-		this.set(subId, list);
+		this.rebuildIndex(subId);
 	};
 
 	/**
@@ -158,12 +175,82 @@ class ChatStore {
 	};
 
 	/**
-	 * Deletes a chat message by ID.
+	 * Deletes a chat message by ID. The id is journaled so a window snapshot fetched
+	 * before the delete cannot resurrect the message (see setFromSnapshot).
 	 * @param {string} subId - The subscription ID.
 	 * @param {string} id - The chat message ID.
 	 */
 	delete (subId: string, id: string) {
+		this.journalAdd(this.deletedMap, subId, id);
 		this.set(subId, this.getList(subId).filter(it => it.id != id));
+	};
+
+	/**
+	 * Journals a content-bearing event update (edit / reactions / pin) for a message, so a
+	 * stale window snapshot applied after async dependency loading keeps the fresher
+	 * event-updated instance instead of reverting it (see setFromSnapshot). Read/sync
+	 * status updates are NOT journaled — those flags merge monotonically on their own.
+	 * @param {string} subId - The subscription ID.
+	 * @param {string} id - The chat message ID.
+	 */
+	markTouched (subId: string, id: string): void {
+		if (subId && id) {
+			this.journalAdd(this.touchedMap, subId, id);
+		};
+	};
+
+	/**
+	 * Records an id into a per-subId journal with the current timestamp.
+	 * @private
+	 */
+	private journalAdd (map: Map<string, Map<string, number>>, subId: string, id: string): void {
+		const journal = map.get(subId) || new Map();
+
+		journal.set(id, Date.now());
+		map.set(subId, journal);
+	};
+
+	/**
+	 * Ids journaled within JOURNAL_TTL for a subId; prunes expired entries in place.
+	 * @private
+	 */
+	private journalRecent (map: Map<string, Map<string, number>>, subId: string): Set<string> {
+		const journal = map.get(subId);
+		const ret = new Set<string>();
+
+		if (!journal) {
+			return ret;
+		};
+
+		const now = Date.now();
+
+		for (const [ id, ts ] of journal) {
+			if (now - ts > JOURNAL_TTL) {
+				journal.delete(id);
+			} else {
+				ret.add(id);
+			};
+		};
+
+		return ret;
+	};
+
+	/**
+	 * Applies a window snapshot fetched from the backend. The snapshot is stale relative to
+	 * events processed while it was in flight (dependency loading adds round-trips before it
+	 * can be applied) — merge instead of overwrite, so live adds, monotonic read/sync flags,
+	 * deletes and content-bearing updates (edits / reactions / pins) seen in the meantime
+	 * survive.
+	 * @param {string} subId - The subscription ID.
+	 * @param {I.ChatMessage[]} list - The snapshot messages, ascending by orderId.
+	 * @param {boolean} keepTrailing - Keep current messages newer than the snapshot tail
+	 * (only when the snapshot represents the chat tail).
+	 */
+	setFromSnapshot (subId: string, list: I.ChatMessage[], keepTrailing: boolean): void {
+		const deleted = this.journalRecent(this.deletedMap, subId);
+		const touched = this.journalRecent(this.touchedMap, subId);
+
+		this.set(subId, mergeWindowSnapshot(this.getList(subId), list, deleted, touched, keepTrailing));
 	};
 
 	/**
@@ -303,9 +390,14 @@ class ChatStore {
 
 		if (current) {
 			const { messages, mentions, reactionOrderId, lastStateId, order } = state;
+			const incoming = Number(order) || 0;
+			const existing = Number(current.order) || 0;
 
-			// Ignore outdated state
-			if (current.order && order && (order < current.order)) {
+			// Per proto, a state applies only if its order is GREATER than the stored one.
+			// A state without an order (e.g. a response snapshot mapped from a missing
+			// chatState) must never clobber an ordered state — that would zero the counters
+			// AND reset current.order, disabling this guard for all future updates.
+			if (existing && (incoming <= existing)) {
 				return;
 			};
 
@@ -349,6 +441,33 @@ class ChatStore {
 	};
 
 	/**
+	 * Reference-counts an active backend message subscription for a subId. Several
+	 * components can render the same chat (page, popup); only the last holder may
+	 * unsubscribe on teardown.
+	 * @param {string} subId - The subscription ID.
+	 */
+	retainSub (subId: string): void {
+		this.subRefs.set(subId, (this.subRefs.get(subId) || 0) + 1);
+	};
+
+	/**
+	 * Releases one subscription reference for a subId.
+	 * @param {string} subId - The subscription ID.
+	 * @returns {number} The remaining reference count — unsubscribe on 0.
+	 */
+	releaseSub (subId: string): number {
+		const n = Math.max(0, (this.subRefs.get(subId) || 0) - 1);
+
+		if (n) {
+			this.subRefs.set(subId, n);
+		} else {
+			this.subRefs.delete(subId);
+		};
+
+		return n;
+	};
+
+	/**
 	 * Clears all chat data for a subId.
 	 * @param {string} subId - The subscription ID.
 	 */
@@ -359,6 +478,8 @@ class ChatStore {
 		this.atChatStartMap.delete(subId);
 		this.atChatEndMap.delete(subId);
 		this.messageByIdMap.delete(subId);
+		this.deletedMap.delete(subId);
+		this.touchedMap.delete(subId);
 	};
 
 	/**
@@ -409,6 +530,9 @@ class ChatStore {
 		this.atChatStartMap.clear();
 		this.atChatEndMap.clear();
 		this.messageByIdMap.clear();
+		this.deletedMap.clear();
+		this.touchedMap.clear();
+		this.subRefs.clear();
 	};
 
 	/**
@@ -428,7 +552,7 @@ class ChatStore {
 	 */
 	getMessageById (subId: string, id: string): I.ChatMessage {
 		// Read the observable list FIRST so observer callers (Message rows) keep a MobX dependency
-		// on the message map key. set()/add()/delete() replace the array with freshly-wrapped
+		// on the message map key. set()/delete() replace the array with freshly-wrapped
 		// M.ChatMessage instances; without this read a memoized observer row bound to a now-detached
 		// instance would stop reflecting reactions/edits/read-status/grouping. The map is the O(1)
 		// accelerator for the actual lookup.

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -147,18 +147,28 @@ class ChatStore {
 		// (makeObservable per message), which turns reconnect catch-up bursts — one add event
 		// per message at up to MAX_MESSAGES window size — into main-thread jank. Mirrors
 		// prepend/append, which also mutate in place.
-		list.splice(idx, 0, new M.ChatMessage(param));
+		const added = new M.ChatMessage(param);
+
+		list.splice(idx, 0, added);
+
+		// Patch the id index incrementally — a full rebuild is O(window) per add event,
+		// so bursts would pay O(n²) and a discarded Map per event.
+		let index = this.messageByIdMap.get(subId);
+		if (index) {
+			index.set(added.id, added);
+		} else {
+			this.rebuildIndex(subId);
+			index = this.messageByIdMap.get(subId);
+		};
 
 		// Tail insert behaves like append: trim the oldest head if over the cap.
 		if (isTail) {
 			const evicted = evictedCount(list.length, MAX_MESSAGES);
 			if (evicted) {
-				list.splice(0, evicted);
+				list.splice(0, evicted).forEach(it => index.delete(it.id));
 				this.setAtChatStart(subId, false);
 			};
 		};
-
-		this.rebuildIndex(subId);
 	};
 
 	/**
@@ -202,19 +212,38 @@ class ChatStore {
 	/**
 	 * Records an id into a per-subId journal with the current timestamp.
 	 * @private
+	 * @param {Map<string, Map<string, number>>} map - The journal map (deletedMap or touchedMap).
+	 * @param {string} subId - The subscription ID.
+	 * @param {string} id - The chat message ID.
 	 */
 	private journalAdd (map: Map<string, Map<string, number>>, subId: string, id: string): void {
 		const journal = map.get(subId) || new Map();
+		const now = Date.now();
 
-		journal.set(id, Date.now());
+		journal.set(id, now);
+
+		// Journals of subIds that never snapshot-merge (previews, space, comments) have no
+		// other prune point — drop expired entries once the journal outgrows a burst-sized
+		// batch, so they stay bounded by the event rate within one TTL.
+		if (journal.size > 128) {
+			for (const [ key, ts ] of journal) {
+				if (now - ts > JOURNAL_TTL) {
+					journal.delete(key);
+				};
+			};
+		};
+
 		map.set(subId, journal);
 	};
 
 	/**
 	 * Ids journaled within JOURNAL_TTL for a subId; prunes expired entries in place.
 	 * @private
+	 * @param {Map<string, Map<string, number>>} map - The journal map (deletedMap or touchedMap).
+	 * @param {string} subId - The subscription ID.
+	 * @returns {Set<string>} The ids still within TTL.
 	 */
-	private journalRecent (map: Map<string, Map<string, number>>, subId: string): Set<string> {
+	private getRecentJournalIds (map: Map<string, Map<string, number>>, subId: string): Set<string> {
 		const journal = map.get(subId);
 		const ret = new Set<string>();
 
@@ -247,8 +276,8 @@ class ChatStore {
 	 * (only when the snapshot represents the chat tail).
 	 */
 	setFromSnapshot (subId: string, list: I.ChatMessage[], keepTrailing: boolean): void {
-		const deleted = this.journalRecent(this.deletedMap, subId);
-		const touched = this.journalRecent(this.touchedMap, subId);
+		const deleted = this.getRecentJournalIds(this.deletedMap, subId);
+		const touched = this.getRecentJournalIds(this.touchedMap, subId);
 
 		this.set(subId, mergeWindowSnapshot(this.getList(subId), list, deleted, touched, keepTrailing));
 	};


### PR DESCRIPTION
Fixes a set of races/inconsistent states in chat event handling. Details in [JS-9827](https://linear.app/anytype/issue/JS-9827).

## Fixes
- **Snapshot clobber**: subscribe/jump window snapshots are applied after async dep loading; events processed in between (live adds, deletes, edits, read/sync status) were discarded — messages vanished, deletes resurrected, statuses reverted. Snapshots now **merge** (`mergeWindowSnapshot` + delete/edit journals in the chat store).
- **Live insert order**: ChatAdd insert-position lookup never matched, so every live message was appended at the tail; late-synced older messages corrupted pagination cursors and author grouping. Now sorted insertion by orderId (`liveAddIndex`), O(1) in-place splice (was a full 500-message re-wrap per event).
- **Send path**: no full window rebuild per send when the live tail is loaded (removes 2 round-trips and the biggest clobber window).
- **Read counters**: state ordering guard per proto contract (orderless snapshots could zero counters and kill the guard); read-receipt range no longer inverted when scrolling up; one consolidated range RPC instead of one per message per scroll frame, flushed on chat switch/unmount.
- **Stale subscriptions**: chat message subscriptions were never unsubscribed (teardown used a subId scheme the block never subscribed with). BlockChat now owns its subscription lifecycle (refcounted `retainSub`/`releaseSub` + `ChatUnsubscribe` on last release).
- **Hidden windows**: event flush was rAF-only; rAF pauses when the window is hidden/occluded, freezing notifications and the dock badge until restore. Added a backstop timer.
- **Send/upload robustness**: failed uploads abort the send with a toast (were silently dropped from the message); failed sends keep the composer text; attachments removed during an in-flight upload no longer resurrect into the message.
- **Misc**: deleted pinned messages leave the banner; rapid chat switches cancel stale init flows (scroll/state hijacking); grouping computed after sort.

## Verification
- `bun run typecheck`, ESLint clean; 19 unit tests for the new pure helpers (`chatWindow.test.ts`)
- 4 independent review passes (concurrency interleavings, behavioral regressions, style, performance) — all findings addressed