### PR TITLE
JS-9829: fix pasted URL wiped in empty block and missing Paste-as menu on virtual block

### DIFF
--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -2355,24 +2355,27 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 		let { focused, range } = focus.state;
 
-		// Pasting into the virgin virtual placeholder: no block exists yet — paste
-		// at the document bottom (empty target id appends), same as dropping onto
-		// the trailing drop zone. The pasted blocks carry their content, so no
-		// empty block is ever created
-		if (virtualBlock.isVirtualId(focused)) {
-			focused = '';
-			range = { from: 0, to: 0 };
-			virtualBlock.deactivate();
-		};
-
-		const block = S.Block.getLeaf(rootId, focused);
+		const isVirtual = virtualBlock.isVirtualId(focused);
+		const block = isVirtual ? virtualBlock.getBlock() : S.Block.getLeaf(rootId, focused);
 		const selection = S.Common.getRef('selectionProvider');
 		const trimmedText = data.text.trim();
 		const urls = U.String.getUrlsFromText(trimmedText);
 
+		// A single pasted URL gets the "Paste as" menu in the virtual placeholder
+		// too — the chosen option materializes the placeholder with the content
 		if (urls.length && (urls[0].value == trimmedText) && block && !block.isTextTitle() && !block.isTextDescription() && !block.isTextCode()) {
 			onPasteUrl(urls[0]);
 			return;
+		};
+
+		// Pasting into the virgin virtual placeholder: no block exists yet — paste
+		// at the document bottom (empty target id appends), same as dropping onto
+		// the trailing drop zone. The pasted blocks carry their content, so no
+		// empty block is ever created
+		if (isVirtual) {
+			focused = '';
+			range = { from: 0, to: 0 };
+			virtualBlock.deactivate();
 		};
 
 		let id = '';
@@ -2430,7 +2433,8 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 		const { focused, range } = focus.state;
 		const currentFrom = range.from;
 		const currentTo = range.to;
-		const block = S.Block.getLeaf(rootId, focused);
+		const isVirtual = virtualBlock.isVirtualId(focused);
+		const block = isVirtual ? virtualBlock.getBlock() : S.Block.getLeaf(rootId, focused);
 
 		if (!block) {
 			return;
@@ -2461,7 +2465,11 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 		const isInsideTable = S.Block.checkIsInsideTable(rootId, block.id);
 		const length = block.getLength();
-		const position = (!length && block.isText()) ? I.BlockPosition.Replace : I.BlockPosition.Bottom;
+
+		// The virtual placeholder has no middleware-side block to replace —
+		// block-creating options append at the document bottom instead
+		const targetId = isVirtual ? '' : focused;
+		const position = isVirtual ? I.BlockPosition.Bottom : ((!length && block.isText()) ? I.BlockPosition.Replace : I.BlockPosition.Bottom);
 		const processor = U.Embed.getProcessorByUrl(url);
 		const canBookmark = !isInsideTable && !isLocal;
 		const isSameSpace = !linkParam.spaceId || (linkParam.spaceId == S.Common.space);
@@ -2530,6 +2538,17 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 					});
 				};
 			},
+			onClose: () => {
+				// Deferred one tick: onClose fires right before onSelect, a selected
+				// option has started materializing by the time the check runs.
+				// Dismissed without materializing: release the placeholder if focus
+				// already left it (blur deactivation is suppressed while the menu is open)
+				window.setTimeout(() => {
+					if (isVirtual && !virtualBlock.realId && !virtualBlock.isCreating && (focus.state.focused != virtualBlock.id)) {
+						virtualBlock.deactivate();
+					};
+				});
+			},
 			data: {
 				value: '',
 				options,
@@ -2539,22 +2558,27 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 					order.unshift(item.id);
 					Storage.set('pasteOptionOrder', order);
 
+					// Block-creating options append at the document bottom in the
+					// virtual context — the placeholder is no longer the target
+					if (isVirtual && [ 'object', 'bookmark', 'embed' ].includes(item.id)) {
+						virtualBlock.deactivate();
+					};
+
 					let marks = U.Common.objectCopy(block.content.marks || []);
 					let value = block.content.text;
 					let to = 0;
 
 					switch (item.id) {
 						case 'object': {
-							const targetId = linkParam.target;
 							const newBlock = {
 								type: I.BlockType.Link,
 								content: {
 									...U.Data.defaultLinkSettings(),
-									targetBlockId: targetId,
+									targetBlockId: linkParam.target,
 								},
 							};
 
-							C.BlockCreate(rootId, focused, position, newBlock, (message: any) => {
+							C.BlockCreate(rootId, targetId, position, newBlock, (message: any) => {
 								if (!message.error.code) {
 									blockCreate(message.blockId, I.BlockPosition.Bottom, { type: I.BlockType.Text });
 
@@ -2576,8 +2600,10 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 							marks.push({ type: I.MarkType.Link, range: { from: currentFrom, to }, param: url });
 
-							U.Data.blockSetText(rootId, block.id, value, marks, true, () => {
-								focus.set(block.id, { from: to + 1, to: to + 1 });
+							// An empty block forks its identity on first content (BlockReplace),
+							// the write then lands on the new id from the callback message
+							U.Data.blockSetText(rootId, block.id, value, marks, true, (message: any) => {
+								focus.set(message.blockId || block.id, { from: to + 1, to: to + 1 });
 								focus.apply();
 							});
 							break;
@@ -2586,7 +2612,7 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 						case 'bookmark': {
 							const bookmark = S.Record.getBookmarkType();
 
-							C.BlockBookmarkCreateAndFetch(rootId, focused, position, url, bookmark?.defaultTemplateId, (message: any) => {
+							C.BlockBookmarkCreateAndFetch(rootId, targetId, position, url, bookmark?.defaultTemplateId, (message: any) => {
 								if (!message.error.code) {
 									blockCreate(message.blockId, I.BlockPosition.Bottom, { type: I.BlockType.Text });
 
@@ -2600,8 +2626,8 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 							value = U.String.insert(block.content.text, url + ' ', currentFrom, currentFrom);
 							to = currentFrom + url.length;
 
-							U.Data.blockSetText(rootId, block.id, value, marks, true, () => {
-								focus.set(block.id, { from: to + 1, to: to + 1 });
+							U.Data.blockSetText(rootId, block.id, value, marks, true, (message: any) => {
+								focus.set(message.blockId || block.id, { from: to + 1, to: to + 1 });
 								focus.apply();
 							});
 							break;
@@ -2609,7 +2635,7 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 						case 'embed': {
 							if (processor !== null) {
-								blockCreate(block.id, position, { type: I.BlockType.Embed, content: { processor, text: url } }, (blockId: string) => {
+								blockCreate(targetId, position, { type: I.BlockType.Embed, content: { processor, text: url } }, (blockId: string) => {
 									blockCreate(blockId, I.BlockPosition.Bottom, { type: I.BlockType.Text });
 									const previewEl = U.Dom.select(`.preview`, U.Dom.get(`block-${blockId}`));
 									if (previewEl) {
@@ -3109,6 +3135,12 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 	};
 
 	const onVirtualBlur = () => {
+		// The "Paste as" menu blurs the placeholder on item mousedown but its
+		// options still target it — the menu releases the placeholder on close
+		if (S.Menu.isOpen('selectPasteUrl')) {
+			return;
+		};
+
 		// Focus left the placeholder with nothing typed: nothing was created,
 		// nothing to clean up. A materialized placeholder finishes its swap on its own
 		if (!virtualBlock.realId && !virtualBlock.isCreating) {

--- a/src/ts/lib/virtualBlock.test.ts
+++ b/src/ts/lib/virtualBlock.test.ts
@@ -34,6 +34,15 @@ let storeBlocks: Map<string, any>;
 let storeChildren: Map<string, string[]>;
 let insideTable: Set<string>;
 
+// Simulates the mounted contenteditable of a block: readDom() parses its
+// innerHTML via the mocked Mark.fromHtml, so text == innerHTML
+const mountEditable = (id: string, html: string) => {
+	const node = { innerHTML: html };
+
+	g.U.Dom.select = (selector: string) => selector.includes(`c${id}`) ? node : null;
+	return node;
+};
+
 const completeCreate = (blockId: string, error?: number) => {
 	const call = createCalls[createCalls.length - 1];
 	call.cb({ blockId, middleTime: 1, error: { code: error || 0 } });
@@ -122,6 +131,12 @@ beforeEach(() => {
 		isComposition: false,
 		getRootId: () => ROOT_ID,
 		setFocus: () => {},
+	};
+
+	g.Mark = {
+		fromHtml: (html: string) => ({ text: html, marks: [] }),
+		hasZws: () => false,
+		domToModel: (n: number) => n,
 	};
 
 	g.analytics = { event: vi.fn() };
@@ -300,6 +315,19 @@ describe('virtualBlock', () => {
 		expect(g.C.BlockSetCarriage).toHaveBeenCalledWith(ROOT_ID, 'real1', { from: 1, to: 1 });
 	});
 
+	it('an editable left empty by a programmatic write does not overwrite the created content', () => {
+		virtualBlock.activate(ROOT_ID, false);
+
+		// Paste-as-URL etc.: the content goes straight to blockSetText, the
+		// mounted placeholder editable never receives it and stays empty
+		mountEditable(VIRTUAL_ID, '');
+
+		virtualBlock.setText(ROOT_ID, 'https://anytype.io ', [], true);
+		completeCreate('real1');
+
+		expect(g.U.Data.blockSetText).not.toHaveBeenCalled();
+	});
+
 	it('deactivation fully resets the placeholder state', () => {
 		virtualBlock.activate(ROOT_ID, false);
 		virtualBlock.setText(ROOT_ID, 'h', [], true);
@@ -428,6 +456,31 @@ describe('virtualBlock: empty-block identity fork (BlockReplace)', () => {
 
 		expect(replaceCalls.length).toBe(1);
 		expect(replaceCalls[0].param.content.text).toBe('かき');
+	});
+
+	it('an editable left empty by a programmatic write (paste as URL) does not overwrite the fork content', () => {
+		const block = makeBlock('f-old7');
+
+		// Paste-as-URL: the content goes straight to blockSetText, the mounted
+		// editable never receives it and stays empty
+		mountEditable('f-old7', '');
+
+		virtualBlock.fork(ROOT_ID, block, 'https://anytype.io ', [], undefined);
+		completeReplace('f-new7');
+
+		expect(g.U.Data.blockSetText).not.toHaveBeenCalled();
+	});
+
+	it('text typed into the editable while the fork is in flight still wins', () => {
+		const block = makeBlock('f-old8');
+		const node = mountEditable('f-old8', 'h');
+
+		virtualBlock.fork(ROOT_ID, block, 'h', [], undefined);
+
+		node.innerHTML = 'hello';
+		completeReplace('f-new8');
+
+		expect(g.U.Data.blockSetText).toHaveBeenCalledWith(ROOT_ID, 'f-new8', 'hello', [], true);
 	});
 
 	it('a fork emptied while held sends nothing', () => {

--- a/src/ts/lib/virtualBlock.ts
+++ b/src/ts/lib/virtualBlock.ts
@@ -10,6 +10,7 @@ interface Fork {
 	newId: string;
 	sentText: string;
 	sentMarks: I.Mark[];
+	domAtSend: { text: string; marks: I.Mark[]; };
 	pending: { text: string; marks: I.Mark[]; };
 	cbQueue: ((message: any) => void)[];
 };
@@ -60,6 +61,7 @@ class VirtualBlock {
 	private block: I.Block = null;
 	private sentText = '';
 	private sentMarks: I.Mark[] = [];
+	private domAtSend: { text: string; marks: I.Mark[]; } = null;
 	private pending: { text: string; marks: I.Mark[]; } = null;
 	private cbQueue: ((message: any) => void)[] = [];
 	private orphans: Map<number, { text: string; marks: I.Mark[]; }> = new Map();
@@ -152,6 +154,7 @@ class VirtualBlock {
 		this.isCreating = false;
 		this.sentText = '';
 		this.sentMarks = [];
+		this.domAtSend = null;
 		this.pending = null;
 		this.cbQueue = [];
 		this.unbindComposition();
@@ -178,6 +181,7 @@ class VirtualBlock {
 		this.isCreating = false;
 		this.sentText = '';
 		this.sentMarks = [];
+		this.domAtSend = null;
 		this.pending = null;
 		this.cbQueue = [];
 		this.block = null;
@@ -255,6 +259,7 @@ class VirtualBlock {
 		this.isCreating = true;
 		this.sentText = text;
 		this.sentMarks = marks;
+		this.domAtSend = this.readDom(this.id);
 
 		C.BlockCreate(rootId, '', I.BlockPosition.Bottom, param, (message: any) => {
 			// The placeholder was re-activated or closed while the request was in
@@ -313,7 +318,7 @@ class VirtualBlock {
 		};
 
 		const dom = this.readDom(this.id);
-		const latest = dom || this.pending;
+		const latest = this.domChangedSince(dom, this.domAtSend) ? dom : this.pending;
 
 		this.pending = null;
 
@@ -424,6 +429,7 @@ class VirtualBlock {
 			newId: '',
 			sentText: text,
 			sentMarks: marks || [],
+			domAtSend: null,
 			pending: null,
 			cbQueue: callBack ? [ callBack ] : [],
 		};
@@ -460,6 +466,8 @@ class VirtualBlock {
 			this.runQueue(fork.cbQueue, { error: { code: 0 } });
 			return;
 		};
+
+		fork.domAtSend = this.readDom(oldId);
 
 		const param = {
 			type: I.BlockType.Text,
@@ -510,7 +518,7 @@ class VirtualBlock {
 	 */
 	private finishFork (oldId: string, fork: Fork) {
 		const dom = this.readDom(oldId);
-		const latest = dom || fork.pending;
+		const latest = this.domChangedSince(dom, fork.domAtSend) ? dom : fork.pending;
 
 		fork.pending = null;
 
@@ -580,6 +588,21 @@ class VirtualBlock {
 				console.error('[VirtualBlock] queued callback error', e);
 			};
 		};
+	};
+
+	/**
+	 * Whether the editable's DOM changed after the request was sent. The DOM is
+	 * only authoritative for input made while the request was in flight:
+	 * programmatic writes (e.g. paste as URL) never enter the editable, so an
+	 * unchanged — typically still empty — DOM must not override the sent content.
+	 */
+	private domChangedSince (dom: { text: string; marks: I.Mark[]; }, snapshot: { text: string; marks: I.Mark[]; }): boolean {
+		if (!dom) {
+			return false;
+		};
+
+		const prev = snapshot || { text: '', marks: [] };
+		return (dom.text !== prev.text) || !U.Common.compareJSON(dom.marks, prev.marks);
 	};
 
 	private getNode (id: string): HTMLElement {


### PR DESCRIPTION
Regression from #2284.

## Bugs
1. **Pasted URL wiped in empty block** — choosing URL/Plain text in the Paste-as menu sent `BlockReplace` carrying the content, but `finishFork()` then read the still-empty editable DOM as "latest" and sent an empty `BlockTextSetText` to the new id. Same latent flaw in the virtual placeholder `finish()` path.
2. **No Paste-as menu on the virtual placeholder** — `onPaste` deactivated the placeholder and rerouted to `BlockPaste` before the URL check ran.
3. **Stale focus after fork** — menu callbacks focused the old (replaced) block id.

## Fixes
- `virtualBlock.ts`: snapshot the editable DOM when the request is sent; the DOM only overrides the sent content if it changed while the request was in flight (i.e. the user typed). Applied to both the fork (`BlockReplace`) and materialize (`BlockCreate`) paths.
- `page.tsx`: run the URL check before the virtual redirect so the menu opens on the placeholder; URL/Plain text materialize it, Object/Bookmark/Embed deactivate it and append at the document bottom. Blur no longer deactivates the placeholder while the menu is open; menu close releases it if nothing materialized.
- Focus callbacks use `message.blockId` (new id from fork/materialize) with fallback to `block.id`.

## Tests
- 3 new unit tests in `virtualBlock.test.ts`: empty-DOM-must-not-overwrite for both fork and materialize paths (both reproduced the bug before the fix), plus a guard that mid-flight typing still wins.