### PR TITLE
fix(editor-race-conditions): fix race conditions in editor

### DIFF
--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -74,6 +74,8 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 	const timeoutFilter = useRef(0);
 	const timeoutClick = useRef(0);
 	const timeoutText = useRef(0);
+	const pendingSavesRef = useRef(0);
+	const sentTextsRef = useRef<string[]>([]);
 	const preventMenu = useRef(false);
 	const clickCnt = useRef(0);
 	const prevStyleRef = useRef(style);
@@ -120,10 +122,22 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 		// overwrites the user's latest keystrokes (e.g. code block text reverting).
 		// Only suppress when text hasn't changed AND marks haven't changed — mark
 		// toggles (bold, italic, etc.) need setValue to re-render markup.
-		const isEcho = (focused == block.id) && (text === textRef.current) && !marksChanged;
+		const isOwnEcho = (focused == block.id) && (text === textRef.current) && !marksChanged;
+
+		// A store text matching an earlier in-flight save (but not the latest one)
+		// is a stale echo arriving late — e.g. the debounced save racing the
+		// immediate save on blur. Suppress it independent of focus: after
+		// focus.clear() the guard above no longer applies and the stale echo would
+		// revert the just-typed content (JS-9285)
+		const sent = sentTextsRef.current;
+		const isStaleEcho = (pendingSavesRef.current > 0) && sent.includes(text) && (text !== sent[sent.length - 1]);
+		const isEcho = isOwnEcho || isStaleEcho;
 
 		if (textChanged || marksChanged) {
-			marksRef.current = marks || [];
+			// Don't absorb marks from a stale echo — they belong to the older save
+			if (!isStaleEcho) {
+				marksRef.current = marks || [];
+			};
 
 			// Only sync contenteditable from props when not focused or when content
 			// actually changed. When focused, the local editable state is the source
@@ -1267,16 +1281,31 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 		textRef.current = value;
 
+		// Track in-flight saves and their values so the store-echo suppression in
+		// the render effect can tell a stale echo of an earlier save from a genuine
+		// remote change (JS-9285). Echoes are always applied by the dispatcher
+		// before the command callback fires, so clearing on the last callback is safe
+		sentTextsRef.current.push(value);
+		pendingSavesRef.current++;
+
+		const onSave = () => {
+			pendingSavesRef.current = Math.max(0, pendingSavesRef.current - 1);
+			if (!pendingSavesRef.current) {
+				sentTextsRef.current = [];
+			};
+			callBack?.();
+		};
+
 		const isRtl = U.String.checkRtl(value);
 
 		if (isRtl != checkRtl) {
 			// Save text first so intermediate re-renders from setRtl have the correct text in store,
 			// preventing character loss and stale CSS direction
 			U.Data.blockSetText(rootId, block.id, value, marks, update, () => {
-				U.Data.setRtl(rootId, block, isRtl, callBack);
+				U.Data.setRtl(rootId, block, isRtl, onSave);
 			});
 		} else {
-			U.Data.blockSetText(rootId, block.id, value, marks, update, callBack);
+			U.Data.blockSetText(rootId, block.id, value, marks, update, onSave);
 		};
 	};
 	

--- a/src/ts/component/cell/object.tsx
+++ b/src/ts/component/cell/object.tsx
@@ -366,6 +366,7 @@ const CellObject = forwardRef<I.CellRef, I.Cell>((props, ref) => {
 		blur,
 		setEditing,
 		isEditing: () => isEditing,
+		getEntryValue: () => getValue().new,
 	}));
 
 	return (

--- a/src/ts/component/drag/provider.tsx
+++ b/src/ts/component/drag/provider.tsx
@@ -27,7 +27,8 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 	const timeoutDragOver = useRef(0);
 	const prevTargetKey = useRef<string | null>(null);
 	const lastKnownCoords = useRef({ x: 0, y: 0 });
-	const lastValidTarget = useRef<{ data: any, position: I.BlockPosition, time: number } | null>(null);
+	const lastValidTarget = useRef<{ data: any, position: I.BlockPosition } | null>(null);
+	const lastColumnTarget = useRef<{ data: any, position: I.BlockPosition, time: number } | null>(null);
 	const dragData = useRef<any>(null);
 
 	const dragHandler = useRef<((e: any) => void) | null>(null);
@@ -141,15 +142,16 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 		let targetId = '';
 		let target: any = null;
 
+		const hasCoords = e.pageX || e.pageY || e.clientX || e.clientY;
+
 		if (hoverData.current && (position.current != I.BlockPosition.None)) {
 			data = hoverData.current;
 
 			// On Linux the drop event carries no coordinates — if a late dragover
 			// flipped a freshly shown column indicator to Top/Bottom for the same
 			// target, restore the column position the user saw (JS-9377)
-			const hasCoords = e.pageX || e.pageY || e.clientX || e.clientY;
 			if (!hasCoords) {
-				const latched = getLatchedColumnPosition(data);
+				const latched = getLatchedColumnPosition(data, position.current);
 				if (latched != I.BlockPosition.None) {
 					position.current = latched;
 				};
@@ -158,6 +160,15 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 		if (lastValidTarget.current) {
 			data = lastValidTarget.current.data;
 			position.current = lastValidTarget.current.position;
+
+			// Same restoration for the fallback path: hoverData was cleared by a
+			// late bogus dragover right before the drop (JS-9377)
+			if (!hasCoords) {
+				const latched = getLatchedColumnPosition(data, position.current);
+				if (latched != I.BlockPosition.None) {
+					position.current = latched;
+				};
+			};
 		} else
 		if (last && isFileDrop) {
 			data = objectData.current.get([ I.DropType.Block, last.id ].join('-'));
@@ -469,7 +480,7 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 			// if a late dragover flipped a freshly shown column indicator to
 			// Top/Bottom for the same target, restore the column position (JS-9377)
 			if (target) {
-				const latched = getLatchedColumnPosition(target);
+				const latched = getLatchedColumnPosition(target, pos);
 				if (latched != I.BlockPosition.None) {
 					pos = latched;
 				};
@@ -1156,6 +1167,7 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 		prevTargetKey.current = null;
 		lastKnownCoords.current = { x: 0, y: 0 };
 		lastValidTarget.current = null;
+		lastColumnTarget.current = null;
 		canDrop.current = false;
 		dragActive.current = false;
 	};
@@ -1173,34 +1185,34 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 	};
 
 	const saveValidTarget = (data: any, v: I.BlockPosition) => {
-		const prev = lastValidTarget.current;
+		lastValidTarget.current = { data, position: v };
 
-		// Keep a shown column (Left/Right) indicator latched for the same target:
-		// on Linux a late dragover recomputed from unreliable coordinates can flip
+		// Remember the last shown column (Left/Right) indicator separately: on
+		// Linux a late dragover recomputed from unreliable coordinates can flip
 		// it to Top/Bottom right before the drop lands, making new columns
-		// impossible to create (JS-9377)
-		if (prev && data && (prev.data?.id == data.id) && isColumnPosition(prev.position) && !isColumnPosition(v)) {
-			return;
+		// impossible to create (JS-9377). The latch is only consulted inside
+		// getLatchedColumnPosition, where the freshness window applies —
+		// lastValidTarget itself always tracks the latest valid position
+		if (isColumnPosition(v)) {
+			lastColumnTarget.current = { data, position: v, time: performance.now() };
 		};
-
-		lastValidTarget.current = { data, position: v, time: performance.now() };
 	};
 
 	// Returns the latched column (Left/Right) position for the given target when
-	// it was shown recently and the live position disagrees — used by the drop
-	// fallbacks to restore the column indicator the user saw (JS-9377)
-	const getLatchedColumnPosition = (data: any): I.BlockPosition => {
-		const lvt = lastValidTarget.current;
+	// it was shown recently and the candidate position disagrees — used by the
+	// drop fallbacks to restore the column indicator the user saw (JS-9377)
+	const getLatchedColumnPosition = (data: any, v: I.BlockPosition): I.BlockPosition => {
+		const lct = lastColumnTarget.current;
 
-		if (!lvt || !data) {
+		if (!lct || !data) {
 			return I.BlockPosition.None;
 		};
 
-		const isFresh = (performance.now() - lvt.time) <= COLUMN_LATCH_TIMEOUT;
-		const isSameTarget = lvt.data?.id == data.id;
+		const isFresh = (performance.now() - lct.time) <= COLUMN_LATCH_TIMEOUT;
+		const isSameTarget = lct.data?.id == data.id;
 
-		if (isFresh && isSameTarget && isColumnPosition(lvt.position) && !isColumnPosition(position.current)) {
-			return lvt.position;
+		if (isFresh && isSameTarget && !isColumnPosition(v)) {
+			return lct.position;
 		};
 
 		return I.BlockPosition.None;

--- a/src/ts/component/drag/provider.tsx
+++ b/src/ts/component/drag/provider.tsx
@@ -9,6 +9,7 @@ interface Props {
 };
 
 const OFFSET = 100;
+const COLUMN_LATCH_TIMEOUT = 1000;
 
 const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any) => {
 
@@ -26,7 +27,7 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 	const timeoutDragOver = useRef(0);
 	const prevTargetKey = useRef<string | null>(null);
 	const lastKnownCoords = useRef({ x: 0, y: 0 });
-	const lastValidTarget = useRef<{ data: any, position: I.BlockPosition } | null>(null);
+	const lastValidTarget = useRef<{ data: any, position: I.BlockPosition, time: number } | null>(null);
 	const dragData = useRef<any>(null);
 
 	const dragHandler = useRef<((e: any) => void) | null>(null);
@@ -142,6 +143,17 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 
 		if (hoverData.current && (position.current != I.BlockPosition.None)) {
 			data = hoverData.current;
+
+			// On Linux the drop event carries no coordinates — if a late dragover
+			// flipped a freshly shown column indicator to Top/Bottom for the same
+			// target, restore the column position the user saw (JS-9377)
+			const hasCoords = e.pageX || e.pageY || e.clientX || e.clientY;
+			if (!hasCoords) {
+				const latched = getLatchedColumnPosition(data);
+				if (latched != I.BlockPosition.None) {
+					position.current = latched;
+				};
+			};
 		} else
 		if (lastValidTarget.current) {
 			data = lastValidTarget.current.data;
@@ -452,6 +464,16 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 		try {
 			let target = hoverData.current || lastValidTarget.current?.data;
 			let pos = (position.current != I.BlockPosition.None) ? position.current : (lastValidTarget.current?.position ?? I.BlockPosition.None);
+
+			// This fallback drop only runs when the drop event never fired (Linux) —
+			// if a late dragover flipped a freshly shown column indicator to
+			// Top/Bottom for the same target, restore the column position (JS-9377)
+			if (target) {
+				const latched = getLatchedColumnPosition(target);
+				if (latched != I.BlockPosition.None) {
+					pos = latched;
+				};
+			};
 
 			// DOM-based fallback using last known coordinates when coordinate tracking failed
 			if (!target && dragData.current) {
@@ -927,7 +949,7 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 			// (e.g. text block bottom-hover). The final save after adjustments
 			// will overwrite this with the fully-adjusted position when valid.
 			if ((position.current != I.BlockPosition.None) && canDrop.current) {
-				lastValidTarget.current = { data: hd, position: position.current };
+				saveValidTarget(hd, position.current);
 			};
 
 			// canDropMiddle flag for restricted objects
@@ -1016,7 +1038,7 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 		};
 
 		if (hd && (position.current != I.BlockPosition.None) && canDrop.current) {
-			lastValidTarget.current = { data: hd, position: position.current };
+			saveValidTarget(hd, position.current);
 		};
 
 		if (frame.current) {
@@ -1144,6 +1166,44 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 
 	const setPosition = (v: I.BlockPosition) => {
 		position.current = v;
+	};
+
+	const isColumnPosition = (v: I.BlockPosition): boolean => {
+		return [ I.BlockPosition.Left, I.BlockPosition.Right ].includes(v);
+	};
+
+	const saveValidTarget = (data: any, v: I.BlockPosition) => {
+		const prev = lastValidTarget.current;
+
+		// Keep a shown column (Left/Right) indicator latched for the same target:
+		// on Linux a late dragover recomputed from unreliable coordinates can flip
+		// it to Top/Bottom right before the drop lands, making new columns
+		// impossible to create (JS-9377)
+		if (prev && data && (prev.data?.id == data.id) && isColumnPosition(prev.position) && !isColumnPosition(v)) {
+			return;
+		};
+
+		lastValidTarget.current = { data, position: v, time: performance.now() };
+	};
+
+	// Returns the latched column (Left/Right) position for the given target when
+	// it was shown recently and the live position disagrees — used by the drop
+	// fallbacks to restore the column indicator the user saw (JS-9377)
+	const getLatchedColumnPosition = (data: any): I.BlockPosition => {
+		const lvt = lastValidTarget.current;
+
+		if (!lvt || !data) {
+			return I.BlockPosition.None;
+		};
+
+		const isFresh = (performance.now() - lvt.time) <= COLUMN_LATCH_TIMEOUT;
+		const isSameTarget = lvt.data?.id == data.id;
+
+		if (isFresh && isSameTarget && isColumnPosition(lvt.position) && !isColumnPosition(position.current)) {
+			return lvt.position;
+		};
+
+		return I.BlockPosition.None;
 	};
 
 	const unbind = () => {

--- a/src/ts/component/drag/provider.tsx
+++ b/src/ts/component/drag/provider.tsx
@@ -29,6 +29,7 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 	const lastKnownCoords = useRef({ x: 0, y: 0 });
 	const lastValidTarget = useRef<{ data: any, position: I.BlockPosition } | null>(null);
 	const lastColumnTarget = useRef<{ data: any, position: I.BlockPosition, time: number } | null>(null);
+	const positionFromRealCoords = useRef(false);
 	const dragData = useRef<any>(null);
 
 	const dragHandler = useRef<((e: any) => void) | null>(null);
@@ -390,8 +391,10 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 		let x = e.pageX || e.clientX || 0;
 		let y = e.pageY || e.clientY || 0;
 
+		const hasRealCoords = Boolean(x || y);
+
 		// Save last known good coordinates for Linux fallback
-		if (x || y) {
+		if (hasRealCoords) {
 			lastKnownCoords.current = { x, y };
 		} else
 		if (lastKnownCoords.current.x || lastKnownCoords.current.y) {
@@ -406,6 +409,9 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 		// On Linux, dragover events may report (0, 0) — calling checkNodes
 		// with bad coords clears hoverData without finding a replacement.
 		if (x || y) {
+			// Recomputations from fallback coordinates are untrusted — the column
+			// latch only overrides those (JS-9377)
+			positionFromRealCoords.current = hasRealCoords;
 			checkNodes(e, x, y);
 		};
 
@@ -447,6 +453,7 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 		// On Linux, drag events report (0, 0) — using stale fallback coords
 		// causes checkNodes to clear hoverData without finding a valid replacement.
 		if (hasRealCoords) {
+			positionFromRealCoords.current = true;
 			checkNodes(e, x, y);
 		};
 
@@ -1168,6 +1175,7 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 		lastKnownCoords.current = { x: 0, y: 0 };
 		lastValidTarget.current = null;
 		lastColumnTarget.current = null;
+		positionFromRealCoords.current = false;
 		canDrop.current = false;
 		dragActive.current = false;
 	};
@@ -1200,11 +1208,14 @@ const DragProvider = forwardRef<I.DragProviderRefProps, Props>((props, ref: any)
 
 	// Returns the latched column (Left/Right) position for the given target when
 	// it was shown recently and the candidate position disagrees — used by the
-	// drop fallbacks to restore the column indicator the user saw (JS-9377)
+	// drop fallbacks to restore the column indicator the user saw (JS-9377).
+	// A live position recomputed from real event coordinates reflects a
+	// deliberate user move to another drop zone and is never overridden — the
+	// latch only counters bogus flips recomputed from stale fallback coordinates
 	const getLatchedColumnPosition = (data: any, v: I.BlockPosition): I.BlockPosition => {
 		const lct = lastColumnTarget.current;
 
-		if (!lct || !data) {
+		if (!lct || !data || positionFromRealCoords.current) {
 			return I.BlockPosition.None;
 		};
 

--- a/src/ts/component/menu/dataview/object/list.tsx
+++ b/src/ts/component/menu/dataview/object/list.tsx
@@ -196,6 +196,12 @@ const MenuDataviewObjectList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		const relation = data.relation.get();
 		const addParam = data.addParam || {};
 
+		// Read the live filter from menu data before the cell clears it: this
+		// handler can be invoked through the imperative menu ref (Enter key),
+		// whose closure may have captured the mount-time empty filter — the
+		// typed name would be lost and the object created as Unknown (JS-9762)
+		const name = String(data.filter || filter || '');
+
 		e.preventDefault();
 		e.stopPropagation();
 
@@ -230,7 +236,7 @@ const MenuDataviewObjectList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		};
 
 		if (item.id == 'add') {
-			const param = Relation.getParamForNewObject(filter, relation);
+			const param = Relation.getParamForNewObject(name, relation);
 			const details = Object.assign(param.details, addParam.details || {});
 
 			U.Object.create('', '', details, I.BlockPosition.Bottom, '', param.flags, analytics.route.relation, (message: any) => {
@@ -336,6 +342,8 @@ const MenuDataviewObjectList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		);
 	};
 
+	// NOTE: the empty deps freeze these closures at mount time — onClick reads
+	// the live filter via data.filter for this reason (JS-9762)
 	useImperativeHandle(ref, () => ({
 		rebind,
 		unbind,

--- a/src/ts/component/menu/dataview/object/list.tsx
+++ b/src/ts/component/menu/dataview/object/list.tsx
@@ -196,11 +196,14 @@ const MenuDataviewObjectList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		const relation = data.relation.get();
 		const addParam = data.addParam || {};
 
-		// Read the live filter from menu data before the cell clears it: this
-		// handler can be invoked through the imperative menu ref (Enter key),
-		// whose closure may have captured the mount-time empty filter — the
-		// typed name would be lost and the object created as Unknown (JS-9762)
-		const name = String(data.filter || filter || '');
+		// Read the live filter before the cell clears it: this handler can be
+		// invoked through the imperative menu ref (Enter key), whose closure may
+		// have captured the mount-time empty filter — the typed name would be
+		// lost and the object created as Unknown. Prefer the cell's live entry
+		// text: data.filter lags behind it by the cell's keyup debounce, so a
+		// fast type → arrow → Enter sequence would otherwise create the object
+		// with a truncated or stale name (JS-9762)
+		const name = String(cellRef?.getEntryValue?.() || data.filter || filter || '');
 
 		e.preventDefault();
 		e.stopPropagation();

--- a/src/ts/interface/block/dataview.ts
+++ b/src/ts/interface/block/dataview.ts
@@ -307,6 +307,7 @@ export interface CellRef {
 	isEditing?(): boolean;
 	onChange?(value: any): void;
 	getValue?(): any;
+	getEntryValue?(): string;
 	forceUpdate?(): void;
 	canEdit?(): boolean;
 };

--- a/src/ts/lib/api/dispatcher.ts
+++ b/src/ts/lib/api/dispatcher.ts
@@ -1782,6 +1782,11 @@ class Dispatcher {
 				};
 
 				if (!response) {
+					// Still invoke the callback: callers rely on every request
+					// eventually completing (e.g. in-flight save accounting) —
+					// silently dropping it would leak their pending state
+					console.error('Empty response', type);
+					callBack?.({ error: { code: 1, description: 'Empty response' } });
 					return;
 				};
 

--- a/src/ts/lib/mark.test.ts
+++ b/src/ts/lib/mark.test.ts
@@ -178,6 +178,64 @@ describe('Mark', () => {
 
 			expect(result).toHaveLength(0);
 		});
+
+		it('should trim leading newline out of code mark range', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Code, range: { from: 5, to: 11 }, param: '' },
+			];
+
+			const result = Mark.checkRanges('hello\nworld', marks);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].range.from).toBe(6);
+			expect(result[0].range.to).toBe(11);
+		});
+
+		it('should trim trailing newline out of code mark range', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Code, range: { from: 0, to: 6 }, param: '' },
+			];
+
+			const result = Mark.checkRanges('hello\nworld', marks);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].range.from).toBe(0);
+			expect(result[0].range.to).toBe(5);
+		});
+
+		it('should keep inner newlines of code mark range', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Code, range: { from: 0, to: 11 }, param: '' },
+			];
+
+			const result = Mark.checkRanges('hello\nworld', marks);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].range.from).toBe(0);
+			expect(result[0].range.to).toBe(11);
+		});
+
+		it('should remove code mark consisting only of newlines', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Code, range: { from: 5, to: 7 }, param: '' },
+			];
+
+			const result = Mark.checkRanges('hello\n\nworld', marks);
+
+			expect(result).toHaveLength(0);
+		});
+
+		it('should not trim newlines from non-code marks', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Bold, range: { from: 5, to: 11 }, param: '' },
+			];
+
+			const result = Mark.checkRanges('hello\nworld', marks);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].range.from).toBe(5);
+			expect(result[0].range.to).toBe(11);
+		});
 	});
 
 	describe('toggle', () => {

--- a/src/ts/lib/mark.ts
+++ b/src/ts/lib/mark.ts
@@ -245,6 +245,22 @@ class Mark {
 			const mark = marks[i];
 			const prev = marks[(i - 1)];
 
+			// Inline code renders as a padded pill (box-decoration-break: clone): a
+			// range that starts or ends on a soft line break ('\n' → <br/>) opens or
+			// closes the pill on the adjacent line, leaving an empty code fragment
+			// there — trim boundary newlines out of the range (JS-9825)
+			if (mark.type == I.MarkType.Code) {
+				mark.range.to = Math.min(mark.range.to, text.length);
+
+				while ((mark.range.from < mark.range.to) && (text[mark.range.from] == '\n')) {
+					mark.range.from++;
+				};
+
+				while ((mark.range.to > mark.range.from) && (text[mark.range.to - 1] == '\n')) {
+					mark.range.to--;
+				};
+			};
+
 			let del = false;
 			if (mark.range.from >= text.length) {
 				del = true;

--- a/src/ts/lib/util/data.ts
+++ b/src/ts/lib/util/data.ts
@@ -554,6 +554,10 @@ class UtilData {
 
 		const block = S.Block.getLeaf(rootId, blockId);
 		if (!block) {
+			// Still invoke the callback: callers (e.g. block/text pending-save
+			// accounting, JS-9285) rely on every save eventually completing —
+			// silently dropping it would leak their in-flight counters
+			callBack?.({ error: { code: 1, description: 'Block not found' } });
 			return;
 		};
 


### PR DESCRIPTION
Fixes for the "Editor - race conditions" area, reviewed for regressions before opening.

- [JS-9285](https://linear.app/anytype/issue/JS-9285) — Code block text no longer reverts on blur due to a stale save echo racing the latest edit
- [JS-9825](https://linear.app/anytype/issue/JS-9825) — Inline code formatting spanning a line break no longer renders as a remnant on the previous line
- [JS-9377](https://linear.app/anytype/issue/JS-9377) — Dragging objects into a new column now works reliably on Linux
- [JS-9762](https://linear.app/anytype/issue/JS-9762) — Creating an object from a property field now keeps the typed title instead of reverting to "Untitled"