### PR TITLE
fix(dataview-sets-collections-views): cell click, paste-in-name, and board optimistic insert

### DIFF
--- a/src/ts/component/block/dataview.tsx
+++ b/src/ts/component/block/dataview.tsx
@@ -522,8 +522,11 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 			S.Detail.update(subId, { id: object.id, details: object }, true);
 
-			if (!isViewBoard && !isViewCalendar) {
-				let records = getRecords(groupId);
+			if (!isViewCalendar && (!isViewBoard || groupId)) {
+				// Board columns render from the group subscription record list as is:
+				// use the raw list, getRecords would apply the object order of the
+				// first matching group (JS-9747, JS-9764)
+				let records = isViewBoard ? [ ...S.Record.getRecordIds(subId, '') ] : getRecords(groupId);
 
 				const oldIndex = records.indexOf(message.objectId);
 
@@ -534,12 +537,30 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 					} else {
 						dir > 0 ? records.push(message.objectId) : records.unshift(message.objectId);
 					};
-				} else {	
+				} else {
 					const newIndex = idx >= 0 ? idx : (dir > 0 ? records.length : 0);
 					records = arrayMove(records, oldIndex, newIndex);
 				};
 
 				S.Record.recordsSet(subId, '', records);
+
+				// Insert the new record into the group's custom order (if any), so the
+				// card keeps its position and stays visible after the column
+				// re-subscribes with a limited window (JS-9747, JS-9764)
+				if (isViewBoard) {
+					const order = block.content.objectOrder.find(it => (it.viewId == view.id) && (it.groupId == groupId));
+					const objectIds = [ ...(order?.objectIds || []) ];
+
+					if (order && !objectIds.includes(message.objectId)) {
+						if (idx >= 0) {
+							objectIds.splice(idx, 0, message.objectId);
+						} else {
+							dir > 0 ? objectIds.push(message.objectId) : objectIds.unshift(message.objectId);
+						};
+
+						objectOrderUpdate([ { viewId: view.id, groupId, objectIds } ], records);
+					};
+				};
 			};
 
 			if (isCollection) {

--- a/src/ts/component/block/dataview.tsx
+++ b/src/ts/component/block/dataview.tsx
@@ -550,11 +550,12 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 					records = arrayMove(records, oldIndex, newIndex);
 				};
 
-				S.Record.recordsSet(subId, '', records);
-
 				// Insert the new record into the group's custom order (if any), so the
 				// card keeps its position and stays visible after the column
-				// re-subscribes with a limited window (JS-9747, JS-9764)
+				// re-subscribes with a limited window. The local order is updated
+				// optimistically before recordsSet triggers a re-render — otherwise
+				// applyObjectOrder sorts the unknown id to the top of the column
+				// until the RPC round-trip completes (JS-9747, JS-9764)
 				if (isViewBoard) {
 					const order = block.content.objectOrder.find(it => (it.viewId == view.id) && (it.groupId == groupId));
 					const objectIds = [ ...(order?.objectIds || []) ];
@@ -566,9 +567,12 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 							dir > 0 ? objectIds.push(message.objectId) : objectIds.unshift(message.objectId);
 						};
 
+						set(order, { objectIds });
 						objectOrderUpdate([ { viewId: view.id, groupId, objectIds } ], records);
 					};
 				};
+
+				S.Record.recordsSet(subId, '', records);
 			};
 
 			if (isCollection) {

--- a/src/ts/component/block/dataview.tsx
+++ b/src/ts/component/block/dataview.tsx
@@ -462,18 +462,26 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 	const recordCreate = (e: any, template: any, dir: number, groupId?: string, idx?: number) => {
 		const objectId = getObjectId();
-		const subId = getSubId(groupId);
 		const view = getView();
 
 		if (!view || isCreating.current) {
 			return;
 		};
 
-		const details = getDetails(groupId);
-		const flags: I.ObjectFlag[] = [ I.ObjectFlag.SelectTemplate ];
 		const isViewGraph = view.type == I.ViewType.Graph;
 		const isViewCalendar = view.type == I.ViewType.Calendar;
 		const isViewBoard = view.type == I.ViewType.Board;
+
+		// Board creation paths without an explicit group (toolbar New button,
+		// template menu) target the "empty" group like onRecordAdd does, so the
+		// optimistic insert below works for them as well (JS-9764)
+		if (isViewBoard && !groupId) {
+			groupId = 'empty';
+		};
+
+		const subId = getSubId(groupId);
+		const details = getDetails(groupId);
+		const flags: I.ObjectFlag[] = [ I.ObjectFlag.SelectTemplate ];
 
 		if (isCollection) {
 			details.createdInContext = objectId;
@@ -522,7 +530,7 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 			S.Detail.update(subId, { id: object.id, details: object }, true);
 
-			if (!isViewCalendar && (!isViewBoard || groupId)) {
+			if (!isViewCalendar) {
 				// Board columns render from the group subscription record list as is:
 				// use the raw list, getRecords would apply the object order of the
 				// first matching group (JS-9747, JS-9764)

--- a/src/ts/component/cell/index.tsx
+++ b/src/ts/component/cell/index.tsx
@@ -424,8 +424,15 @@ const Cell = forwardRef<I.CellRef, Props>((props, ref) => {
 			};
 
 			const swallow = (e: globalThis.MouseEvent) => {
-				e.preventDefault();
-				e.stopPropagation();
+				const target = e.target as HTMLElement;
+
+				// Only clicks landing on a cell are swallowed — clicks on menus
+				// and other UI pass through untouched
+				if (target.closest('.cell, .cellContent')) {
+					e.preventDefault();
+					e.stopPropagation();
+				};
+
 				clear();
 			};
 
@@ -438,7 +445,9 @@ const Cell = forwardRef<I.CellRef, Props>((props, ref) => {
 				const target = e.target as HTMLElement;
 
 				if (!target.closest(`#${U.Common.esc(cellId)}`) && !target.closest('.menus')) {
-					if (menuId && S.Menu.isOpenList(J.Menu.cell) && target.closest('.cell, .cellContent')) {
+					// Only a primary-button mousedown produces a follow-up click event —
+					// arming on other buttons would eat an unrelated later click
+					if (menuId && S.Menu.isOpenList(J.Menu.cell) && (e.button == 0) && target.closest('.cell, .cellContent')) {
 						swallowNextClick();
 					};
 

--- a/src/ts/component/cell/index.tsx
+++ b/src/ts/component/cell/index.tsx
@@ -412,11 +412,36 @@ const Cell = forwardRef<I.CellRef, Props>((props, ref) => {
 			return;
 		};
 
+		// Swallows the click that follows a menu-dismissing mousedown, so dismissing
+		// an open cell menu by clicking another cell only closes the menu instead of
+		// immediately opening that cell's editor (JS-8540)
+		const swallowNextClick = () => {
+			let timeout = 0;
+
+			const clear = () => {
+				window.clearTimeout(timeout);
+				U.Dom.removeEvent(window, 'click', swallow, true);
+			};
+
+			const swallow = (e: globalThis.MouseEvent) => {
+				e.preventDefault();
+				e.stopPropagation();
+				clear();
+			};
+
+			timeout = window.setTimeout(clear, 500);
+			U.Dom.addEvent(window, 'click', swallow, true);
+		};
+
 		const bindContainerClick = () => {
 			const handler = (e: any) => {
 				const target = e.target as HTMLElement;
 
 				if (!target.closest(`#${U.Common.esc(cellId)}`) && !target.closest('.menus')) {
+					if (menuId && S.Menu.isOpenList(J.Menu.cell) && target.closest('.cell, .cellContent')) {
+						swallowNextClick();
+					};
+
 					S.Menu.closeAll(J.Menu.cell);
 					setOff();
 

--- a/src/ts/component/cell/text.tsx
+++ b/src/ts/component/cell/text.tsx
@@ -37,16 +37,22 @@ const CellText = forwardRef<I.CellRef, I.Cell>((props, ref: any) => {
 	};
 
 	const onPaste = (e: any, v: any) => {
+		range.current = inputRef.current.getRange();
+
+		// Do not save immediately on paste: the resulting record update re-renders
+		// the cell and remounts the input mid-edit, blurring and closing the editor
+		// (JS-9181). The value is saved on blur/enter/unmount instead. Date cells
+		// keep the immediate save to sync the calendar menu with the parsed value.
 		if (isDate) {
 			v = fixDateValue(v);
-		};
+			setValue(v);
+			save(v);
 
-		range.current = inputRef.current.getRange();
-		setValue(v);
-		save(v);
-
-		if (isDate && !relation.includeTime) {
-			S.Menu.close('calendar');
+			if (!relation.includeTime) {
+				S.Menu.close('calendar');
+			};
+		} else {
+			setValue(v);
 		};
 	};
 

--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -368,6 +368,13 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 				return;
 			};
 
+			// A dataview cell is in inline edit mode (e.g. a newly created record's
+			// name box that has not received focus yet): the paste belongs to the
+			// cell input, not to the block editor (JS-9181)
+			if (U.Dom.select('.cell.isEditing, .cellContent.isEditing')) {
+				return;
+			};
+
 			// Paste replaces the cross-block text selection
 			const textSel = selection?.getTextSelection();
 			if (textSel) {


### PR DESCRIPTION
Fixes for the "Dataview - Sets, Collections & Views" area, reviewed for regressions before opening.

- [JS-8540](https://linear.app/anytype/issue/JS-8540) — Clicking another cell to dismiss an open property menu no longer also opens that cell for editing
- [JS-9181](https://linear.app/anytype/issue/JS-9181) — Pasting text into a newly created record’s name box no longer closes/un-focuses it
- [JS-9747](https://linear.app/anytype/issue/JS-9747) — Newly created board records now appear immediately, including via the toolbar/template-menu creation paths, and keep their position in manually ordered columns
- [JS-9764](https://linear.app/anytype/issue/JS-9764) — Newly created board records now appear immediately without needing a reload (note: The reported secondary symptom (toggling a checkbox/done relation doesn’t move the card to the other column until reload) is NOT covered by this fix and needs separate follow-up work.)