### PR TITLE
GO-7387: fix new object position in collections with sorts

### DIFF
--- a/docs/src/ts/lib/api/README.md
+++ b/docs/src/ts/lib/api/README.md
@@ -40,6 +40,7 @@ The dispatcher manages:
 - Event stream subscription (`listenEvents`) with ordered event processing
 - MobX store updates from server events (block changes, detail updates, subscription counters)
 - Event sorting to ensure correct processing order (e.g., `BlockSetChildrenIds` before `BlockAdd`); event type/data are precomputed once per message before the sort (`SORT_IDS` priority order)
+- Subscription record ordering: `SubscriptionAdd`/`SubscriptionPosition` events apply via the pure `applySubscriptionPosition` (`Lib/util/subscription`); on sorted subscriptions (`getMeta().isSorted`) a `SubscriptionAdd` repositions an optimistically inserted record instead of being skipped. While a freshly created record's name is inline-edited, a position lock (`S.Record.positionLockSet`) stashes reposition events; the dataview applies the stash when editing ends (GO-7387)
 
 ## Protobuf Bindings
 

--- a/docs/src/ts/lib/util/README.md
+++ b/docs/src/ts/lib/util/README.md
@@ -13,7 +13,7 @@
 | `space.ts` | `U.Space` | Dashboard, space list, participants, sharing, publishing |
 | `menu.ts` | `U.Menu` | Menu item builders, vault items, color lists, turnTo options |
 | `embed.ts` | `U.Embed` | Embed HTML generators (YouTube, Vimeo, Google Maps, Figma, etc.) |
-| `subscription.ts` | `U.Subscription` | Data subscription management for real-time updates |
+| `subscription.ts` | `U.Subscription` | Data subscription management for real-time updates; exports pure `applySubscriptionPosition` (record reorder reducer for SubscriptionAdd/Position events, unit-tested in `subscription.test.ts`) |
 | `date.ts` | `U.Date` | Date formatting, calendar helpers |
 | `string.ts` | `U.String` | String manipulation (camelCase, truncate, URL parsing) |
 | `file.ts` | `U.File` | File upload, download, type detection |

--- a/src/ts/component/block/dataview.tsx
+++ b/src/ts/component/block/dataview.tsx
@@ -109,6 +109,10 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 			window.clearTimeout(timeoutFilter.current);
 			cellRefs.current.clear();
 			recordRefs.current.clear();
+
+			// A dangling lock would keep deferring subscription events after the view
+			// is gone; the record order re-syncs on the next subscribe (GO-7387)
+			S.Record.positionLockClear(getSubId(), '');
 		};
 	}, []);
 
@@ -530,6 +534,8 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 			S.Detail.update(subId, { id: object.id, details: object }, true);
 
+			const isSorted = !isViewBoard && S.Record.getMeta(subId, '').isSorted;
+
 			if (!isViewCalendar) {
 				// Board columns render from the group subscription record list as is:
 				// use the raw list, getRecords would apply the object order of the
@@ -591,6 +597,14 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 			if (isViewGraph || isViewCalendar || (U.Object.isNoteLayout(object.layout))) {
 				U.Object.openConfig(e, object);
 			} else {
+				// On sorted subscriptions the middleware repositions the new record right
+				// away (an empty name sorts to the top under Name Asc), which would move
+				// the row while its name is being typed: hold the reposition until editing
+				// ends — setRecordEditingOff applies the stashed position (GO-7387)
+				if (isSorted) {
+					S.Record.positionLockSet(subId, '', object.id);
+				};
+
 				window.setTimeout(() => setRecordEditingOn(e, object.id), 15);
 			};
 
@@ -1599,6 +1613,9 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 		};
 
 		nameRef?.onBlur();
+
+		// Apply any subscription reposition stashed while the name was being edited (GO-7387)
+		U.Subscription.applyPendingPosition(getSubId());
 	};
 
 	const multiSelectAction = (id: string) => {

--- a/src/ts/lib/api/dispatcher.ts
+++ b/src/ts/lib/api/dispatcher.ts
@@ -10,6 +10,7 @@ import { unaryInterceptors, streamInterceptors } from './grpc-devtools';
 import * as I from 'Interface';
 import * as M from 'Model';
 import { liveAddIndex } from 'Lib/util/chatWindow';
+import { applySubscriptionPosition } from 'Lib/util/subscription';
 
 const SORT_IDS = [
 	'BlockAdd',
@@ -1639,15 +1640,6 @@ class Dispatcher {
 		};
 	};
 
-	/**
-	 * Update the position of a record within a subscription's ordered list.
-	 * Used for maintaining correct sort order when items are added or moved.
-	 *
-	 * @param subId - Subscription ID containing the record list
-	 * @param id - ID of the record to position
-	 * @param afterId - ID of the record after which to place the item (empty for start)
-	 * @param isAdding - Whether this is a new addition (skip if already exists)
-	 */
 	parseSubId (subId: string): [string, string] {
 		const idx = subId.indexOf('/');
 		if (idx === -1) {
@@ -1656,36 +1648,36 @@ class Dispatcher {
 		return [ subId.slice(0, idx), subId.slice(idx + 1) ];
 	};
 
+	/**
+	 * Update the position of a record within a subscription's ordered list.
+	 * Used for maintaining correct sort order when items are added or moved.
+	 *
+	 * @param subId - Subscription ID containing the record list
+	 * @param id - ID of the record to position
+	 * @param afterId - ID of the record after which to place the item (empty for start)
+	 * @param isAdding - Whether this is a new addition (repositions an already present record only on sorted subscriptions)
+	 */
 	subscriptionPosition (subId: string, id: string, afterId: string, isAdding: boolean): void {
 		const [ sid, dep ] = this.parseSubId(subId);
 		if (dep) {
 			return;
 		};
 
-		let records = S.Record.getRecordIds(sid, '');
-		let newIndex = records.indexOf(afterId);
-
-		const oldIndex = records.indexOf(id);
-
-		if (isAdding && (oldIndex >= 0)) {
+		// While the record's name is being inline-edited, stash the position instead
+		// of applying it — moving the row would remount the editor mid-typing. The
+		// stash is applied when editing ends (GO-7387)
+		const lock = S.Record.getPositionLock(sid, '');
+		if (lock && (lock.id == id)) {
+			S.Record.positionLockStash(sid, '', afterId);
 			return;
 		};
 
-		if (!afterId) {
-			newIndex = 0;
-		} else
-		if ((newIndex >= 0) && (newIndex < oldIndex)) {
-			newIndex++;
-		};
+		const { isSorted } = S.Record.getMeta(sid, '');
+		const records = applySubscriptionPosition(S.Record.getRecordIds(sid, ''), id, afterId, isAdding, isSorted);
 
-		if (oldIndex < 0) {
-			records.splice(afterId ? newIndex + 1 : 0, 0, id);
-		} else
-		if (oldIndex !== newIndex) {
-			records = arrayMove(records, oldIndex, newIndex);
+		if (records) {
+			S.Record.recordsSet(sid, '', records);
 		};
-
-		S.Record.recordsSet(sid, '', records);
 	};
 
 	/**

--- a/src/ts/lib/dataview.ts
+++ b/src/ts/lib/dataview.ts
@@ -166,6 +166,14 @@ class Dataview {
 		]);
 		let sorts = U.Common.objectCopy(view.sorts).concat(param.sorts || []);
 
+		const order = block ? block.content.objectOrder.find(it => (it.viewId == view.id) && (it.groupId == '')) : null;
+		const orderIds = order ? order.objectIds || [] : [];
+
+		// The record order is defined by explicit view sorts only when no manual order
+		// overrides them: for such subscriptions the dispatcher lets SubscriptionAdd
+		// reposition optimistically inserted records to the middleware position (GO-7387)
+		meta.isSorted = !orderIds.length && (this.getFilteredSorts(sorts).length > 0);
+
 		if (viewChange) {
 			meta.viewId = newViewId;
 		};
@@ -180,13 +188,8 @@ class Dataview {
 
 		S.Record.metaSet(subId, '', meta);
 
-		if (block) {
-			const el = block.content.objectOrder.find(it => (it.viewId == view.id) && (it.groupId == ''));
-			const objectIds = el ? el.objectIds || [] : [];
-
-			if (objectIds.length) {
-				sorts.unshift({ relationKey: 'id', type: I.SortType.Custom, customOrder: objectIds });
-			};
+		if (orderIds.length) {
+			sorts.unshift({ relationKey: 'id', type: I.SortType.Custom, customOrder: orderIds });
 		};
 
 		filters = this.getFilteredFilters(filters).map(it => this.filterMapper({ ...it, includeTime: false }, { rootId }));

--- a/src/ts/lib/util/subscription.test.ts
+++ b/src/ts/lib/util/subscription.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { applySubscriptionPosition } from './subscription';
+
+/**
+ * Regression coverage for GO-7387: in a collection with an explicit sort (e.g. Name Asc),
+ * an object created via "+ New object" stayed at the bottom of the list instead of moving
+ * to its sorted position.
+ *
+ * The client optimistically appends the created id to the record list before the
+ * middleware processes ObjectCollectionAdd. The middleware then emits SubscriptionAdd
+ * with the correct sorted position (afterId), but the reducer skipped every
+ * SubscriptionAdd whose id was already present, so the optimistic tail position stuck.
+ * Follow-up SubscriptionPosition events are only emitted when the record's relative
+ * order changes middleware-side — renaming the object to a name that keeps its slot
+ * (empty names sort first under Name Asc, so e.g. "a" never moves) produced no event,
+ * and the record was stranded at the bottom permanently.
+ *
+ * The fix: on sorted subscriptions a SubscriptionAdd for an already present id is
+ * applied as a move to the middleware position. Unsorted (manually ordered)
+ * subscriptions keep the old behavior — there the optimistic index is the user's
+ * chosen insert position and must win. While the record's name is being
+ * inline-edited the dispatcher stashes the position via a position lock instead
+ * (so the row does not move mid-typing) and the dataview replays it through this
+ * function when editing ends.
+ */
+describe('applySubscriptionPosition', () => {
+
+	const base = [ 'r1', 'r2', 'r3' ];
+
+	describe('SubscriptionAdd, id not in the list', () => {
+
+		it('inserts at head when afterId is empty', () => {
+			expect(applySubscriptionPosition(base, 'x', '', true, false)).toEqual([ 'x', 'r1', 'r2', 'r3' ]);
+		});
+
+		it('inserts after afterId', () => {
+			expect(applySubscriptionPosition(base, 'x', 'r2', true, false)).toEqual([ 'r1', 'r2', 'x', 'r3' ]);
+		});
+
+	});
+
+	describe('SubscriptionAdd, id already in the list (optimistic insert)', () => {
+
+		it('keeps the optimistic position on unsorted subscriptions', () => {
+			expect(applySubscriptionPosition([ ...base, 'x' ], 'x', '', true, false)).toBeNull();
+		});
+
+		it('moves an optimistically appended record to the head on sorted subscriptions (GO-7387)', () => {
+			expect(applySubscriptionPosition([ ...base, 'x' ], 'x', '', true, true)).toEqual([ 'x', 'r1', 'r2', 'r3' ]);
+		});
+
+		it('moves an optimistically appended record after afterId on sorted subscriptions', () => {
+			expect(applySubscriptionPosition([ ...base, 'x' ], 'x', 'r1', true, true)).toEqual([ 'r1', 'x', 'r2', 'r3' ]);
+		});
+
+		it('keeps the list unchanged when the record is already at the middleware position', () => {
+			expect(applySubscriptionPosition([ 'x', ...base ], 'x', '', true, true)).toEqual([ 'x', 'r1', 'r2', 'r3' ]);
+		});
+
+	});
+
+	describe('SubscriptionPosition', () => {
+
+		it('moves a record towards the head, placing it after afterId', () => {
+			expect(applySubscriptionPosition([ ...base, 'x' ], 'x', 'r1', false, false)).toEqual([ 'r1', 'x', 'r2', 'r3' ]);
+		});
+
+		it('moves a record towards the tail, placing it after afterId', () => {
+			expect(applySubscriptionPosition([ 'x', ...base ], 'x', 'r2', false, false)).toEqual([ 'r1', 'r2', 'x', 'r3' ]);
+		});
+
+		it('moves a record to the head when afterId is empty', () => {
+			expect(applySubscriptionPosition([ ...base, 'x' ], 'x', '', false, false)).toEqual([ 'x', 'r1', 'r2', 'r3' ]);
+		});
+
+		it('inserts a missing record after afterId', () => {
+			expect(applySubscriptionPosition(base, 'x', 'r3', false, false)).toEqual([ 'r1', 'r2', 'r3', 'x' ]);
+		});
+
+	});
+
+	describe('GO-7387 scenario replay', () => {
+
+		// Name Asc collection of bookmarks; B1 sorts before "b", B2..B7 after "c" and before "z".
+		// Objects are created unnamed (sorting to the head middleware-side), optimistically
+		// appended at the tail client-side, then renamed to a, z, b, c.
+		it('places every created object correctly once SubscriptionAdd is applied as a move', () => {
+			const apply = (records: string[], id: string, afterId: string, isAdding: boolean) => {
+				return applySubscriptionPosition(records, id, afterId, isAdding, true) || records;
+			};
+
+			let records = [ 'B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7' ];
+
+			// create "a": optimistic append, then SubscriptionAdd(head); the rename to "a"
+			// keeps the head slot middleware-side, so no SubscriptionPosition ever follows
+			records = apply([ ...records, 'a' ], 'a', '', true);
+			expect(records[0]).toBe('a');
+
+			// create "z": optimistic append, SubscriptionAdd(head), rename moves it after B7
+			records = apply([ ...records, 'z' ], 'z', '', true);
+			records = apply(records, 'z', 'B7', false);
+
+			// create "b": same flow, rename moves it after B1
+			records = apply([ ...records, 'b' ], 'b', '', true);
+			records = apply(records, 'b', 'B1', false);
+
+			// create "c": same flow, rename moves it after "b"
+			records = apply([ ...records, 'c' ], 'c', '', true);
+			records = apply(records, 'c', 'b', false);
+
+			expect(records).toEqual([ 'a', 'B1', 'b', 'c', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'z' ]);
+		});
+
+	});
+
+});

--- a/src/ts/lib/util/subscription.ts
+++ b/src/ts/lib/util/subscription.ts
@@ -2,6 +2,52 @@ import sha1 from 'sha1';
 import * as I from 'Interface';
 
 /**
+ * Computes the next record id list for a SubscriptionAdd / SubscriptionPosition event.
+ * Returns null when the list must not change.
+ *
+ * A SubscriptionAdd for an id that is already in the list keeps the client's position:
+ * optimistic inserts pick the index the user chose, and in manually ordered views the
+ * middleware position must not override it. Sorted subscriptions are the exception —
+ * there the middleware position is authoritative, and keeping the optimistic position
+ * desyncs the client from the subscription window permanently, because follow-up
+ * SubscriptionPosition events are only sent when the order changes middleware-side (GO-7387).
+ *
+ * @param {string[]} records - The current record id list.
+ * @param {string} id - The record id from the event.
+ * @param {string} afterId - The id to place the record after; empty string means head.
+ * @param {boolean} isAdding - Whether the event is a SubscriptionAdd (vs SubscriptionPosition).
+ * @param {boolean} isSorted - Whether the subscription order is defined by explicit view sorts.
+ * @returns {string[] | null} The new record id list, or null when no change should be applied.
+ */
+export const applySubscriptionPosition = (records: string[], id: string, afterId: string, isAdding: boolean, isSorted: boolean): string[] | null => {
+	const oldIndex = records.indexOf(id);
+
+	if (isAdding && (oldIndex >= 0) && !isSorted) {
+		return null;
+	};
+
+	records = [ ...records ];
+
+	let newIndex = records.indexOf(afterId);
+
+	if (!afterId) {
+		newIndex = 0;
+	} else
+	if ((newIndex >= 0) && (newIndex < oldIndex)) {
+		newIndex++;
+	};
+
+	if (oldIndex < 0) {
+		records.splice(afterId ? newIndex + 1 : 0, 0, id);
+	} else
+	if (oldIndex !== newIndex) {
+		records.splice(newIndex < 0 ? records.length + newIndex : newIndex, 0, records.splice(oldIndex, 1)[0]);
+	};
+
+	return records;
+};
+
+/**
  * Utility class for managing subscriptions, search, and data synchronization in the application.
  * Provides methods for subscribing to object changes, searching, and managing subscription state.
  */
@@ -66,6 +112,28 @@ class UtilSubscription {
 		};
 
 		S.Record.recordsSet(subId, '', message.records.map(it => it[idField]).filter(it => it));
+	};
+
+	/**
+	 * Applies the position stashed for a position-locked record and releases the lock.
+	 * Called when inline name editing of a freshly created record ends, moving the row
+	 * to the position the middleware reported while the lock was held (GO-7387).
+	 * @param {string} subId - The subscription ID.
+	 */
+	applyPendingPosition (subId: string) {
+		const lock = S.Record.getPositionLock(subId, '');
+
+		S.Record.positionLockClear(subId, '');
+
+		if (!lock || !lock.hasPending) {
+			return;
+		};
+
+		const records = applySubscriptionPosition(S.Record.getRecordIds(subId, ''), lock.id, lock.afterId, false, true);
+
+		if (records) {
+			S.Record.recordsSet(subId, '', records);
+		};
 	};
 
 	/**

--- a/src/ts/store/record.ts
+++ b/src/ts/store/record.ts
@@ -35,6 +35,7 @@ class RecordStore {
 	public metaMap: Map<string, any> = observable.map(new Map());
 	public groupMap: Map<string, any> = observable.map(new Map());
 	public spaceMap: Map<string, string> = new Map();
+	public positionLockMap: Map<string, { id: string; afterId: string; hasPending: boolean }> = new Map();
 
 	constructor() {
 		makeObservable(this, {
@@ -71,6 +72,7 @@ class RecordStore {
 		this.metaMap.clear();
 		this.groupMap.clear();
 		this.spaceMap.clear();
+		this.positionLockMap.clear();
 	};
 
 	/**
@@ -289,6 +291,52 @@ class RecordStore {
 	 */
 	metaClear (rootId: string, blockId: string) {
 		this.metaMap.delete(this.getId(rootId, blockId));
+	};
+
+	/**
+	 * Locks the subscription position of a record: reposition events for it are
+	 * stashed instead of applied until the lock is cleared. Used while the record's
+	 * name is being inline-edited, so the row does not move mid-typing (GO-7387).
+	 * @param {string} rootId - The root ID (subscription ID).
+	 * @param {string} blockId - The block ID.
+	 * @param {string} id - The record ID to lock.
+	 */
+	positionLockSet (rootId: string, blockId: string, id: string) {
+		this.positionLockMap.set(this.getId(rootId, blockId), { id, afterId: '', hasPending: false });
+	};
+
+	/**
+	 * Stashes the latest deferred position for a locked record.
+	 * @param {string} rootId - The root ID (subscription ID).
+	 * @param {string} blockId - The block ID.
+	 * @param {string} afterId - The record ID to place the locked record after; empty string means head.
+	 */
+	positionLockStash (rootId: string, blockId: string, afterId: string) {
+		const lock = this.positionLockMap.get(this.getId(rootId, blockId));
+
+		if (lock) {
+			lock.afterId = afterId;
+			lock.hasPending = true;
+		};
+	};
+
+	/**
+	 * Gets the position lock for a subscription, if any.
+	 * @param {string} rootId - The root ID (subscription ID).
+	 * @param {string} blockId - The block ID.
+	 * @returns {object|null} The lock, or null when the subscription is not locked.
+	 */
+	getPositionLock (rootId: string, blockId: string): { id: string; afterId: string; hasPending: boolean } | null {
+		return this.positionLockMap.get(this.getId(rootId, blockId)) || null;
+	};
+
+	/**
+	 * Clears the position lock for a subscription.
+	 * @param {string} rootId - The root ID (subscription ID).
+	 * @param {string} blockId - The block ID.
+	 */
+	positionLockClear (rootId: string, blockId: string) {
+		this.positionLockMap.delete(this.getId(rootId, blockId));
 	};
 
 	/**
@@ -731,6 +779,7 @@ class RecordStore {
 			offset: Number(map.offset) || 0,
 			viewId: String(map.viewId || ''),
 			keys: map.keys || [],
+			isSorted: Boolean(map.isSorted),
 		};
 	};
 


### PR DESCRIPTION
## Problem

In a collection with Name Asc sort, an object created via "+ New object" sometimes stayed at the bottom instead of moving to its sorted position (confirmed via gRPC event log analysis).

**Root cause:** `recordCreate` optimistically appends the new id to the record list before `ObjectCollectionAdd` is sent. The middleware then emits `SubscriptionAdd` with the correct sorted position (empty names sort first under Name Asc), but the dispatcher dropped the event because the id was already present (`isAdding && oldIndex >= 0` guard). The middleware's minimal-diff protocol only emits a follow-up `SubscriptionPosition` when the record's relative order changes middleware-side — renaming to a name that keeps its slot (e.g. "a", still sorted first) produced no event, so the record was stranded at the bottom permanently.

## Fix

- `Lib/util/subscription`: reorder logic extracted to pure `applySubscriptionPosition()`; on sorted subscriptions a `SubscriptionAdd` for an already present record is applied as a move to the middleware position. Unsorted (manually ordered) views keep the old skip-guard, protecting insert-at-index UX.
- Position lock: while the new record's name is being inline-edited, reposition events are stashed (`S.Record.positionLockSet`/`positionLockStash`) instead of applied — the row holds its creation position during typing and only re-sorts when editing ends (`U.Subscription.applyPendingPosition` on blur/Enter/Escape). Cleared on dataview unmount.
- `Dataview.getData` stamps `meta.isSorted` (explicit view sorts present, no manual object order overriding them; the `createdDate` fallback doesn't count). Board group subscriptions never get it — board behavior (JS-9747/JS-9764) untouched.

## Testing

- Unit: `src/ts/lib/util/subscription.test.ts` — 11 tests incl. a replay of the reported a/z/b/c session; all fail without the fix
- E2E: `anyproto/anytype-desktop-suite` — collection-sort-new-object.spec.ts (companion PR), 3/3 consecutive passes
- `bun run typecheck` / `lint` clean