### PR TITLE
fix(editor-marks-markdown-parsing): fix inline code, IME, underscore emphasis, and dead-key marks

### DIFF
--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -110,6 +110,18 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 	}, []);
 
 	useEffect(() => {
+		// Never touch the editable DOM or its selection while an IME composition
+		// is in progress: replacing innerHTML or re-applying the (stale) focus
+		// range aborts the composition and commits the candidate text at the old
+		// caret position — e.g. wedged between the caret and an adjacent
+		// mention/object mark (JS-7510). Skip without updating prevTextRef /
+		// prevMarksRef so the store change is re-applied on the next render;
+		// onCompositionEnd reconciles value, marks and range once the
+		// composition settles.
+		if (keyboard.isComposition) {
+			return;
+		};
+
 		const { focused } = focus.state;
 		const textChanged = prevTextRef.current !== text;
 		const marksChanged = !U.Common.compareJSON(prevMarksRef.current, marks || []);

--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -307,7 +307,7 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 		return editableRef.current?.getRange();
 	};
 	
-	const getMarksFromHtml = (): { marks: I.Mark[], text: string } => {
+	const getMarksFromHtml = (): I.FromHtmlResult => {
 		let value = getHtmlValue();
 
 		// Strip phantom <br/> that was added to make trailing newlines visible in contenteditable
@@ -1633,6 +1633,32 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 		};
 
 		setValue(v, r);
+
+		// Dead-key layouts commit markdown symbols (e.g. the closing backtick)
+		// through an IME composition, so the keyup-driven markdown conversion can
+		// miss the commit or run with a stale focus range. Re-run the conversion
+		// on the settled value, using the fresh composition range for the caret
+		// math (JS-9071)
+		if (block.canHaveMarks() && r) {
+			const parsed = getMarksFromHtml();
+
+			marksRef.current = parsed.marks;
+
+			if (parsed.adjustMarks || (parsed.text != v)) {
+				const diff = v.length - parsed.text.length;
+				const next = { from: Math.max(0, r.from - diff), to: Math.max(0, r.to - diff) };
+
+				setValue(parsed.text, next);
+				focus.set(block.id, next);
+
+				// Move the caret past the trailing ZWS anchor so continued typing
+				// stays unformatted (same as the keyup conversion path)
+				const editable = U.Dom.select('.editable', editableRef.current?.getNode());
+				if (editable) {
+					Mark.escapeMarkBoundary(editable);
+				};
+			};
+		};
 	};
 
 	const onBeforeInput = (e: any) => {

--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -110,19 +110,21 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 	}, []);
 
 	useEffect(() => {
-		// Never touch the editable DOM or its selection while an IME composition
-		// is in progress: replacing innerHTML or re-applying the (stale) focus
-		// range aborts the composition and commits the candidate text at the old
-		// caret position — e.g. wedged between the caret and an adjacent
-		// mention/object mark (JS-7510). Skip without updating prevTextRef /
-		// prevMarksRef so the store change is re-applied on the next render;
-		// onCompositionEnd reconciles value, marks and range once the
-		// composition settles.
-		if (keyboard.isComposition) {
+		const { focused } = focus.state;
+
+		// Never touch the composing editable's DOM or its selection while an IME
+		// composition is in progress: replacing innerHTML or re-applying the
+		// (stale) focus range aborts the composition and commits the candidate
+		// text at the old caret position — e.g. wedged between the caret and an
+		// adjacent mention/object mark (JS-7510). Scoped to the focused block so
+		// a composition elsewhere (chat input, search filter) doesn't stop other
+		// visible blocks from syncing store updates to their DOM. Skip without
+		// updating prevTextRef / prevMarksRef so the store change is re-applied
+		// on the next render; onCompositionEnd reconciles value, marks and range
+		// once the composition settles.
+		if (keyboard.isComposition && (focused == block.id)) {
 			return;
 		};
-
-		const { focused } = focus.state;
 		const textChanged = prevTextRef.current !== text;
 		const marksChanged = !U.Common.compareJSON(prevMarksRef.current, marks || []);
 

--- a/src/ts/lib/mark.test.ts
+++ b/src/ts/lib/mark.test.ts
@@ -528,6 +528,42 @@ describe('Mark', () => {
 			expect(result.marks).toHaveLength(1);
 			expect(result.marks[0].type).toBe(I.MarkType.Italic);
 		});
+
+		it('should convert a plain backtick code span', () => {
+			const result = Mark.fromMarkdown('Hello `World`', [], [], false, false);
+
+			expect(result.text).toBe('Hello World');
+			expect(result.marks).toHaveLength(1);
+			expect(result.marks[0].type).toBe(I.MarkType.Code);
+			expect(result.marks[0].range).toEqual({ from: 6, to: 11 });
+		});
+
+		it('should keep a leading space inside backticks out of the code mark (JS-9071)', () => {
+			// Dead-key layouts can commit the space next to the backtick inside the span
+			const result = Mark.fromMarkdown('Hello ` World`', [], [], false, false);
+
+			expect(result.text).toBe('Hello  World');
+			expect(result.marks).toHaveLength(1);
+			expect(result.marks[0].type).toBe(I.MarkType.Code);
+			expect(result.marks[0].range).toEqual({ from: 7, to: 12 });
+		});
+
+		it('should keep a leading nbsp inside backticks out of the code mark (JS-9071)', () => {
+			const result = Mark.fromMarkdown('Hello `\u00A0World`', [], [], false, false);
+
+			expect(result.marks).toHaveLength(1);
+			expect(result.marks[0].type).toBe(I.MarkType.Code);
+			expect(result.marks[0].range).toEqual({ from: 7, to: 12 });
+		});
+
+		it('should convert a code span after an nbsp boundary (JS-9071)', () => {
+			const result = Mark.fromMarkdown('Hello\u00A0`World`', [], [], false, false);
+
+			expect(result.text).toBe('Hello\u00A0World');
+			expect(result.marks).toHaveLength(1);
+			expect(result.marks[0].type).toBe(I.MarkType.Code);
+			expect(result.marks[0].range).toEqual({ from: 6, to: 11 });
+		});
 	});
 
 	describe('fromHtml', () => {

--- a/src/ts/lib/mark.test.ts
+++ b/src/ts/lib/mark.test.ts
@@ -597,6 +597,25 @@ describe('Mark', () => {
 			expect(result.marks).toHaveLength(0);
 		});
 
+		it('should not let a kept literal </a> shadow a later real closing </a> (JS-7238)', () => {
+			const result = Mark.fromHtml('hi &lt;/a&gt; <a href="u" class="markuplink" data-param="u" data-range="8-12">link</a> end', []);
+
+			expect(result.text).toBe('hi </a> link end');
+			expect(result.marks).toHaveLength(1);
+			expect(result.marks[0].type).toBe(I.MarkType.Link);
+			expect(result.marks[0].param).toBe('u');
+			expect(result.marks[0].range).toEqual({ from: 8, to: 12 });
+		});
+
+		it('should not let a kept literal <a> shadow a later real link opening (JS-7238)', () => {
+			const result = Mark.fromHtml('&lt;a&gt; <a href="u" class="markuplink" data-param="u" data-range="4-8">link</a>', []);
+
+			expect(result.text).toBe('<a> link');
+			expect(result.marks).toHaveLength(1);
+			expect(result.marks[0].type).toBe(I.MarkType.Link);
+			expect(result.marks[0].range).toEqual({ from: 4, to: 8 });
+		});
+
 		it('should still parse real link markup with data-param (JS-7238)', () => {
 			const result = Mark.fromHtml('<a href="https://x.com" class="markuplink" data-param="https://x.com" data-range="0-4">link</a>', []);
 

--- a/src/ts/lib/mark.test.ts
+++ b/src/ts/lib/mark.test.ts
@@ -478,6 +478,58 @@ describe('Mark', () => {
 		});
 	});
 
+	describe('fromMarkdown', () => {
+		it('should not italicize intra-word underscores like _physics_process() (JS-7786)', () => {
+			const result = Mark.fromMarkdown('tilde _physics_process() tilde', [], [], false, false);
+
+			expect(result.text).toBe('tilde _physics_process() tilde');
+			expect(result.marks).toHaveLength(0);
+		});
+
+		it('should not italicize across a code-marked snake_case identifier (JS-7786)', () => {
+			// First snippet already converted to a Code mark, second one still being typed
+			const text = 'tilde _progress() tilde and `_physics_';
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Code, range: { from: 6, to: 17 }, param: '' },
+			];
+
+			const result = Mark.fromMarkdown(text, marks, [], false, false);
+
+			expect(result.text).toBe(text);
+			expect(result.marks).toEqual(marks);
+		});
+
+		it('should still convert _italic_ followed by a boundary', () => {
+			const result = Mark.fromMarkdown('word _italic_ word', [], [], false, false);
+
+			expect(result.text).toBe('word italic word');
+			expect(result.marks).toHaveLength(1);
+			expect(result.marks[0].type).toBe(I.MarkType.Italic);
+			expect(result.marks[0].range).toEqual({ from: 5, to: 11 });
+		});
+
+		it('should still convert _italic_ followed by punctuation', () => {
+			const result = Mark.fromMarkdown('word _italic_, word', [], [], false, false);
+
+			expect(result.marks).toHaveLength(1);
+			expect(result.marks[0].type).toBe(I.MarkType.Italic);
+		});
+
+		it('should not bold intra-word double underscores (JS-7786)', () => {
+			const result = Mark.fromMarkdown('name __dunder__method here', [], [], false, false);
+
+			expect(result.text).toBe('name __dunder__method here');
+			expect(result.marks).toHaveLength(0);
+		});
+
+		it('should still convert *italic* with asterisks', () => {
+			const result = Mark.fromMarkdown('word *italic* word', [], [], false, false);
+
+			expect(result.marks).toHaveLength(1);
+			expect(result.marks[0].type).toBe(I.MarkType.Italic);
+		});
+	});
+
 	describe('fromHtml', () => {
 		it('should keep user-typed <a> as literal text (JS-7238)', () => {
 			const result = Mark.fromHtml('typed &lt;a&gt; tag', []);

--- a/src/ts/lib/mark.test.ts
+++ b/src/ts/lib/mark.test.ts
@@ -154,6 +154,28 @@ describe('Mark', () => {
 
 			expect(adjusted[0].range.from).toBe(0);
 		});
+
+		it('should push a mention fully right when text is inserted exactly at its start (JS-7510)', () => {
+			// IME commit in front of an @-reference: the committed text is placed
+			// at the caret and the object mark must shift right by the full diff
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Mention, range: { from: 5, to: 6 }, param: 'objectId' },
+			];
+
+			const adjusted = Mark.adjust(marks, 5, 2);
+
+			expect(adjusted[0].range).toEqual({ from: 7, to: 8 });
+		});
+
+		it('should not move a mention when text is inserted exactly at its end (JS-7510)', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Mention, range: { from: 5, to: 6 }, param: 'objectId' },
+			];
+
+			const adjusted = Mark.adjust(marks, 6, 2);
+
+			expect(adjusted[0].range).toEqual({ from: 5, to: 6 });
+		});
 	});
 
 	describe('checkRanges', () => {

--- a/src/ts/lib/mark.test.ts
+++ b/src/ts/lib/mark.test.ts
@@ -1,6 +1,37 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import Mark from './mark';
 import * as I from 'Interface';
+import { U, S } from 'Lib';
+
+beforeAll(() => {
+	const g = globalThis as any;
+	const u = U as any;
+
+	// mark.ts uses auto-imported globals (U, S) that the vite plugin injects at
+	// build time — expose the mocked Lib barrel on globalThis for the tests
+	g.U = U;
+	g.S = S;
+
+	// Realistic entity decoding (the Lib mock stubs it as identity)
+	u.String.fromHtmlSpecialChars = (s: string) => {
+		return String(s || '').replace(/(&lt;|&gt;|&amp;)/g, (m: string, p: string) => {
+			if (p == '&lt;') p = '<';
+			if (p == '&gt;') p = '>';
+			if (p == '&amp;') p = '&';
+			return p;
+		});
+	};
+
+	// Minimal DOM plumbing so cleanHtml/fromHtml can run in the node environment
+	u.Dom = {
+		select: () => null,
+		selectAll: () => [],
+	};
+
+	g.document = {
+		createElement: () => ({ innerHTML: '' }),
+	};
+});
 
 describe('Mark', () => {
 
@@ -422,6 +453,48 @@ describe('Mark', () => {
 
 			expect(result.text).toBe(' world');
 			expect(result.marks).toHaveLength(0);
+		});
+	});
+
+	describe('fromHtml', () => {
+		it('should keep user-typed <a> as literal text (JS-7238)', () => {
+			const result = Mark.fromHtml('typed &lt;a&gt; tag', []);
+
+			expect(result.text).toBe('typed <a> tag');
+			expect(result.marks).toHaveLength(0);
+		});
+
+		it('should keep user-typed <a> inside inline code (JS-7238)', () => {
+			const result = Mark.fromHtml('<markupcode spellcheck="false">&lt;a&gt;</markupcode>', []);
+
+			expect(result.text).toBe('<a>');
+			expect(result.marks).toHaveLength(1);
+			expect(result.marks[0].type).toBe(I.MarkType.Code);
+			expect(result.marks[0].range).toEqual({ from: 0, to: 3 });
+		});
+
+		it('should keep user-typed <area> as literal text (JS-7238)', () => {
+			const result = Mark.fromHtml('&lt;area&gt;', []);
+
+			expect(result.text).toBe('<area>');
+			expect(result.marks).toHaveLength(0);
+		});
+
+		it('should keep user-typed closing </a> as literal text (JS-7238)', () => {
+			const result = Mark.fromHtml('hello &lt;/a&gt; world', []);
+
+			expect(result.text).toBe('hello </a> world');
+			expect(result.marks).toHaveLength(0);
+		});
+
+		it('should still parse real link markup with data-param (JS-7238)', () => {
+			const result = Mark.fromHtml('<a href="https://x.com" class="markuplink" data-param="https://x.com" data-range="0-4">link</a>', []);
+
+			expect(result.text).toBe('link');
+			expect(result.marks).toHaveLength(1);
+			expect(result.marks[0].type).toBe(I.MarkType.Link);
+			expect(result.marks[0].param).toBe('https://x.com');
+			expect(result.marks[0].range).toEqual({ from: 0, to: 4 });
 		});
 	});
 

--- a/src/ts/lib/mark.test.ts
+++ b/src/ts/lib/mark.test.ts
@@ -522,6 +522,34 @@ describe('Mark', () => {
 			expect(result.marks).toHaveLength(0);
 		});
 
+		it('should not italicize intra-word underscores in Cyrillic text (JS-7786)', () => {
+			const result = Mark.fromMarkdown('слово _физика_процесс конец', [], [], false, false);
+
+			expect(result.text).toBe('слово _физика_процесс конец');
+			expect(result.marks).toHaveLength(0);
+		});
+
+		it('should not italicize underscores opened right after a non-Latin letter (JS-7786)', () => {
+			const result = Mark.fromMarkdown('слово_физика_ конец', [], [], false, false);
+
+			expect(result.text).toBe('слово_физика_ конец');
+			expect(result.marks).toHaveLength(0);
+		});
+
+		it('should not bold intra-word double underscores in Cyrillic text (JS-7786)', () => {
+			const result = Mark.fromMarkdown('слово __жирный__метод конец', [], [], false, false);
+
+			expect(result.text).toBe('слово __жирный__метод конец');
+			expect(result.marks).toHaveLength(0);
+		});
+
+		it('should still convert _курсив_ at word boundaries in Cyrillic text', () => {
+			const result = Mark.fromMarkdown('слово _курсив_ конец', [], [], false, false);
+
+			expect(result.marks).toHaveLength(1);
+			expect(result.marks[0].type).toBe(I.MarkType.Italic);
+		});
+
 		it('should still convert *italic* with asterisks', () => {
 			const result = Mark.fromMarkdown('word *italic* word', [], [], false, false);
 

--- a/src/ts/lib/mark.ts
+++ b/src/ts/lib/mark.ts
@@ -668,7 +668,10 @@ class Mark {
 	 * @returns {I.FromHtmlResult} The parsed result.
 	 */
 	fromMarkdown(html: string, marks: I.Mark[], restricted: I.MarkType[], adjustMarks: boolean, updatedValue: boolean): I.FromHtmlResult {
-		const reg1 = /(^|[\s\(\[\{]|[^\x00-\x7F])(`[^`]+`|\*\*[^*]+\*\*|__[^_]+__|\*[^*]+\*|_[^_]+_|~~[^~]+~~|\[[^\]]+\]\([^\)]+\)\s|$)/;
+		// Underscore emphasis requires a word boundary after the closing _/__ so
+		// identifiers like _physics_process() or code spans containing snake_case
+		// never get italicized/bolded mid-word (JS-7786)
+		const reg1 = /(^|[\s\(\[\{]|[^\x00-\x7F])(`[^`]+`|\*\*[^*]+\*\*|__[^_]+__(?![0-9A-Za-z_])|\*[^*]+\*|_[^_]+_(?![0-9A-Za-z_])|~~[^~]+~~|\[[^\]]+\]\([^\)]+\)\s|$)/;
 		const reg2 = /^(`{1}|\*+|_+|\[|~{2})/;
 		const test = reg1.test(html);
 		const checked = marks.filter(it => [I.MarkType.Code].includes(it.type));

--- a/src/ts/lib/mark.ts
+++ b/src/ts/lib/mark.ts
@@ -600,17 +600,31 @@ class Mark {
 		text = U.String.fromHtmlSpecialChars(text);
 
 		const newHtml = text;
+
+		// Tags are processed in scan order and stripping only ever shortens the
+		// part of `text` after the previous occurrence, so the occurrence that
+		// belongs to the current match always sits at or after searchFrom.
+		// Searching from there — and advancing past kept literals — keeps
+		// identical strings (e.g. a kept user-typed </a> before a real closing
+		// </a>) from shadowing each other and corrupting offsets (JS-7238)
+		let searchFrom = 0;
+
 		newHtml.replace(rh, (s: string, p1: string, p2: string, p3: string) => {
 			p1 = String(p1 || '').trim();
 			p2 = String(p2 || '').trim();
 			p3 = String(p3 || '').trim();
 
 			const end = p1 == '/';
-			const offset = Number(text.indexOf(s)) || 0;
+			const offset = text.indexOf(s, searchFrom);
+
+			if (offset < 0) {
+				return '';
+			};
 
 			const key = U.Common.getKeyByValue(Tags, p2);
 			if (undefined === key) {
-				return;
+				searchFrom = offset + s.length;
+				return '';
 			};
 
 			const type = Number(key) as I.MarkType;
@@ -630,7 +644,8 @@ class Mark {
 				// A closing </a> without a matching link markup opening is user-typed
 				// literal text — keep it instead of stripping it (JS-7238)
 				if (!found && (type == I.MarkType.Link)) {
-					return;
+					searchFrom = offset + s.length;
+					return '';
 				};
 			} else {
 				const pm = p3.match(rp);
@@ -640,7 +655,8 @@ class Mark {
 				// <a>/<a ...> is user-typed literal text (e.g. inside inline code) —
 				// keep it instead of swallowing it as a Link mark (JS-7238)
 				if ((type == I.MarkType.Link) && !param) {
-					return;
+					searchFrom = offset + s.length;
+					return '';
 				};
 
 				marks.push({
@@ -650,7 +666,10 @@ class Mark {
 				});
 			};
 
-			text = text.replace(s, '');
+			// Strip exactly the occurrence at offset (not the first match of an
+			// identical string elsewhere in the text)
+			text = text.slice(0, offset) + text.slice(offset + s.length);
+			searchFrom = offset;
 			return '';
 		});
 

--- a/src/ts/lib/mark.ts
+++ b/src/ts/lib/mark.ts
@@ -687,10 +687,11 @@ class Mark {
 	 * @returns {I.FromHtmlResult} The parsed result.
 	 */
 	fromMarkdown(html: string, marks: I.Mark[], restricted: I.MarkType[], adjustMarks: boolean, updatedValue: boolean): I.FromHtmlResult {
-		// Underscore emphasis requires a word boundary after the closing _/__ so
-		// identifiers like _physics_process() or code spans containing snake_case
-		// never get italicized/bolded mid-word (JS-7786)
-		const reg1 = /(^|[\s\(\[\{]|[^\x00-\x7F])(`[^`]+`|\*\*[^*]+\*\*|__[^_]+__(?![0-9A-Za-z_])|\*[^*]+\*|_[^_]+_(?![0-9A-Za-z_])|~~[^~]+~~|\[[^\]]+\]\([^\)]+\)\s|$)/;
+		// Underscore emphasis requires a Unicode word boundary on both sides of
+		// the _/__ pair so identifiers like _physics_process() and non-Latin
+		// text like слово_физика_процесс never get italicized/bolded mid-word
+		// (JS-7786). Asterisks intentionally stay intra-word (CommonMark rule)
+		const reg1 = /(^|[\s\(\[\{]|[^\x00-\x7F])(`[^`]+`|\*\*[^*]+\*\*|(?<![\p{L}\p{N}_])__[^_]+__(?![\p{L}\p{N}_])|\*[^*]+\*|(?<![\p{L}\p{N}_])_[^_]+_(?![\p{L}\p{N}_])|~~[^~]+~~|\[[^\]]+\]\([^\)]+\)\s|$)/u;
 		const reg2 = /^(`{1}|\*+|_+|\[|~{2})/;
 		const test = reg1.test(html);
 		const checked = marks.filter(it => [I.MarkType.Code].includes(it.type));

--- a/src/ts/lib/mark.ts
+++ b/src/ts/lib/mark.ts
@@ -616,16 +616,32 @@ class Mark {
 			const type = Number(key) as I.MarkType;
 
 			if (end) {
+				let found = false;
+
 				for (let i = 0; i < marks.length; ++i) {
 					const m = marks[i];
 					if ((m.type == type) && !m.range.to) {
 						marks[i].range.to = offset;
+						found = true;
 						break;
 					};
+				};
+
+				// A closing </a> without a matching link markup opening is user-typed
+				// literal text — keep it instead of stripping it (JS-7238)
+				if (!found && (type == I.MarkType.Link)) {
+					return;
 				};
 			} else {
 				const pm = p3.match(rp);
 				const param = pm ? pm[1] : '';
+
+				// Link markup rendered by toHtml always carries data-param, so a bare
+				// <a>/<a ...> is user-typed literal text (e.g. inside inline code) —
+				// keep it instead of swallowing it as a Link mark (JS-7238)
+				if ((type == I.MarkType.Link) && !param) {
+					return;
+				};
 
 				marks.push({
 					type,


### PR DESCRIPTION
Fixes for the "Editor - marks & markdown parsing" area, reviewed for regressions before opening.

- [JS-7238](https://linear.app/anytype/issue/JS-7238) — Typed `<a>` tags inside inline code no longer get corrupted/stripped
- [JS-9196](https://linear.app/anytype/issue/JS-9196) — Typed `<a>`/`</a>` text no longer gets silently deleted as a stray link-mark tag (same root cause as JS-7238, same fix)
- [JS-7510](https://linear.app/anytype/issue/JS-7510) — IME composition no longer commits text at the wrong position next to an @-mention
- [JS-7786](https://linear.app/anytype/issue/JS-7786) — Underscores inside code spans (e.g. `_physics_process()`) no longer get italicized
- [JS-9071](https://linear.app/anytype/issue/JS-9071) — Backtick code formatting on dead-key/international keyboard layouts no longer includes a leading space
- [JS-8467](https://linear.app/anytype/issue/JS-8467) — not fixed here, needs an anytype-heart change (see ticket comment)