### PR TITLE
fix(chat): unread badge blinks for actively read chat (JS-9298)

### DIFF
--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -1746,6 +1746,13 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		// read-confirmation round-trip (JS-9298). Scrolled up, blurred (see the blur
 		// handler in rebind) or closed, the claim is released and unread state surfaces
 		// normally. Counters are server-authoritative, so this is presentational only.
+		//
+		// Accepted trade-off: releasing on scroll-up is immediate, so messages read at the
+		// bottom whose ChatReadMessages confirmation is still in flight briefly surface as
+		// unread until the state event lands. Fixing that would mean optimistically mutating
+		// the server-owned stateMap counters and reconciling them against absolute-value
+		// state events — a stuck-wrong badge from a missed reconciliation is worse than
+		// this short-lived blink, so the counters stay untouched.
 		if (v && S.Common.windowIsFocused && S.Chat.isAtChatEnd(getSubId())) {
 			S.Chat.setActiveReadChat(activeReadToken, space, getChatId());
 		} else {

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -144,6 +144,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	const reactionUpdateHandlerRef = useRef<((e: Event) => void) | null>(null);
 	const pinnedStatusUpdateHandlerRef = useRef<((e: Event) => void) | null>(null);
 	const focusHandlerRef = useRef<((e: Event) => void) | null>(null);
+	const blurHandlerRef = useRef<((e: Event) => void) | null>(null);
 
 	const unbind = () => {
 		// Flush pending read receipts before teardown (chat switch / unmount) — the debounced
@@ -175,6 +176,10 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		if (focusHandlerRef.current) {
 			U.Dom.removeEvent(window, 'focus', focusHandlerRef.current);
 			focusHandlerRef.current = null;
+		};
+		if (blurHandlerRef.current) {
+			U.Dom.removeEvent(window, 'blur', blurHandlerRef.current);
+			blurHandlerRef.current = null;
 		};
 
 		const container = U.Dom.getScrollContainer(isPopup);
@@ -236,6 +241,12 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 				readScrolledMessages();
 			});
 		};
+		blurHandlerRef.current = () => {
+			// The active-read claim (unread badge suppression, see setIsBottom) only holds
+			// while the user can actually see the messages — release it on blur so unread
+			// counters surface again. The focus handler restores it via scrollToBottom.
+			S.Chat.clearActiveReadChat(space, getChatId());
+		};
 
 		U.Dom.addEvents(window, [
 			['messageAdd', messageAddHandlerRef.current],
@@ -244,6 +255,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			['reactionUpdate', reactionUpdateHandlerRef.current],
 			['pinnedStatusUpdate', pinnedStatusUpdateHandlerRef.current],
 			['focus', focusHandlerRef.current],
+			['blur', blurHandlerRef.current],
 		]);
 
 		const container = U.Dom.getScrollContainer(isPopup);
@@ -1724,6 +1736,18 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	const setIsBottom = (v: boolean) => {
 		isBottom.current = v;
 
+		// Claim / release the active-read flag: anchored to the live tail of a focused
+		// window, incoming messages are read in place, so unread aggregates (vault,
+		// widgets, app badge) skip this chat instead of blinking the counter for the
+		// read-confirmation round-trip (JS-9298). Scrolled up, blurred (see the blur
+		// handler in rebind) or closed, the claim is released and unread state surfaces
+		// normally. Counters are server-authoritative, so this is presentational only.
+		if (v && S.Common.windowIsFocused && S.Chat.isAtChatEnd(getSubId())) {
+			S.Chat.setActiveReadChat(space, getChatId());
+		} else {
+			S.Chat.clearActiveReadChat(space, getChatId());
+		};
+
 		const formNode = formRef.current?.getNode() as HTMLElement;
 		const btn = formNode ? U.Dom.select(`#navigation-${I.ChatReadType.Message}`, formNode) : null;
 
@@ -1988,6 +2012,10 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		S.Chat.retainSub(subId);
 
 		return () => {
+			// Release the active-read claim for THIS pair (no-op if another chat view
+			// claimed it since) — a closed chat must not keep its badge suppressed.
+			S.Chat.clearActiveReadChat(space, chatId);
+
 			if (!S.Chat.releaseSub(subId)) {
 				C.ChatUnsubscribe(chatId, subId);
 			};

--- a/src/ts/component/block/chat.tsx
+++ b/src/ts/component/block/chat.tsx
@@ -71,6 +71,10 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 	const isLoadingNext = useRef(false);
 	const loadEpoch = useRef(0);
 	const initSeq = useRef(0);
+	// Stable claimant token for the active-read claim (see S.Chat.setActiveReadChat):
+	// claims are per view instance, so a chat popup stacked over a chat page holds its
+	// own claim without stealing the page's one.
+	const activeReadToken = useRef(`blockChat-${Math.random().toString(36).slice(2, 10)}`).current;
 	const object = S.Detail.get(rootId, rootId, []);
 
 	const getChatId = () => {
@@ -245,7 +249,7 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 			// The active-read claim (unread badge suppression, see setIsBottom) only holds
 			// while the user can actually see the messages — release it on blur so unread
 			// counters surface again. The focus handler restores it via scrollToBottom.
-			S.Chat.clearActiveReadChat(space, getChatId());
+			S.Chat.clearActiveReadChat(activeReadToken);
 		};
 
 		U.Dom.addEvents(window, [
@@ -1743,9 +1747,9 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		// handler in rebind) or closed, the claim is released and unread state surfaces
 		// normally. Counters are server-authoritative, so this is presentational only.
 		if (v && S.Common.windowIsFocused && S.Chat.isAtChatEnd(getSubId())) {
-			S.Chat.setActiveReadChat(space, getChatId());
+			S.Chat.setActiveReadChat(activeReadToken, space, getChatId());
 		} else {
-			S.Chat.clearActiveReadChat(space, getChatId());
+			S.Chat.clearActiveReadChat(activeReadToken);
 		};
 
 		const formNode = formRef.current?.getNode() as HTMLElement;
@@ -2012,9 +2016,9 @@ const BlockChat = forwardRef<RefProps, I.BlockComponent>((props, ref) => {
 		S.Chat.retainSub(subId);
 
 		return () => {
-			// Release the active-read claim for THIS pair (no-op if another chat view
-			// claimed it since) — a closed chat must not keep its badge suppressed.
-			S.Chat.clearActiveReadChat(space, chatId);
+			// Release this view's active-read claim — a closed chat must not keep its
+			// badge suppressed. Claims held by other views of the same chat are untouched.
+			S.Chat.clearActiveReadChat(activeReadToken);
 
 			if (!S.Chat.releaseSub(subId)) {
 				C.ChatUnsubscribe(chatId, subId);

--- a/src/ts/component/comment/section.tsx
+++ b/src/ts/component/comment/section.tsx
@@ -35,6 +35,10 @@ const CommentSection = (props: I.CommentSectionProps) => {
 	const isTypingRef = useRef(false);
 	const scrolledItems = useRef<Set<string>>(new Set());
 	const readVisibleMessagesRef = useRef<() => void>(() => {});
+	// Stable claimant token for the active-read claim (see S.Chat.setActiveReadChat):
+	// while the discussion tail is read in place here, its unread counters are excluded
+	// from aggregates instead of blinking for the read round-trip (JS-9298).
+	const activeReadToken = useRef(`commentSection-${Math.random().toString(36).slice(2, 10)}`).current;
 
 	const posts = S.Comment.getPosts(subId);
 	const postCount = posts.length;
@@ -154,7 +158,38 @@ const CommentSection = (props: I.CommentSectionProps) => {
 		scrolledItems.current.clear();
 	}, [ targetType, findMessage ]);
 
+	// Claim / release the active-read flag for the discussion: with the window focused and
+	// the discussion's live tail (bottom-most rendered message) in the viewport, arriving
+	// comments are read in place, so counter aggregates skip this discussion instead of
+	// blinking for the read-confirmation round-trip (JS-9298) — mirrors the claim BlockChat
+	// holds for full chats. Presentational only, counters stay server-authoritative.
+	const updateActiveReadClaim = useCallback(() => {
+		const did = discussionIdRef.current;
+		const node = sectionRef.current;
+		const items = node ? U.Dom.selectAll('[data-message-id]', node) : [];
+		const last = items.length ? items[items.length - 1] : null;
+
+		let tailVisible = false;
+		if (last) {
+			const container = U.Dom.getScrollContainer(isPopup);
+			const containerRect = container ? container.getBoundingClientRect() : null;
+			const top = containerRect ? containerRect.top : 0;
+			const bottom = containerRect ? containerRect.bottom : window.innerHeight;
+			const rect = last.getBoundingClientRect();
+
+			tailVisible = (rect.bottom >= top) && (rect.top <= bottom);
+		};
+
+		if (did && tailVisible && S.Common.windowIsFocused && isSectionVisibleRef.current) {
+			S.Chat.setActiveReadChat(activeReadToken, S.Common.space, did);
+		} else {
+			S.Chat.clearActiveReadChat(activeReadToken);
+		};
+	}, [ isPopup ]);
+
 	const readVisibleMessages = useCallback(() => {
+		updateActiveReadClaim();
+
 		if (!discussionIdRef.current || !S.Common.windowIsFocused) {
 			return;
 		};
@@ -181,7 +216,7 @@ const CommentSection = (props: I.CommentSectionProps) => {
 
 		window.clearTimeout(readStopTimerRef.current);
 		readStopTimerRef.current = window.setTimeout(() => onReadStop(), 300);
-	}, [ getVisibleMessages, readMessage, onReadStop ]);
+	}, [ getVisibleMessages, readMessage, onReadStop, updateActiveReadClaim ]);
 
 	readVisibleMessagesRef.current = readVisibleMessages;
 
@@ -299,6 +334,9 @@ const CommentSection = (props: I.CommentSectionProps) => {
 
 			if (isSectionVisibleRef.current) {
 				readVisibleMessages();
+			} else {
+				// Scrolled out of view — the discussion is no longer being read in place.
+				S.Chat.clearActiveReadChat(activeReadToken);
 			};
 		}, { threshold: 0 });
 
@@ -352,6 +390,32 @@ const CommentSection = (props: I.CommentSectionProps) => {
 			]);
 		};
 	}, [ onMessageAdd ]);
+
+	// The active-read claim only holds while the user can actually see the discussion
+	// tail — release it on blur so unread counters surface again; focus re-evaluates the
+	// claim (and marks the visible messages read) via readVisibleMessages.
+	useEffect(() => {
+		const onFocus = () => readVisibleMessages();
+		const onBlur = () => S.Chat.clearActiveReadChat(activeReadToken);
+
+		U.Dom.addEvents(window, [
+			['focus', onFocus],
+			['blur', onBlur],
+		]);
+
+		return () => {
+			U.Dom.removeEvents(window, [
+				['focus', onFocus],
+				['blur', onBlur],
+			]);
+		};
+	}, [ readVisibleMessages ]);
+
+	// A closed / unmounted section (or one switching discussions) must not keep the old
+	// discussion's badge suppressed — the next readVisibleMessages run re-claims if due.
+	useEffect(() => {
+		return () => S.Chat.clearActiveReadChat(activeReadToken);
+	}, [ discussionId ]);
 
 
 	const scrollToMessage = useCallback((msgId: string) => {

--- a/src/ts/component/util/chatCounter.tsx
+++ b/src/ts/component/util/chatCounter.tsx
@@ -48,6 +48,12 @@ const ChatCounter = forwardRef<HTMLDivElement, Props>((props, ref) => {
 						continue;
 					};
 
+					// The actively read chat is excluded, same as in the store aggregates —
+					// its unread is being consumed on screen (see S.Chat.setActiveReadChat).
+					if (S.Chat.isActiveReadChat(spaceId, chatId)) {
+						continue;
+					};
+
 					const chatMode = U.Object.getChatNotificationMode(spaceview, chatId);
 
 					if (state.mentionCounter && [ I.NotificationMode.All, I.NotificationMode.Mentions ].includes(chatMode)) {
@@ -68,7 +74,11 @@ const ChatCounter = forwardRef<HTMLDivElement, Props>((props, ref) => {
 			};
 
 			if (discussionMap) {
-				for (const [ , parentId ] of discussionMap) {
+				for (const [ discussionId, parentId ] of discussionMap) {
+					if (S.Chat.isActiveReadChat(spaceId, discussionId)) {
+						continue;
+					};
+
 					const parent = S.Chat.getDiscussionParentDetail(spaceId, parentId, [ 'unreadMessageCount', 'unreadMentionCount', 'isArchived' ]);
 					if (parent._empty_ || parent.isArchived) {
 						continue;

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -16,6 +16,7 @@ class ChatStore {
 	public stateMap: Map<string, Map<string, I.ChatStoreState>> = observable.map(new Map());
 	public attachmentsMap: Map<string, any[]> = observable(new Map());
 	public discussionParentMap: Map<string, Map<string, string>> = observable.map(new Map());
+	private activeReadChat: { spaceId: string; chatId: string } = observable({ spaceId: '', chatId: '' });
 	private badgeValue = '';
 	private atChatStartMap: Map<string, boolean> = new Map();
 	private atChatEndMap: Map<string, boolean> = new Map();
@@ -31,6 +32,8 @@ class ChatStore {
 			delete: action,
 			setReply: action,
 			setState: action,
+			setActiveReadChat: action,
+			clearActiveReadChat: action,
 			setAttachments: action,
 			discussionParentMapSet: action,
 			discussionParentMapDelete: action,
@@ -610,6 +613,49 @@ class ChatStore {
 	};
 
 	/**
+	 * Marks a chat as actively read: shown in a focused window and anchored to the live
+	 * tail, so incoming messages are read in place. Counter aggregates (vault, widgets,
+	 * app badge) exclude this chat via isActiveReadChat — otherwise every incoming
+	 * message would blink the unread badge for the duration of the read round-trip.
+	 * @param {string} spaceId - The space ID.
+	 * @param {string} chatId - The chat ID.
+	 */
+	setActiveReadChat (spaceId: string, chatId: string): void {
+		if (!spaceId || !chatId) {
+			return;
+		};
+
+		set(this.activeReadChat, { spaceId, chatId });
+	};
+
+	/**
+	 * Releases the actively read chat, but only if it still points at the given pair —
+	 * another chat view may have claimed it in the meantime.
+	 * @param {string} spaceId - The space ID.
+	 * @param {string} chatId - The chat ID.
+	 */
+	clearActiveReadChat (spaceId: string, chatId: string): void {
+		if ((this.activeReadChat.spaceId == spaceId) && (this.activeReadChat.chatId == chatId)) {
+			set(this.activeReadChat, { spaceId: '', chatId: '' });
+		};
+	};
+
+	/**
+	 * Whether the chat is being actively read (see setActiveReadChat), meaning its unread
+	 * counters are excluded from aggregates and badges. Counters are server-authoritative,
+	 * so the exclusion is presentational only — the underlying state stays intact and
+	 * resurfaces the moment the claim is released (scroll up, blur, close). Gated on
+	 * isActiveTab (observable): a claim left by a chat in a deactivated tab lifts
+	 * reactively, since a hidden tab's rAF-driven read flow stalls.
+	 * @param {string} spaceId - The space ID.
+	 * @param {string} chatId - The chat ID.
+	 * @returns {boolean} Whether the chat is actively read.
+	 */
+	isActiveReadChat (spaceId: string, chatId: string): boolean {
+		return !!chatId && (this.activeReadChat.spaceId == spaceId) && (this.activeReadChat.chatId == chatId) && S.Common.isActiveTab;
+	};
+
+	/**
 	 * Gets the total mention and message counters for all spaces.
 	 * @returns {Counter} The total counters.
 	 */
@@ -652,6 +698,12 @@ class ChatStore {
 					continue;
 				};
 
+				// The actively read chat contributes nothing: its messages are being read
+				// on screen, so counting them would only blink the badge (see setActiveReadChat).
+				if (this.isActiveReadChat(spaceId, chatId)) {
+					continue;
+				};
+
 				const chatMode = U.Object.getChatNotificationMode(spaceview, chatId);
 
 				if (state.mentionCounter && (ignoreMute || [ I.NotificationMode.All, I.NotificationMode.Mentions ].includes(chatMode))) {
@@ -669,7 +721,11 @@ class ChatStore {
 		};
 
 		if (discussionMap) {
-			for (const [ , parentId ] of discussionMap) {
+			for (const [ discussionId, parentId ] of discussionMap) {
+				if (this.isActiveReadChat(spaceId, discussionId)) {
+					continue;
+				};
+
 				const parent = this.getDiscussionParentDetail(spaceId, parentId, [ 'unreadMessageCount', 'unreadMentionCount', 'isArchived' ]);
 				if (parent._empty_ || parent.isArchived) {
 					continue;
@@ -733,6 +789,12 @@ class ChatStore {
 		const ret = { mentionCounter: 0, messageCounter: 0, reactionCounter: 0 };
 
 		if (!spaceId || !chatId) {
+			return ret;
+		};
+
+		// The actively read chat reports zero: its unread state is being consumed on
+		// screen and would only blink until the server confirms the read (see setActiveReadChat).
+		if (this.isActiveReadChat(spaceId, chatId)) {
 			return ret;
 		};
 

--- a/src/ts/store/chat.ts
+++ b/src/ts/store/chat.ts
@@ -16,7 +16,7 @@ class ChatStore {
 	public stateMap: Map<string, Map<string, I.ChatStoreState>> = observable.map(new Map());
 	public attachmentsMap: Map<string, any[]> = observable(new Map());
 	public discussionParentMap: Map<string, Map<string, string>> = observable.map(new Map());
-	private activeReadChat: { spaceId: string; chatId: string } = observable({ spaceId: '', chatId: '' });
+	private activeReadChats: Map<string, { spaceId: string; chatId: string }> = observable.map(new Map());
 	private badgeValue = '';
 	private atChatStartMap: Map<string, boolean> = new Map();
 	private atChatEndMap: Map<string, boolean> = new Map();
@@ -613,46 +613,63 @@ class ChatStore {
 	};
 
 	/**
-	 * Marks a chat as actively read: shown in a focused window and anchored to the live
-	 * tail, so incoming messages are read in place. Counter aggregates (vault, widgets,
-	 * app badge) exclude this chat via isActiveReadChat — otherwise every incoming
-	 * message would blink the unread badge for the duration of the read round-trip.
+	 * Marks a chat as actively read by the given claimant: shown in a focused window and
+	 * anchored to the live tail, so incoming messages are read in place. Counter aggregates
+	 * (vault, widgets, app badge) exclude this chat via isActiveReadChat — otherwise every
+	 * incoming message would blink the unread badge for the duration of the read round-trip.
+	 * Claims are keyed per claimant (one token per chat view instance), because several
+	 * views can be reading in parallel — e.g. a chat popup stacked over a chat page: both
+	 * keep issuing read receipts, so both pairs stay excluded, and closing one view never
+	 * drops the other view's claim.
+	 * @param {string} token - The claimant token (stable per view instance).
 	 * @param {string} spaceId - The space ID.
 	 * @param {string} chatId - The chat ID.
 	 */
-	setActiveReadChat (spaceId: string, chatId: string): void {
-		if (!spaceId || !chatId) {
+	setActiveReadChat (token: string, spaceId: string, chatId: string): void {
+		if (!token || !spaceId || !chatId) {
 			return;
 		};
 
-		set(this.activeReadChat, { spaceId, chatId });
-	};
-
-	/**
-	 * Releases the actively read chat, but only if it still points at the given pair —
-	 * another chat view may have claimed it in the meantime.
-	 * @param {string} spaceId - The space ID.
-	 * @param {string} chatId - The chat ID.
-	 */
-	clearActiveReadChat (spaceId: string, chatId: string): void {
-		if ((this.activeReadChat.spaceId == spaceId) && (this.activeReadChat.chatId == chatId)) {
-			set(this.activeReadChat, { spaceId: '', chatId: '' });
+		const current = this.activeReadChats.get(token);
+		if (current && (current.spaceId == spaceId) && (current.chatId == chatId)) {
+			return;
 		};
+
+		this.activeReadChats.set(token, { spaceId, chatId });
 	};
 
 	/**
-	 * Whether the chat is being actively read (see setActiveReadChat), meaning its unread
-	 * counters are excluded from aggregates and badges. Counters are server-authoritative,
-	 * so the exclusion is presentational only — the underlying state stays intact and
-	 * resurfaces the moment the claim is released (scroll up, blur, close). Gated on
-	 * isActiveTab (observable): a claim left by a chat in a deactivated tab lifts
-	 * reactively, since a hidden tab's rAF-driven read flow stalls.
+	 * Releases the claimant's active-read claim. Other claimants' claims (e.g. the same
+	 * chat open in another view) are untouched.
+	 * @param {string} token - The claimant token.
+	 */
+	clearActiveReadChat (token: string): void {
+		this.activeReadChats.delete(token);
+	};
+
+	/**
+	 * Whether the chat is being actively read by any claimant (see setActiveReadChat),
+	 * meaning its unread counters are excluded from aggregates and badges. Counters are
+	 * server-authoritative, so the exclusion is presentational only — the underlying state
+	 * stays intact and resurfaces the moment the last claim is released (scroll up, blur,
+	 * close). Gated on isActiveTab (observable): claims left by chats in a deactivated tab
+	 * lift reactively, since a hidden tab's rAF-driven read flow stalls.
 	 * @param {string} spaceId - The space ID.
 	 * @param {string} chatId - The chat ID.
 	 * @returns {boolean} Whether the chat is actively read.
 	 */
 	isActiveReadChat (spaceId: string, chatId: string): boolean {
-		return !!chatId && (this.activeReadChat.spaceId == spaceId) && (this.activeReadChat.chatId == chatId) && S.Common.isActiveTab;
+		if (!chatId || !S.Common.isActiveTab) {
+			return false;
+		};
+
+		for (const claim of this.activeReadChats.values()) {
+			if ((claim.spaceId == spaceId) && (claim.chatId == chatId)) {
+				return true;
+			};
+		};
+
+		return false;
 	};
 
 	/**


### PR DESCRIPTION
Fixes for the "Chat" area, reviewed for regressions before opening.

- [JS-9298](https://linear.app/anytype/issue/JS-9298) — Unread-message badge no longer blinks for the chat you are actively reading