### PR TITLE
GO-7386: fix leaked menu keydown listeners eating keys app-wide

### DIFF
--- a/docs/src/ts/component/menu/README.md
+++ b/docs/src/ts/component/menu/README.md
@@ -17,6 +17,13 @@ Each menu component exposes a `MenuRef` interface via `useImperativeHandle`:
 { rebind, unbind, getItems, getIndex, setIndex, onClick, onOver, getListRef, ... }
 ```
 
+### Window keydown lifecycle
+
+Child menus bind their own `window` keydown listener in `rebind()`/`unbind()`. Invariants (a leaked listener otherwise `preventDefault`s its keys app-wide until restart):
+- `unbind()` in the unmount cleanup, and cancel any deferred bind timers
+- Handlers that call `e.preventDefault()` bail on an `isUnmountedRef` guard first
+- Submenus restore the parent's keydown via `{ rebind, parentId }` in `S.Menu.open` — `parentId` must be the **store id** (`props.id`), not the DOM id from `getId()`. On submenu close, `rebindPrevious` resolves the live parent instance through the `S.Menu` ref registry (`setRef`/`getRef`); the `rebind` closure captured at open time is treated as intent only and never called, so a closed-and-reopened parent can't resurrect a dead listener
+
 ## Menu Categories
 
 ### Block Menus (`block/`)

--- a/docs/src/ts/store/README.md
+++ b/docs/src/ts/store/README.md
@@ -11,7 +11,7 @@ Reactive state stores using MobX. Each store manages a specific domain. Accessed
 | `block.ts` | `S.Block` | Document block trees: block CRUD, tree traversal, children management |
 | `detail.ts` | `S.Detail` | Object details/properties: get/set details, relations, layout info. Stores raw values in shallow observable maps (per-relation-key reactivity); `get()` results are cached per-args in reactive contexts via self-evicting computeds |
 | `record.ts` | `S.Record` | Dataview records: views, sorts, filters, groups, types, relations |
-| `menu.ts` | `S.Menu` | Menu state: open/close/update menus, sub-menu management |
+| `menu.ts` | `S.Menu` | Menu state: open/close/update menus, sub-menu management, live-instance ref registry (`setRef`/`getRef`/`deleteRef`) for safe keydown rebinding |
 | `popup.ts` | `S.Popup` | Popup state: open/close/update popups, dimmer control |
 | `chat.ts` | `S.Chat` | Chat messages: message CRUD, reactions, threads, counters |
 | `comment.ts` | `S.Comment` | Comment posts and replies: CRUD for posts/replies, pagination (hasMore) |

--- a/src/ts/component/menu/block/action.tsx
+++ b/src/ts/component/menu/block/action.tsx
@@ -20,6 +20,8 @@ const MenuBlockAction = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		rebind();
 
 		return () => {
+			isUnmountedRef.current = true;
+
 			unbind();
 			keyboard.setFocus(false);
 			S.Menu.closeAll(J.Menu.action);
@@ -42,6 +44,7 @@ const MenuBlockAction = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 	
 	const keydownHandler = useRef(null);
+	const isUnmountedRef = useRef(false);
 
 	const rebind = () => {
 		unbind();
@@ -58,6 +61,13 @@ const MenuBlockAction = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 
 	const onKeyDownHandler = (e: any) => {
+		// A leaked window listener must never act for a dead menu — bail before
+		// any preventDefault/blockRemove or it silently eats the key (or deletes
+		// blocks) app-wide until restart
+		if (isUnmountedRef.current) {
+			return;
+		};
+
 		const cmd = keyboard.cmdKey();
 
 		let ret = false;

--- a/src/ts/component/menu/block/relation/edit.tsx
+++ b/src/ts/component/menu/block/relation/edit.tsx
@@ -36,6 +36,8 @@ const MenuBlockRelationEdit = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		rebind();
 
 		return () => {
+			isUnmountedRef.current = true;
+
 			menuClose();
 			unbind();
 		};
@@ -49,6 +51,7 @@ const MenuBlockRelationEdit = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	});
 
 	const keydownHandler = useRef(null);
+	const isUnmountedRef = useRef(false);
 
 	const rebind = () => {
 		unbind();
@@ -148,6 +151,12 @@ const MenuBlockRelationEdit = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 
 	const onKeyDown = (e: any) => {
+		// A leaked window listener must never act for a dead menu — bail before
+		// any preventDefault or it silently eats the key app-wide until restart
+		if (isUnmountedRef.current) {
+			return;
+		};
+
 		keyboard.shortcut('enter', e, () => onSubmit(e));
 	};
 

--- a/src/ts/component/menu/dataview/filter/values.tsx
+++ b/src/ts/component/menu/dataview/filter/values.tsx
@@ -417,7 +417,7 @@ const MenuDataviewFilterValues = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		className,
 		classNameWrap,
 		rebind,
-		parentId: getId(),
+		parentId: props.id,
 	};
 
 	let wrapValue = false;

--- a/src/ts/component/menu/dataview/group/list.tsx
+++ b/src/ts/component/menu/dataview/group/list.tsx
@@ -22,6 +22,7 @@ const MenuGroupList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	const listRef = useRef(null);
 	const top = useRef(0);
 	const n = useRef(-1);
+	const isUnmountedRef = useRef(false);
 	const sensors = useSensors(
 		useSensor(PointerSensor, { activationConstraint: { distance: 10 } }),
 		useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
@@ -42,6 +43,12 @@ const MenuGroupList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 
 	const onKeyDownHandler = (e: any) => {
+		// A leaked window listener must never act for a dead menu — bail before
+		// any preventDefault or it silently eats the key app-wide until restart
+		if (isUnmountedRef.current) {
+			return;
+		};
+
 		const items = getItems();
 		const item = items[n.current];
 
@@ -50,7 +57,9 @@ const MenuGroupList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		keyboard.shortcut('space', e, (pressed: string) => {
 			e.preventDefault();
 
-			onSwitch(e, item, !item.isVisible);
+			if (item) {
+				onSwitch(e, item, !item.isVisible);
+			};
 			ret = true;
 		});
 
@@ -218,6 +227,8 @@ const MenuGroupList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		});
 
 		return () => {
+			isUnmountedRef.current = true;
+
 			unbind();
 			S.Menu.closeAll(J.Menu.cell);
 		};

--- a/src/ts/component/menu/dataview/option/edit.tsx
+++ b/src/ts/component/menu/dataview/option/edit.tsx
@@ -13,6 +13,7 @@ const MenuOptionEdit = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	const colorRef = useRef('');
 	const n = useRef(-1);
 	const keydownHandler = useRef(null);
+	const isUnmountedRef = useRef(false);
 
 	const rebind = () => {
 		unbind();
@@ -56,6 +57,12 @@ const MenuOptionEdit = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 
 	const onKeyDownHandler = (e: any) => {
+		// A leaked window listener must never act for a dead menu — bail before
+		// any preventDefault or it silently eats the key app-wide until restart
+		if (isUnmountedRef.current) {
+			return;
+		};
+
 		let ret = false;
 
 		keyboard.shortcut('enter', e, () => {
@@ -233,6 +240,8 @@ const MenuOptionEdit = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		setDummy(dummy + 1);
 
 		return () => {
+			isUnmountedRef.current = true;
+
 			unbind();
 		};
 	}, []);

--- a/src/ts/component/menu/dataview/relation/edit.tsx
+++ b/src/ts/component/menu/dataview/relation/edit.tsx
@@ -37,6 +37,8 @@ const MenuDataviewRelationEdit = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		rebind();
 
 		return () => {
+			isUnmountedRef.current = true;
+
 			menuClose();
 			unbind();
 		};
@@ -50,6 +52,7 @@ const MenuDataviewRelationEdit = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	});
 
 	const keydownHandler = useRef<(e: any) => void>(null);
+	const isUnmountedRef = useRef(false);
 
 	const rebind = () => {
 		unbind();
@@ -519,6 +522,12 @@ const MenuDataviewRelationEdit = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 
 	const onKeyDown = (e: any) => {
+		// A leaked window listener must never act for a dead menu — bail before
+		// any preventDefault or it silently eats the key app-wide until restart
+		if (isUnmountedRef.current) {
+			return;
+		};
+
 		keyboard.shortcut('enter', e, () => onSubmit(e));
 	};
 

--- a/src/ts/component/menu/dataview/relation/list.tsx
+++ b/src/ts/component/menu/dataview/relation/list.tsx
@@ -27,6 +27,7 @@ const MenuRelationList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	);
 	const keydownHandler = useRef<(e: any) => void>(null);
 	const keyHandlerRef = useRef<(e: any) => void>(null);
+	const isUnmountedRef = useRef(false);
 
 	const rebind = () => {
 		unbind();
@@ -44,6 +45,12 @@ const MenuRelationList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 
 	const onKeyDownHandler = (e: any) => {
+		// A leaked window listener must never act for a dead menu — bail before
+		// any preventDefault or it silently eats the key app-wide until restart
+		if (isUnmountedRef.current) {
+			return;
+		};
+
 		const items = getItems();
 		const item = items[n.current];
 
@@ -82,7 +89,7 @@ const MenuRelationList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			noAnimation: true,
 			noFlipY: true,
 			rebind,
-			parentId: getId(),
+			parentId: props.id,
 			data: {
 				...data,
 				menuIdEdit: 'dataviewRelationEdit',
@@ -138,7 +145,7 @@ const MenuRelationList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			horizontal: I.MenuDirection.Center,
 			noAnimation: true,
 			rebind,
-			parentId: getId(),
+			parentId: props.id,
 			data: {
 				...data,
 				relationId: relation.id,
@@ -297,6 +304,8 @@ const MenuRelationList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		});
 
 		return () => {
+			isUnmountedRef.current = true;
+
 			unbind();
 			S.Menu.closeAll(J.Menu.cell);
 		};

--- a/src/ts/component/menu/dataview/template/list.tsx
+++ b/src/ts/component/menu/dataview/template/list.tsx
@@ -14,6 +14,7 @@ const MenuTemplateList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	const nodeRef = useRef(null);
 	const n = useRef(0);
 	const keydownHandler = useRef(null);
+	const isUnmountedRef = useRef(false);
 	const subId = [ getId(), 'data' ].join('-');
 
 	const rebind = () => {
@@ -30,6 +31,12 @@ const MenuTemplateList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 
 	const onKeyDownHandler = (e: any) => {
+		// A leaked window listener must never act for a dead menu — bail before
+		// any preventDefault or it silently eats the key app-wide until restart
+		if (isUnmountedRef.current) {
+			return;
+		};
+
 		let ret = false;
 
 		keyboard.shortcut('arrowup, arrowleft, arrowdown, arrowright', e, (pressed: string) => {
@@ -232,6 +239,8 @@ const MenuTemplateList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		load();
 
 		return () => {
+			isUnmountedRef.current = true;
+
 			U.Subscription.destroyList([ subId ]);
 			unbind();
 		};

--- a/src/ts/component/menu/dataview/text.tsx
+++ b/src/ts/component/menu/dataview/text.tsx
@@ -13,8 +13,16 @@ const MenuDataviewText = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	const inputRef = useRef(null);
 	const n = useRef(-1);
 	const keydownHandler = useRef(null);
+	const isUnmountedRef = useRef(false);
+	const timeoutBind = useRef(0);
 	const length = value.length;
 	const valueRef = useRef(value);
+
+	useEffect(() => {
+		return () => {
+			isUnmountedRef.current = true;
+		};
+	}, []);
 
 	useEffect(() => {
 		rebind();
@@ -27,7 +35,7 @@ const MenuDataviewText = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 
 	const rebind = () => {
 		unbind();
-		
+
 		if (inputRef.current) {
 			inputRef.current.setValue(U.String.htmlSpecialChars(value));
 			inputRef.current.setRange({ from: length, to: length });
@@ -35,7 +43,7 @@ const MenuDataviewText = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			inputRef.current.setFocus();
 		};
 
-		window.setTimeout(() => {
+		timeoutBind.current = window.setTimeout(() => {
 			setActive();
 			keydownHandler.current = (e: any) => onKeyDownHandler(e);
 			U.Dom.addEvent(window, 'keydown', keydownHandler.current);
@@ -43,6 +51,10 @@ const MenuDataviewText = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 
 	const unbind = () => {
+		// The add runs on a timer — cancel a pending one or it re-adds the
+		// listener after unmount with nobody left to remove it
+		window.clearTimeout(timeoutBind.current);
+
 		if (keydownHandler.current) {
 			U.Dom.removeEvent(window, 'keydown', keydownHandler.current);
 			keydownHandler.current = null;
@@ -55,6 +67,12 @@ const MenuDataviewText = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 
 	const onKeyDownHandler = (e: any) => {
+		// A leaked window listener must never act for a dead menu — bail before
+		// any preventDefault or it silently eats the key app-wide until restart
+		if (isUnmountedRef.current) {
+			return;
+		};
+
 		let ret = false;
 		const hasActions = actions.length > 0;
 

--- a/src/ts/component/menu/dataview/view/layout.tsx
+++ b/src/ts/component/menu/dataview/view/layout.tsx
@@ -15,6 +15,7 @@ const MenuViewLayout = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	const saveParam = useRef<any>({});
 	const { type } = saveParam.current;
 	const [ dummy, setDummy ] = useState(0);
+	const isUnmountedRef = useRef(false);
 
 	useEffect(() => {
 		saveParam.current = U.Common.objectCopy(data.view.get());
@@ -23,6 +24,8 @@ const MenuViewLayout = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		position();
 
 		return () => {
+			isUnmountedRef.current = true;
+
 			unbind();
 			save();
 			menuClose();
@@ -46,6 +49,12 @@ const MenuViewLayout = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 	
 	const onKeyDownHandler = (e: any) => {
+		// A leaked window listener must never act for a dead menu — bail before
+		// any preventDefault or it silently eats the key app-wide until restart
+		if (isUnmountedRef.current) {
+			return;
+		};
+
 		const item = getItems()[n.current];
 
 		let ret = false;

--- a/src/ts/component/menu/index.tsx
+++ b/src/ts/component/menu/index.tsx
@@ -214,6 +214,11 @@ const Menu = forwardRef<RefProps, I.Menu>((props, ref) => {
 	const isUnmountedRef = useRef(false);
 	const framePosition = useRef(0);
 
+	// Stable per-instance handle registered in S.Menu.refs so a closing submenu
+	// can rebind the LIVE instance of its parent (see rebindPrevious) instead of
+	// whatever closure was captured when the submenu opened
+	const liveRef = useRef({ rebind: () => childRef.current?.rebind?.() });
+
 	const getContext = () => ({
 		getChildRef: () => childRef.current,
 		close,
@@ -225,6 +230,8 @@ const Menu = forwardRef<RefProps, I.Menu>((props, ref) => {
 	useImperativeHandle(ref, getContext);
 
 	useEffect(() => {
+		S.Menu.setRef(id, liveRef.current);
+
 		polyRef.current = U.Dom.get('menu-polygon');
 		setClass();
 		position();
@@ -254,6 +261,7 @@ const Menu = forwardRef<RefProps, I.Menu>((props, ref) => {
 
 			isUnmountedRef.current = true;
 
+			S.Menu.deleteRef(id, liveRef.current);
 			unbind();
 
 			if (el) {
@@ -294,14 +302,21 @@ const Menu = forwardRef<RefProps, I.Menu>((props, ref) => {
 	const rebindPrevious = () => {
 		childRef.current?.unbind?.();
 
-		// Without parentId we can't verify that the menu owning param.rebind
-		// is still mounted — calling rebind() on an unmounted owner re-adds
-		// its window keydown listener with nobody left to remove it, which
-		// silently leaks an `e.preventDefault()` on space across the whole tab.
+		// param.rebind/data.rebind only signal INTENT to restore the parent's
+		// keydown handling — the closures themselves are never called. They were
+		// captured when this submenu opened, so after the parent is closed and
+		// reopened under the same id they point at a DEAD instance; calling one
+		// re-adds a window keydown listener whose owner has already cleaned up,
+		// silently leaking an `e.preventDefault()` on its keys (e.g. space)
+		// across the whole tab until restart. Resolve the live instance through
+		// the S.Menu ref registry instead — a parent that hasn't mounted yet
+		// binds itself on mount anyway.
+		if (!param.rebind && !data.rebind) {
+			return;
+		};
+
 		if (!parentId) {
-			if (param.rebind) {
-				console.error(`[Menu].rebindPrevious: param.rebind passed without parentId in ${id}, skipping to avoid keydown leak`);
-			};
+			console.error(`[Menu].rebindPrevious: rebind passed without parentId in ${id}, skipping to avoid keydown leak`);
 			return;
 		};
 
@@ -309,13 +324,7 @@ const Menu = forwardRef<RefProps, I.Menu>((props, ref) => {
 			return;
 		};
 
-		if (param.rebind) {
-			param.rebind();
-		} else
-		if (data.rebind) {
-			data.rebind();
-			console.error(`[Menu].rebindPrevious uses data.rebind in ${id}`);
-		};
+		S.Menu.getRef(parentId)?.rebind();
 	};
 
 	const setClass = () => {

--- a/src/ts/component/menu/object.tsx
+++ b/src/ts/component/menu/object.tsx
@@ -295,7 +295,7 @@ const MenuObject = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			className,
 			classNameWrap,
 			rebind,
-			parentId: getId(),
+			parentId: props.id,
 			data: {
 				rootId,
 				blockId: rootId,

--- a/src/ts/component/menu/smile.tsx
+++ b/src/ts/component/menu/smile.tsx
@@ -69,6 +69,8 @@ const MenuSmile = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		analytics.event('ScreenEmoji', { route: data?.route });
 
 		return () => {
+			isUnmountedRef.current = true;
+
 			window.clearTimeout(timeoutMenu.current);
 			window.clearTimeout(timeoutFilter.current);
 
@@ -102,6 +104,7 @@ const MenuSmile = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	}, [ tab, filter ]);
 
 	const keydownHandler = useRef<(e: any) => void>(() => {});
+	const isUnmountedRef = useRef(false);
 
 	const rebind = () => {
 		unbind();
@@ -380,6 +383,12 @@ const MenuSmile = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 
 	const onKeyDown = (e: any) => {
+		// A leaked window listener must never act for a dead menu — bail before
+		// any preventDefault or it silently eats the key app-wide until restart
+		if (isUnmountedRef.current) {
+			return;
+		};
+
 		if (S.Menu.isOpen('smileColor')) {
 			return;
 		};

--- a/src/ts/component/menu/widget/section.tsx
+++ b/src/ts/component/menu/widget/section.tsx
@@ -16,6 +16,7 @@ const MenuWidgetSection = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	const { widgetSections } = S.Common;
 	const nodeRef = useRef(null);
 	const n = useRef(-1);
+	const isUnmountedRef = useRef(false);
 	const sensors = useSensors(
 		useSensor(PointerSensor, { activationConstraint: { distance: 10 } }),
 		useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
@@ -33,6 +34,12 @@ const MenuWidgetSection = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 	};
 
 	const onKeyDownHandler = (e: any) => {
+		// A leaked window listener must never act for a dead menu — bail before
+		// any preventDefault or it silently eats the key app-wide until restart
+		if (isUnmountedRef.current) {
+			return;
+		};
+
 		const items = getItems();
 		const item = items[n.current];
 
@@ -174,6 +181,8 @@ const MenuWidgetSection = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		rebind();
 
 		return () => {
+			isUnmountedRef.current = true;
+
 			unbind();
 		};
 

--- a/src/ts/component/popup/shortcut.tsx
+++ b/src/ts/component/popup/shortcut.tsx
@@ -449,6 +449,15 @@ const PopupShortcut = forwardRef<{}, I.Popup>((props, ref) => {
 		};
 		U.Dom.addEvent(window, 'keydown', keydownHandler.current);
 
+		// This handler preventDefaults EVERY key while recording — it must be
+		// torn down by this effect itself, not rely on a sibling effect's cleanup,
+		// or a leak would eat all keys app-wide until restart
+		return () => {
+			if (keydownHandler.current) {
+				U.Dom.removeEvent(window, 'keydown', keydownHandler.current);
+				keydownHandler.current = null;
+			};
+		};
 	}, [ editingId ]);
 
 	useEffect(() => {

--- a/src/ts/store/menu.ts
+++ b/src/ts/store/menu.ts
@@ -7,6 +7,7 @@ class MenuStore {
 
 	timeout = 0;
 	isAnimatingFlag: Map<string, boolean> = new Map();
+	refs: Map<string, any> = new Map();
 
 	constructor () {
 		makeObservable(this, {
@@ -113,6 +114,37 @@ class MenuStore {
 	 */
 	get (id: string): I.Menu {
 		return this.menuList.find(it => it.id == id);
+	};
+
+	/**
+	 * Registers the live component instance for a menu ID.
+	 * @param {string} id - The menu ID.
+	 * @param {any} ref - The instance handle.
+	 */
+	setRef (id: string, ref: any) {
+		this.refs.set(id, ref);
+	};
+
+	/**
+	 * Gets the live component instance for a menu ID.
+	 * @param {string} id - The menu ID.
+	 * @returns {any} The instance handle, if mounted.
+	 */
+	getRef (id: string): any {
+		return this.refs.get(id);
+	};
+
+	/**
+	 * Removes a registered instance. When ref is passed, only removes if it is
+	 * still the registered one — an unmounting instance must not evict a newer
+	 * instance that reopened under the same ID.
+	 * @param {string} id - The menu ID.
+	 * @param {any} [ref] - The instance handle to match.
+	 */
+	deleteRef (id: string, ref?: any) {
+		if (!ref || (this.refs.get(id) === ref)) {
+			this.refs.delete(id);
+		};
 	};
 
 	/**


### PR DESCRIPTION
## Problem

Users intermittently lose a single key — most visibly **Space** — across the entire app (editor and chat, all spaces) until the app is restarted. Option+Space still types, everything else works. Reported on 0.55.26-beta; same class as the earlier JS-9763 fix, which plugged two instances but not the root cause.

## Root cause

Menus bind their keydown handlers on `window`. When a submenu closes, `rebindPrevious()` restored the parent's handler by calling the `rebind` **closure captured in the submenu's param at open time**. Its safety check `S.Menu.isOpen(parentId)` compares by menu **id, not instance** — and menus stay in the store during the close animation — so if the parent was closed and quickly reopened under the same id while its submenu was closing, the check passed and the **dead** instance's listener was re-added after its cleanup had already run. Nothing ever removes it. Any handler with an unguarded `e.preventDefault()` (plain `space` in the dataview relation-list / view-layout / widget-section / group-list menus, `enter`/arrows in others) then silently eats that key app-wide. `keyboard.shortcut()` matches modifiers exactly, which is why only the bare key dies and Option+Space still worked.

## Fix

**Framework (root cause):**
- `S.Menu` gains a live-instance ref registry (`setRef`/`getRef`/`deleteRef`, identity-guarded delete so an unmounting instance can't evict a newer same-id one)
- `rebindPrevious()` now treats `param.rebind` as intent only and rebinds through the **live registered instance** (`getRef(parentId)` → child's `rebind`); the captured closure is never called, so a dead instance can't be resurrected

**Defense in depth** — `isUnmountedRef` bail before any `preventDefault` in the 11 child menus with local window keydown handlers: `blockAction` (also stops `blockRemove()` firing on Backspace from a dead menu), `blockRelationEdit`, `dataviewRelationList/Edit`, `dataviewViewLayout`, `dataviewGroupList`, `dataviewTemplateList`, `dataviewOptionEdit`, `dataviewText`, `smile`, `widgetSection`

**Individual bugs found during the audit:**
- `dataviewText`: the bind ran in an untracked `setTimeout` — open + quick close re-added the listener after unmount with no owner (leak with no race needed); the timer is now tracked and cancelled
- `popup/shortcut`: the shortcut-recording handler (which preventDefaults every key) now has its own effect cleanup instead of relying on a sibling effect
- `parentId` passed as DOM id (`getId()`) instead of store id in `object`, `dataviewRelationList`, `dataviewFilterValues` — the `isOpen(parentId)` guard never matched, so their rebind-restore path was silently dead
- `dataviewGroupList`: pressing Space with no item hovered threw on `undefined.isVisible`

## Verification

- `bun run typecheck` clean, `bun run lint` 0 errors (7 pre-existing warnings in untouched files)
- Full audit of all 73 files binding window/document key listeners (3 parallel reviewers); adversarial follow-up review traced registry ordering across close/reopen interleavings, all 7 `rebind`-passing call sites, and confirmed no remaining live leak vector
- Docs updated: menu README (window-keydown lifecycle invariants), store README