### PR TITLE
fix(editor-toggle-keyboard-access-block-menu-paste): keyboard access, paste target, and toggle child preservation

### DIFF
--- a/src/ts/component/block/index.tsx
+++ b/src/ts/component/block/index.tsx
@@ -204,9 +204,11 @@ const Block = forwardRef<Ref, Props>((props, ref) => {
 				};
 			};
 
+			// The focus range describes the caret in whichever block holds it — forward it only when
+			// that is this block, otherwise menu actions (e.g. paste) would land at a foreign offset (JS-8598)
 			menuOpen({
 				rect: { x: keyboard.mouse.page.x, y: keyboard.mouse.page.y, width: 0, height: 0 },
-				data: { range: U.Common.objectCopy(range) },
+				data: { range: (focused == block.id) ? U.Common.objectCopy(range) : null },
 			});
 		});
 	};

--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -43,6 +43,9 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 	const isEnterProcessing = useRef(false);
 	const scrollHandlerRef = useRef<(() => void) | null>(null);
 	const windowHandlersRef = useRef<Map<string, (e: any) => void>>(new Map());
+	const blocksResizeObserver = useRef<ResizeObserver | null>(null);
+	const blocksResizeTarget = useRef<Element | null>(null);
+	const resizePageRef = useRef<(callBack?: () => void) => void>(null);
 
 	useEffect(() => {
 		open();
@@ -52,6 +55,10 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 			close();
 
 			focus.clear(false);
+
+			blocksResizeObserver.current?.disconnect();
+			blocksResizeObserver.current = null;
+			blocksResizeTarget.current = null;
 
 			raf.cancel(frameMove.current);
 			raf.cancel(frameResize.current);
@@ -69,6 +76,8 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 	}, [ rootId ]);
 
 	useEffect(() => {
+		resizePageRef.current = resizePage;
+
 		if (!root) {
 			return;
 		};
@@ -94,6 +103,22 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 		container.current = U.Dom.select('.editor', node);
 		buttonAdd.current = U.Dom.select('#button-block-add', node);
 		blockFeatured.current = U.Dom.select(`#block-${U.Common.esc(J.Constant.blockId.featured)}`, node);
+
+		// Recompute the trailing #blockLast filler when the content height changes without a
+		// page re-render — e.g. dataview records loading or being added in an inline set —
+		// otherwise a stale filler leaves extra space and scroll length at the bottom (JS-8898).
+		// #blockLast sits outside .blocks, so resizing it does not re-trigger the observer
+		const blocks = U.Dom.select('.blocks', node);
+
+		if (blocks && (blocksResizeTarget.current !== blocks)) {
+			if (!blocksResizeObserver.current) {
+				blocksResizeObserver.current = new ResizeObserver(() => resizePageRef.current?.());
+			};
+
+			blocksResizeObserver.current.disconnect();
+			blocksResizeObserver.current.observe(blocks);
+			blocksResizeTarget.current = blocks;
+		};
 	};
 
 	// Sizes the trailing #blockLast filler so the document is tall enough for a

--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -1892,6 +1892,24 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 			return;
 		};
 
+		// Moving down from an open empty toggle header materializes the first child, mirroring click on the placeholder
+		if (
+			(dir > 0) &&
+			!readonly &&
+			block.canToggle() &&
+			Storage.checkToggle(rootId, block.id) &&
+			!S.Block.getChildrenIds(rootId, block.id).length
+		) {
+			e.preventDefault();
+
+			C.BlockCreate(rootId, block.id, I.BlockPosition.Inner, { type: I.BlockType.Text }, (message: any) => {
+				if (!message.error.code) {
+					focusSet(message.blockId, 0, 0, true);
+				};
+			});
+			return;
+		};
+
 		let next: I.Block = null;
 
 		const cb = () => {
@@ -2597,6 +2615,20 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 		const { rootId } = props;
 		let next = S.Block.getNextBlock(rootId, focused.id, dir, it => it.isFocusable());
 		if (!next) {
+			return;
+		};
+
+		// When backspacing below an open empty toggle, move the block inside it instead of merging into the header
+		if (
+			(dir < 0) &&
+			next.canToggle() &&
+			Storage.checkToggle(rootId, next.id) &&
+			!S.Block.getChildrenIds(rootId, next.id).length &&
+			focused.isIndentable()
+		) {
+			Action.move(rootId, rootId, next.id, [ focused.id ], I.BlockPosition.Inner, () => {
+				focus.setWithTimeout(focused.id, { from: 0, to: 0 }, 50);
+			});
 			return;
 		};
 

--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -2669,6 +2669,30 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 			};
 		};
 
+		// Backspace on an empty first child of a toggle: when the toggle has more children,
+		// delete the empty block and keep the caret inside on the next child instead of
+		// merging into the toggle header
+		if ((dir < 0) && !length) {
+			const parent = S.Block.getParentLeaf(rootId, focused.id);
+
+			if (parent && parent.canToggle() && (next.id == parent.id)) {
+				const childrenIds = S.Block.getChildrenIds(rootId, parent.id);
+				const idx = childrenIds.indexOf(focused.id);
+				const nextChild = childrenIds.slice(idx + 1).map(id => S.Block.getLeaf(rootId, id)).find(it => it && it.isFocusable());
+
+				if (nextChild) {
+					focus.clear(true);
+					C.BlockListDelete(rootId, [ focused.id ], (message: any) => {
+						if (!message.error.code) {
+							focusSet(nextChild.id, 0, 0, true);
+							analytics.event('DeleteBlock', { count: 1 });
+						};
+					});
+					return;
+				};
+			};
+		};
+
 		// When deleting at end of a closed toggle, skip its descendants
 		if ((dir > 0) && focused.canToggle() && !Storage.checkToggle(rootId, focused.id)) {
 			next = S.Block.getNextBlock(rootId, focused.id, dir, it => {

--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -46,6 +46,8 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 	const blocksResizeObserver = useRef<ResizeObserver | null>(null);
 	const blocksResizeTarget = useRef<Element | null>(null);
 	const resizePageRef = useRef<(callBack?: () => void) => void>(null);
+	// Block materialized by arrow-entry into an open empty toggle (JS-8420) — ephemeral until the user interacts with it
+	const emptyToggleEntry = useRef({ pending: false, blockId: '' });
 
 	useEffect(() => {
 		open();
@@ -59,6 +61,7 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 			blocksResizeObserver.current?.disconnect();
 			blocksResizeObserver.current = null;
 			blocksResizeTarget.current = null;
+			emptyToggleEntry.current = { pending: false, blockId: '' };
 
 			raf.cancel(frameMove.current);
 			raf.cancel(frameResize.current);
@@ -70,6 +73,8 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 	useEffect(() => {
 		if (idRef.current != rootId) {
+			emptyToggleEntry.current = { pending: false, blockId: '' };
+
 			close();
 			open();
 		};
@@ -1007,6 +1012,25 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 		const styleParam = getStyleParam();
 		const cmd = keyboard.cmdKey();
 
+		// A block materialized by arrow-entry into an empty toggle stays ephemeral only while the
+		// user merely navigates — any other interaction makes it permanent (JS-8420)
+		if (emptyToggleEntry.current.blockId) {
+			const nav = [
+				'arrowup', 'arrowdown', 'arrowleft', 'arrowright',
+				'pageup', 'pagedown', 'prevBlock', 'nextBlock',
+				`${cmd}+arrowup`, `${cmd}+arrowdown`, `${cmd}+home`, `${cmd}+end`,
+				'ctrl+home', 'ctrl+end', 'ctrl+p', 'ctrl+n',
+			];
+
+			let isNav = false;
+
+			keyboard.shortcut(nav.join(', '), e, () => isNav = true);
+
+			if (!isNav || (focused != emptyToggleEntry.current.blockId)) {
+				emptyToggleEntry.current.blockId = '';
+			};
+		};
+
 		// Last line break doesn't expand range.to
 		let length = String(text || '').length;
 		if (length && (text[length - 1] == '\n')) {
@@ -1917,7 +1941,9 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 			return;
 		};
 
-		// Moving down from an open empty toggle header materializes the first child, mirroring click on the placeholder
+		// Moving down from an open empty toggle header materializes the first child, mirroring click on
+		// the placeholder. The block stays ephemeral: navigating away while it is still empty deletes it
+		// again (checkEphemeralToggleChild), so pass-through navigation never permanently mutates the document
 		if (
 			(dir > 0) &&
 			!readonly &&
@@ -1927,8 +1953,18 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 		) {
 			e.preventDefault();
 
+			// Key repeat can fire again before the create lands — never materialize twice
+			if (emptyToggleEntry.current.pending) {
+				return;
+			};
+
+			emptyToggleEntry.current.pending = true;
+
 			C.BlockCreate(rootId, block.id, I.BlockPosition.Inner, { type: I.BlockType.Text }, (message: any) => {
+				emptyToggleEntry.current.pending = false;
+
 				if (!message.error.code) {
+					emptyToggleEntry.current.blockId = message.blockId;
 					focusSet(message.blockId, 0, 0, true);
 				};
 			});
@@ -3107,10 +3143,38 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 		}, 15);
 	};
 
+	// A block materialized by arrow-entry into an open empty toggle (onArrowVertical) is ephemeral:
+	// when keyboard navigation moves the caret away while it is still empty, delete it again, so
+	// passing through open empty toggles never permanently mutates the document (JS-8420)
+	const checkEphemeralToggleChild = (nextId: string) => {
+		const id = emptyToggleEntry.current.blockId;
+
+		if (!id || (id == nextId)) {
+			return;
+		};
+
+		emptyToggleEntry.current.blockId = '';
+
+		// The caret left the block through some other interaction — leave it alone
+		if (focus.state.focused != id) {
+			return;
+		};
+
+		const block = S.Block.getLeaf(rootId, id);
+
+		if (!block || block.getLength() || S.Block.getChildrenIds(rootId, id).length) {
+			return;
+		};
+
+		C.BlockListDelete(rootId, [ id ]);
+	};
+
 	const focusNextBlock = (next: I.Block, dir: number) => {
 		if (!next) {
 			return;
 		};
+
+		checkEphemeralToggleChild(next.id);
 
 		const from = dir > 0 ? 0 : next.getLength();
 		focusSet(next.id, from, from, true);

--- a/src/ts/component/menu/block/action.tsx
+++ b/src/ts/component/menu/block/action.tsx
@@ -606,10 +606,12 @@ const MenuBlockAction = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			};
 
 			case 'clipboardPaste': {
-				// Range is missing when the block was selected via its gripper (no text caret) —
-				// fall back to a caret at the end of the block, so the synthetic paste targets
-				// the selected block instead of appending at the document bottom. A stale range
-				// from another block is clamped to this block's length
+				// Range is missing when the block was selected via its gripper or right-clicked
+				// without holding the caret (block/index.tsx only forwards the range when this
+				// block is the focused one) — fall back to a caret at the end of the block, so
+				// the synthetic paste targets the selected block instead of appending at the
+				// document bottom. Clamping guards against the text having changed since the
+				// range was captured
 				const length = block.getLength();
 				const to = range ? Math.min(range.to, length) : length;
 				const from = range ? Math.min(range.from, to) : length;

--- a/src/ts/component/menu/block/action.tsx
+++ b/src/ts/component/menu/block/action.tsx
@@ -606,9 +606,17 @@ const MenuBlockAction = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			};
 
 			case 'clipboardPaste': {
+				// Range is missing when the block was selected via its gripper (no text caret) —
+				// fall back to a caret at the end of the block, so the synthetic paste targets
+				// the selected block instead of appending at the document bottom. A stale range
+				// from another block is clamped to this block's length
+				const length = block.getLength();
+				const to = range ? Math.min(range.to, length) : length;
+				const from = range ? Math.min(range.from, to) : length;
+
 				close();
 				window.setTimeout(() => {
-					focus.set(blockId, range);
+					focus.set(blockId, { from, to });
 					focus.apply();
 					window.setTimeout(() => Renderer.send('paste'), 50);
 				}, J.Constant.delay.menu);

--- a/src/ts/component/selection/provider.tsx
+++ b/src/ts/component/selection/provider.tsx
@@ -997,6 +997,17 @@ const SelectionProvider = forwardRef<SelectionRefProps, Props>((props, ref) => {
 
 	// Used to click and set selection automatically in block menu for example
 	const getForClick = (id: string, withChildren: boolean, save: boolean): string[] => {
+		// The children cache is rebuilt only on selection mousedown, which gripper clicks and
+		// context menus bypass — recompute it from the block store so cut/copy from the block
+		// menu never loses or gets stale descendants (JS-8599)
+		if (withChildren) {
+			get(I.SelectType.Block, false).forEach(it => cacheChildrenIds(it));
+
+			if (id) {
+				cacheChildrenIds(id);
+			};
+		};
+
 		let ids: string[] = get(I.SelectType.Block, withChildren);
 
 		if (id && !ids.includes(id)) {
@@ -1036,7 +1047,9 @@ const SelectionProvider = forwardRef<SelectionRefProps, Props>((props, ref) => {
 	};
 
 	const getChildrenIds = (id: string) => {
-		return cacheChildrenMap.current.get(id) || [];
+		// The cache is only built on selection mousedown — gripper clicks and context menus
+		// bypass it, so fall back to computing from the block store (JS-8599)
+		return cacheChildrenMap.current.get(id) || cacheChildrenIds(id);
 	};
 
 	const getPageContainer = () => {


### PR DESCRIPTION
Fixes for the "Editor - toggle keyboard access & block-menu paste" area, reviewed for regressions before opening.

- [JS-8420](https://linear.app/anytype/issue/JS-8420) — Backspace/Arrow-down now provide keyboard access into an empty toggle, matching Tab
- [JS-8598](https://linear.app/anytype/issue/JS-8598) — Paste from a block's "..." content menu now targets the selected block instead of jumping to the end of the page
- [JS-8599](https://linear.app/anytype/issue/JS-8599) — Cutting/pasting a toggle via the context menu no longer drops its child blocks
- [JS-8898](https://linear.app/anytype/issue/JS-8898) — Trailing filler space and scrollbar no longer get out of sync as content grows without a full re-render
- [JS-8919](https://linear.app/anytype/issue/JS-8919) — Backspace on an empty first child of a toggle now keeps the caret inside the toggle