### PR TITLE
fix: restore cursor focus when breaking out of a toggle block (#2287)

### DIFF
--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -1912,7 +1912,10 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 			}, releaseEnterGuard);
 		} else
 		if (block.isTextParagraph() && !length && parent && (parent.canToggle() || parent.isTextCallout() || parent.isTextQuote())) {
-			Action.move(rootId, rootId, parent.id, [ block.id ], I.BlockPosition.Bottom, releaseEnterGuard);
+			Action.move(rootId, rootId, parent.id, [ block.id ], I.BlockPosition.Bottom, () => {
+				focusSet(block.id, 0, 0, true);
+				releaseEnterGuard();
+			});
 		} else {
 			blockSplit(block, range, isShift, releaseEnterGuard);
 		};


### PR DESCRIPTION
### Issue for this PR

Closes #2287

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes a cursor focus loss when pressing Enter twice to break out of a toggle block.

**Root cause:** When the user presses Enter on an empty child paragraph inside a toggle, `Action.move()` moves the block outside the toggle. The callback (`releaseEnterGuard`) only released the enter processing guard but did **not** re-apply focus on the moved block. Since `Action.move()` triggers a React unmount/remount of the block element, the DOM mutation clears the editor's focus state, and without a `focusSet()` call afterward, the cursor is lost.

**Fix:** The `Action.move()` callback now calls `focusSet(block.id, 0, 0, true)` before releasing the enter guard. This is consistent with how `blockCreate()` and `blockSplit()` handle focus after creating or moving blocks.

### How did you verify your code works?

The fix matches the existing focus restoration pattern used throughout the editor (e.g., `blockCreate()` at line 2680, `blockSplit()` at line 2897). The change is a single callback parameter in one code path.

### Checklist

- [x] I have not included unrelated changes in this PR
