### PR TITLE
fix(dataview-inline-board-layout): inline board width and horizontal scrollbar (JS-9714)

### DIFF
--- a/src/ts/component/block/dataview.tsx
+++ b/src/ts/component/block/dataview.tsx
@@ -473,7 +473,6 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 		const flags: I.ObjectFlag[] = [ I.ObjectFlag.SelectTemplate ];
 		const isViewGraph = view.type == I.ViewType.Graph;
 		const isViewCalendar = view.type == I.ViewType.Calendar;
-		const isViewBoard = view.type == I.ViewType.Board;
 
 		if (isCollection) {
 			details.createdInContext = objectId;
@@ -522,7 +521,7 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 			S.Detail.update(subId, { id: object.id, details: object }, true);
 
-			if (!isViewBoard && !isViewCalendar) {
+			if (!isViewCalendar) {
 				let records = getRecords(groupId);
 
 				const oldIndex = records.indexOf(message.objectId);

--- a/src/ts/component/block/dataview.tsx
+++ b/src/ts/component/block/dataview.tsx
@@ -473,6 +473,7 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 		const flags: I.ObjectFlag[] = [ I.ObjectFlag.SelectTemplate ];
 		const isViewGraph = view.type == I.ViewType.Graph;
 		const isViewCalendar = view.type == I.ViewType.Calendar;
+		const isViewBoard = view.type == I.ViewType.Board;
 
 		if (isCollection) {
 			details.createdInContext = objectId;
@@ -521,7 +522,7 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 			S.Detail.update(subId, { id: object.id, details: object }, true);
 
-			if (!isViewCalendar) {
+			if (!isViewBoard && !isViewCalendar) {
 				let records = getRecords(groupId);
 
 				const oldIndex = records.indexOf(message.objectId);
@@ -536,21 +537,6 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 				} else {
 					const newIndex = idx >= 0 ? idx : (dir > 0 ? records.length : 0);
 					records = arrayMove(records, oldIndex, newIndex);
-				};
-
-				// In manually ordered groups the render-time order sort would place an unknown
-				// id on top, so add it to the group order to keep the optimistic position
-				if (groupId) {
-					const order = block.content.objectOrder.find(it => (it.viewId == view.id) && (it.groupId == groupId));
-
-					if (order) {
-						const objectIds = order.objectIds || [];
-
-						if (!objectIds.includes(message.objectId)) {
-							dir > 0 ? objectIds.push(message.objectId) : objectIds.unshift(message.objectId);
-							order.objectIds = objectIds;
-						};
-					};
 				};
 
 				S.Record.recordsSet(subId, '', records);

--- a/src/ts/component/block/dataview.tsx
+++ b/src/ts/component/block/dataview.tsx
@@ -364,7 +364,7 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 		const subId = getSubId(groupId);
 		const records = S.Record.getRecordIds(subId, '');
 
-		return applyObjectOrder('', [ ...records ]);
+		return applyObjectOrder(groupId || '', [ ...records ]);
 	};
 
 	const getRecord = (id: string) => {
@@ -533,9 +533,24 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 					} else {
 						dir > 0 ? records.push(message.objectId) : records.unshift(message.objectId);
 					};
-				} else {	
+				} else {
 					const newIndex = idx >= 0 ? idx : (dir > 0 ? records.length : 0);
 					records = arrayMove(records, oldIndex, newIndex);
+				};
+
+				// In manually ordered groups the render-time order sort would place an unknown
+				// id on top, so add it to the group order to keep the optimistic position
+				if (groupId) {
+					const order = block.content.objectOrder.find(it => (it.viewId == view.id) && (it.groupId == groupId));
+
+					if (order) {
+						const objectIds = order.objectIds || [];
+
+						if (!objectIds.includes(message.objectId)) {
+							dir > 0 ? objectIds.push(message.objectId) : objectIds.unshift(message.objectId);
+							order.objectIds = objectIds;
+						};
+					};
 				};
 
 				S.Record.recordsSet(subId, '', records);

--- a/src/ts/component/block/dataview/view/board.tsx
+++ b/src/ts/component/block/dataview/view/board.tsx
@@ -17,7 +17,7 @@ const ViewBoard = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 	const cn = [ 'viewContent', className ];
 	const nodeRef = useRef(null);
 	const scrollRef = useRef(null);
-	const stickyScrollRef = useRef(null);
+	const stickyScrollRef = useRef<I.StickyScrollbarRef>(null);
 	const isSyncingScroll = useRef(false);
 	const hoverId = useRef('');
 	const newIndex = useRef(-1);

--- a/src/ts/component/block/dataview/view/board.tsx
+++ b/src/ts/component/block/dataview/view/board.tsx
@@ -11,7 +11,7 @@ const PADDING = 46;
 
 const ViewBoard = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 
-	const { rootId, block, getView, getTarget, className, onViewSettings, isInline, isPopup, readonly, objectOrderUpdate } = props;
+	const { rootId, block, getView, getTarget, className, onViewSettings, isInline, isPopup, readonly, objectOrderUpdate, getWrapperWidth } = props;
 	const view = getView();
 	const relation = S.Record.getRelationByKey(view.groupRelationKey);
 	const cn = [ 'viewContent', className ];
@@ -73,9 +73,7 @@ const ViewBoard = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 			U.Dom.addEvent(pageContainer, 'scroll', scrollViewHandlerRef.current);
 		};
 
-		if (!isInline) {
-			stickyScrollRef.current?.bind(scroll, isSyncingScroll.current);
-		};
+		stickyScrollRef.current?.bind(scroll, isSyncingScroll.current);
 	};
 
 	const unbind = () => {
@@ -660,16 +658,27 @@ const ViewBoard = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 			});
 		} else
 		if (parent && (parent.isPage() || parent.isLayoutDiv())) {
-			const wrapper = U.Dom.get('editorWrapper');
-			const ww = U.Dom.contentWidth(wrapper);
-			const margin = (cw - ww) / 2;
+			const wrapper = U.Dom.select('#editorWrapper', container);
+			const ww = getWrapperWidth ? getWrapperWidth() : U.Dom.contentWidth(wrapper);
+			const margin = Math.max(0, (cw - ww) / 2);
+			const vw = width + margin + 2;
 
 			if (scroll) {
 				U.Dom.css(scroll, { width: `${cw}px`, marginLeft: `${-margin}px`, paddingLeft: `${margin}px` });
 			};
 			if (viewEl) {
-				U.Dom.css(viewEl, { width: `${width + margin + 2}px` });
+				U.Dom.css(viewEl, { width: `${vw}px` });
 			};
+
+			stickyScrollRef.current?.resize({
+				width: ww,
+				left: 0,
+				paddingLeft: 0,
+				display: (vw + margin) <= cw ? 'none' : '',
+				trackWidth: vw,
+			});
+		} else {
+			stickyScrollRef.current?.resize({ display: 'none' });
 		};
 	};
 
@@ -717,7 +726,7 @@ const ViewBoard = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 					</div>
 				</div>
 			</div>
-			{!isInline ? <StickyScrollbar ref={stickyScrollRef} /> : ''}
+			<StickyScrollbar ref={stickyScrollRef} />
 		</div>
 	);	
 

--- a/src/ts/component/util/stickyScrollbar.tsx
+++ b/src/ts/component/util/stickyScrollbar.tsx
@@ -14,18 +14,22 @@ const StickyScrollbar = forwardRef<I.StickyScrollbarRef, Props>((props, ref) => 
 	const isSyncing = useRef(false);
 	const scrollHandler = useRef<(() => void) | null>(null);
 
+	const toPx = (v: any): any => {
+		return typeof v == 'number' ? `${v}px` : v;
+	};
+
 	const resize = (config) => {
 		if (!nodeRef.current || !trackRef.current) {
 			return;
 		};
 
 		U.Dom.css(nodeRef.current, {
-			width: config.width,
-			left: config.left,
-			paddingLeft: config.paddingLeft,
+			width: toPx(config.width),
+			left: toPx(config.left),
+			paddingLeft: toPx(config.paddingLeft),
 			display: config.display,
 		});
-		U.Dom.css(trackRef.current, { width: config.trackWidth });
+		U.Dom.css(trackRef.current, { width: toPx(config.trackWidth) });
 	};
 
 	const bind = (scrollElement, status) => {

--- a/src/ts/interface/block/dataview.ts
+++ b/src/ts/interface/block/dataview.ts
@@ -189,6 +189,7 @@ export interface ViewComponent {
 	getIdPrefix?(): string;
 	getLimit?(): number;
 	getVisibleRelations?(): I.ViewRelation[];
+	getWrapperWidth?(): number;
 	getTypeId?(): string;
 	getTemplateId?(): string;
 	getEmpty?(type: string): any;

--- a/src/ts/interface/common.ts
+++ b/src/ts/interface/common.ts
@@ -459,7 +459,7 @@ export interface ImageParam {
 };
 
 export interface StickyScrollbarRef {
-	resize: (config: { width: number; left: number; paddingLeft: number; display: string; trackWidth: number }) => void;
+	resize: (config: Partial<{ width: number; left: number; paddingLeft: number; display: string; trackWidth: number }>) => void;
 	bind: (element: HTMLElement, isSyncing: boolean) => void;
 	unbind: () => void;
 	sync: (element: HTMLElement, isSyncing: boolean) => boolean;


### PR DESCRIPTION
Fixes for the "Dataview - inline board layout" area, reviewed for regressions before opening.

- [JS-9714](https://linear.app/anytype/issue/JS-9714) — Inline Kanban board is no longer cut off at 200% layout width and now has a horizontal scrollbar when columns overflow (note: This PR covers the layout/scrollbar half. The "board doesn't show a new card until reload" half of this ticket is fixed by the companion Dataview PR for JS-9747/JS-9764.)