### PR TITLE
fix(chat): refresh tab title on space switch (JS-9828)

### DIFF
--- a/src/ts/component/page/main/chat.tsx
+++ b/src/ts/component/page/main/chat.tsx
@@ -74,6 +74,11 @@ const PageMainChat = forwardRef<I.PageRef, I.PageComponent>((props, ref) => {
 			headerRef.current?.forceUpdate();
 			chatRef.current?.getChildNode()?.forceUpdate();
 
+			// Chat-layout objects skip ObjectOpen, so the tab/window title is never refreshed via
+			// onObjectView the way other pages are. Refresh it here once the object's details load,
+			// otherwise the tab name keeps the previous space's title after a space switch (JS-9828).
+			keyboard.setWindowTitle();
+
 			Onboarding.startChat(isPopup);
 			setDummy(dummy + 1);
 			analytics.event('ScreenChat', { chatId: object.analyticsChatId });


### PR DESCRIPTION
## Problem
When using tabs, switching space (channel) in the vault didn't update the tab name — it only updated after opening a different object.

## Cause
Chat-layout objects skip `C.ObjectOpen` (their change-tree is the full message history), loading details via a lightweight `subscribeIds` instead. As a side effect the `onObjectView → keyboard.setWindowTitle()` retry never runs for chat pages, so the landing chat's initial `setWindowTitle()` no-ops (details not loaded yet) and nothing refreshes it afterward.

## Fix
Call `keyboard.setWindowTitle()` in the chat page's load callback, once details are available. Fires once per open (incl. every space switch); no ongoing overhead.

Closes JS-9828.