### PR TITLE
fix(dataview): sticky horizontal scrollbar for inline grid (JS-9811)

### DIFF
--- a/src/ts/component/block/dataview/view/grid.tsx
+++ b/src/ts/component/block/dataview/view/grid.tsx
@@ -22,7 +22,7 @@ const ViewGrid = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 	} = props;
 	const nodeRef = useRef(null);
 	const listRef = useRef(null);
-	const stickyScrollbarRef = useRef(null);
+	const stickyScrollbarRef = useRef<I.StickyScrollbarRef>(null);
 	const isSyncingScroll = useRef(false);
 	const scrollRef = useRef(null);
 	const scrollWrapRef = useRef(null);
@@ -83,9 +83,7 @@ const ViewGrid = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 			U.Dom.addEvent(container, 'scroll', scrollVerticalHandlerRef.current);
 		};
 
-		if (!isInline) {
-			stickyScrollbarRef.current?.bind(scroll, isSyncingScroll.current);
-		};
+		stickyScrollbarRef.current?.bind(scroll, isSyncingScroll.current);
 	};
 
 	const unbind = () => {
@@ -110,21 +108,18 @@ const ViewGrid = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 			resizeColumns('', 0);
 		};
 
-		if (isInline) {
-			return;
-		};
-
-		const node = nodeRef.current;
 		const scroll = scrollRef.current;
-		const clone = U.Dom.select('#rowHeadClone', node);
 
-		if (clone) {
-			U.Dom.css(clone, { transform: `translate3d(${-(scroll?.scrollLeft ?? 0)}px,0px,0px)` });
+		if (!isInline) {
+			const node = nodeRef.current;
+			const clone = U.Dom.select('#rowHeadClone', node);
+
+			if (clone) {
+				U.Dom.css(clone, { transform: `translate3d(${-(scroll?.scrollLeft ?? 0)}px,0px,0px)` });
+			};
 		};
 
-		if (stickyScrollbarRef) {
-			isSyncingScroll.current = stickyScrollbarRef.current?.sync(scroll, isSyncingScroll.current);
-		};
+		isSyncingScroll.current = stickyScrollbarRef.current?.sync(scroll, isSyncingScroll.current);
 	};
 
 	const onScrollVertical = () => {
@@ -423,6 +418,14 @@ const ViewGrid = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 					if (wrap) {
 						U.Dom.css(wrap, { width: `${vw + margin - offset}px`, paddingLeft: `${margin}px`, paddingRight: `${offset * 2}px` });
 					};
+
+					stickyScrollbarRef.current?.resize({
+						width: ww,
+						left: 0,
+						paddingLeft: 0,
+						display: (vw + margin - offset) <= cw ? 'none' : '',
+						trackWidth: vw,
+					});
 				} else {
 					const parentObj = U.Dom.get(`block-${parent.id}`);
 					const vw = parentObj ? (U.Dom.contentWidth(parentObj) - J.Size.blockMenu) : 0;
@@ -430,7 +433,11 @@ const ViewGrid = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 					if (wrap) {
 						U.Dom.css(wrap, { width: `${Math.max(vw, width)}px` });
 					};
+
+					stickyScrollbarRef.current?.resize({ display: 'none' });
 				};
+			} else {
+				stickyScrollbarRef.current?.resize({ display: 'none' });
 			};
 		} else {
 			const mw = cw - PADDING * 2;
@@ -593,7 +600,7 @@ const ViewGrid = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 					</div>
 				</div>
 			</div>
-			{!isInline ? <StickyScrollbar ref={stickyScrollbarRef} /> : ''}
+			<StickyScrollbar ref={stickyScrollbarRef} />
 		</div>
 	);
 


### PR DESCRIPTION
## Problem

Inline grid (query/collection) views had **no reachable horizontal scrollbar** when columns extend past the viewport. The native scrollbar is hidden by design (`dataview.scss`, since 2023), and `StickyScrollbar` was mounted only for the full-page grid (`{!isInline ? … : ''}`). So a wide inline query could only be scrolled with **shift+wheel** — undiscoverable, and unusable without a horizontal-axis pointer (the exact complaint in [community thread 30943](https://community.anytype.io/t/add-horizontal-scrollbar-to-grid-view/30943), from Linux and Windows users).

Reported as **JS-9811**.

## Fix

Mirror the inline-**board** treatment shipped in #2296 (JS-9714), applied to inline **grid**:

- Mount `StickyScrollbar` unconditionally (was full-page only)
- Bind / sync it on horizontal scroll for the inline case (the `#rowHeadClone` transform stays full-page-only)
- Add a sticky resize config in the inline `page`/`layoutDiv` branch, and `resize({ display: 'none' })` for the other inline branches

The sticky bar **rests at the block's bottom edge** for short blocks and **pins to the viewport bottom** for tall ones, so it's always reachable — it *is* the block's scrollbar, it just doesn't get stranded below the fold. Full-page grid and board are unchanged.

## Behaviour

| Case | Bar |
|------|-----|
| Inline grid, short block | rests at block bottom |
| Inline grid, tall block | pinned to viewport bottom while in view |
| Inline grid, content fits | hidden (no overflow) |
| Full-page grid / board | unchanged (sticky) |

## Verification

- `bun run typecheck` + `eslint` + `biome lint` pass
- Config validated in headed Chromium against the real compiled CSS: thumb ratio = `ww/vw`, bar aligns to the block, main-scroll ↔ sticky sync works, rests at block-bottom for short blocks
- Overflow threshold `(vw + margin - offset) <= cw` verified against actual `.scroll` overflow across a width sweep (an earlier `vw <= ww` draft showed a dead thumb in a ~200px band — fixed)

## Note for reviewers

Pixel-exact alignment of the bar against inline grid content was validated in a Chromium replica but **not in a running build** (needs the heart middleware). Grid now uses the same geometry as board's #2296 sticky, so if board's inline bar aligns correctly, grid's will too — worth a quick manual check on a wide inline query.