### PR TITLE
fix: defer window resize dispatch after route commit on popup close (#2293)

### DIFF
--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -1912,7 +1912,10 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 			}, releaseEnterGuard);
 		} else
 		if (block.isTextParagraph() && !length && parent && (parent.canToggle() || parent.isTextCallout() || parent.isTextQuote())) {
-			Action.move(rootId, rootId, parent.id, [ block.id ], I.BlockPosition.Bottom, releaseEnterGuard);
+			Action.move(rootId, rootId, parent.id, [ block.id ], I.BlockPosition.Bottom, () => {
+				focusSet(block.id, 0, 0, true);
+				releaseEnterGuard();
+			});
 		} else {
 			blockSplit(block, range, isShift, releaseEnterGuard);
 		};

--- a/src/ts/store/popup.ts
+++ b/src/ts/store/popup.ts
@@ -196,7 +196,7 @@ class PopupStore {
 
 				callBack?.();
 				U.Data.updateTabsDimmer();
-				U.Dom.eventDispatch(window, 'resize');
+				window.setTimeout(() => U.Dom.eventDispatch(window, 'resize'));
 
 				this.setIsAnimating(id, false);
 			}, J.Constant.delay.popup);


### PR DESCRIPTION
### Issue for this PR

Closes #2293

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes object types not resizing correctly after navigating with the Ctrl+K switcher.

**Root cause:** `Popup.close` in `src/ts/store/popup.ts` runs the user callback (`callBack?.()`) synchronously and then dispatches the `'resize'` window event on the same tick. When the callback navigates to a new route (the Ctrl+K switcher uses `U.Object.openEvent → U.Router.go → history.push`), React has only *scheduled* a re-render — the new `EditorPage` has not mounted yet, and the previous editor's window `'resize'` listener is still attached.

The resize fires against the **previous** editor's container, writing the old column width onto the soon-to-be-unmounted tree. When React then mounts the new `EditorPage` (forced remount via `key={rootId}` in `page/main/edit.tsx:44`), no new `resize` event is dispatched, so the new page stays stuck at the old width.

Direct navigation (links inside a page) doesn't hit this because no `Popup.close` is involved — the route change is handled by the `useLayoutEffect` at `page/index.tsx:180-182` which queues `raf(() => resize())` after the new tree commits.

**Fix:** Wrap the `'resize'` dispatch inside `window.setTimeout(...)` so it lands on the next task, after React commits the new route. The new `EditorPage` will have mounted and `rebind()` will have registered its own window `'resize'` listener, so the dispatched event updates the correct tree.

### How did you verify your code works?

The change reuses the same pattern already used by `Popup.updateData` (line 112-114) in the same file, which wraps `U.Dom.eventDispatch(window, 'resize')` in `window.setTimeout` to defer it. The fix is symmetric with that existing behaviour.

Manual verification (using the Anytype desktop app):
1. Open a page with the left sidebar visible (so the content area is narrow).
2. Press Ctrl+K to open the switcher.
3. Select a different page whose content width should be larger (e.g. one that was previously rendered with the sidebar closed).
4. Confirm the new page's content actively resizes to fit its container.

### Checklist

- [x] I have not included unrelated changes in this PR
