### PR TITLE
fix: replace linux-distro with direct /etc/os-release parsing (#2236)

### DIFF
--- a/electron/ts/api.ts
+++ b/electron/ts/api.ts
@@ -669,12 +669,52 @@ class Api {
 		return await checkDiskSpace(app.getPath('userData'));
 	};
 
-	async linuxDistro (win: AppWindow): Promise<{ name: string; version: string }> {
-		const load = require('linux-distro');
-		return await load().catch((err: Error) => {
-			Util.log('error', `[Api].linuxDistro: ${err.message}`);
-			return { name: 'Unknown', version: 'Unknown' };
-		});
+	async linuxDistro (win: AppWindow): Promise<{ os: string; name: string; release: string; code: string }> {
+		try {
+			// Read /etc/os-release (standard on modern Linux) or /etc/lsb-release (older)
+			const paths = [ '/etc/os-release', '/usr/lib/os-release', '/etc/lsb-release' ];
+			let content = '';
+
+			for (const p of paths) {
+				try {
+					content = fs.readFileSync(p, 'utf-8');
+					break;
+				} catch (_) {};
+			};
+
+			if (!content) {
+				return { os: 'Linux', name: 'Unknown', release: '', code: '' };
+			};
+
+			const parse = (text: string): Map<string, string> => {
+				const map = new Map<string, string>();
+				for (const line of text.split('\n')) {
+					const trimmed = line.trim();
+					if (!trimmed || trimmed.startsWith('#')) continue;
+					const eq = trimmed.indexOf('=');
+					if (eq < 0) continue;
+					const key = trimmed.slice(0, eq).trim();
+					let val = trimmed.slice(eq + 1).trim();
+					if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+						val = val.slice(1, -1);
+					};
+					map.set(key.toLowerCase(), val);
+				};
+				return map;
+			};
+
+			const vars = parse(content);
+
+			return {
+				os: vars.get('id') || vars.get('distrib_id') || 'linux',
+				name: vars.get('pretty_name') || vars.get('name') || vars.get('distrib_description') || '',
+				release: vars.get('version_id') || vars.get('distrib_release') || '',
+				code: vars.get('version_codename') || vars.get('distrib_codename') || '',
+			};
+		} catch (e: any) {
+			Util.log('error', `[Api].linuxDistro: ${e.message}`);
+			return { os: 'Unknown', name: 'Unknown', release: '', code: '' };
+		}
 	};
 
 	menu (win: AppWindow): void {


### PR DESCRIPTION
## Description

Fixes #2236 — replaces the `linux-distro` npm dependency with a direct read of `/etc/os-release`, eliminating the fragile `execa` CJS/ESM interop chain that caused `TypeError: execa is not a function` on Linux.

## What changed

**Before:** `require('linux-distro')` which internally called `require('execa')`. Since the bundled `execa` is ESM-only (v7), the CJS `require` resolved a module namespace object instead of a callable function, crashing at the call site on line 11 of `linux-distro/index.js`.

**After:** Read `/etc/os-release` (or `/usr/lib/os-release` / `/etc/lsb-release` as fallbacks) directly with `fs.readFileSync`. Parse the `KEY=value` format and return the `{ os, name, release, code }` shape that `analytics.ts` already expects.

## Why not the previous approach

The earlier commit switched from `require()` to dynamic `import()`. This didn't fix the actual problem — `linux-distro@4` is still a CJS module, and its internal `require('execa')` resolves identically regardless of how we import it from the outside. The `try/catch` only masked the crash while returning a wrong-shaped fallback. This version removes the dependency entirely.

## Verification

- `analytics.ts` reads `data.os` and `data.release` — both are now populated from `/etc/os-release`
- esbuild compilation succeeds
- On non-Linux or missing os-release files, returns `{ os: 'Linux', name: 'Unknown', release: '', code: '' }`
