### PR TITLE
JS-9831: warn when vault data location is in a cloud-synced or network folder

### DIFF
--- a/electron/js/preload.cjs
+++ b/electron/js/preload.cjs
@@ -4,11 +4,283 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const mime = require('mime-types');
+const { execFileSync } = require('child_process');
 const tmpPath = () => app.getPath('temp');
 const commonPath = () => {
 	const dir = path.join(app.getPath('userData'), 'common');
 	try { fs.mkdirSync(dir, { recursive: true }); } catch (e) {};
 	return dir;
+};
+
+// --- Vault data location safety check ---
+
+// Segment-level markers (tested against each path segment to avoid "Sandbox" → "box" false positives).
+const CLOUD_MARKERS = [
+	[ /dropbox/i, 'Dropbox' ],
+	[ /onedrive/i, 'OneDrive' ],
+	[ /^google\s?drive/i, 'Google Drive' ],
+	[ /googledrive/i, 'Google Drive' ],       // macOS File Provider: "GoogleDrive-<email>"
+	[ /icloud/i, 'iCloud Drive' ],
+	[ /nextcloud/i, 'Nextcloud' ],
+	[ /owncloud/i, 'ownCloud' ],
+	[ /^box( sync)?$/i, 'Box' ],
+	[ /pcloud/i, 'pCloud' ],
+	[ /^mega(sync)?$/i, 'MEGA' ],
+	[ /yandex\.?disk/i, 'Yandex.Disk' ],
+	[ /baidu(net|sync)disk/i, 'Baidu' ],
+	[ /syncthing/i, 'Syncthing' ],
+	[ /creative cloud files/i, 'Creative Cloud' ],
+];
+
+// Linux statfs f_type magic numbers for remote filesystems.
+// No FUSE magic here: FUSE also backs local filesystems (ntfs-3g, gocryptfs, exfat-fuse) —
+// remote FUSE backends (sshfs, rclone) are resolved by fstype via /proc/self/mounts instead.
+const NET_MAGIC = {
+	0x6969:     'NFS',
+	0x517b:     'SMB',
+	0xfe534d42: 'SMB',   // SMB2
+	0xff534d42: 'SMB',   // CIFS
+	0x564c:     'NetWare',
+	0xaad7aaea: 'PanFS',
+	0x01021997: 'V9FS',
+	0x73757245: 'Coda',
+};
+
+// Linux fstype names (3rd field of /proc/self/mounts) that mean a remote filesystem.
+const LINUX_REMOTE_FSTYPES = {
+	nfs:            'NFS',
+	nfs4:           'NFS',
+	cifs:           'SMB',
+	smb3:           'SMB',
+	smbfs:          'SMB',
+	davfs:          'WebDAV',
+	'fuse.davfs2':  'WebDAV',
+	'fuse.sshfs':   'SSHFS',
+	'fuse.rclone':  'rclone',
+	'fuse.gcsfuse': 'gcsfuse',
+	'fuse.s3fs':    's3fs',
+	'9p':           '9P',
+	ceph:           'Ceph',
+	glusterfs:      'GlusterFS',
+	afs:            'AFS',
+};
+
+const providerFromSegment = (seg) => {
+	seg = String(seg || '');
+	for (const [ re, name ] of CLOUD_MARKERS) {
+		if (re.test(seg)) {
+			return name;
+		};
+	};
+	return seg.split('-')[0] || '';   // File Provider folders are "<Provider>-<account>"
+};
+
+const providerFromPath = (p) => {
+	const segs = String(p).split(/[\/\\]+/).filter(Boolean);
+	for (const seg of segs) {
+		for (const [ re, name ] of CLOUD_MARKERS) {
+			if (re.test(seg)) {
+				return name;
+			};
+		};
+	};
+	return '';
+};
+
+// Read Dropbox info.json to get the real folder path(s), regardless of folder name.
+const dropboxFolders = () => {
+	const out = [];
+	const files = [];
+
+	if (process.platform == 'win32') {
+		[ process.env.APPDATA, process.env.LOCALAPPDATA ].forEach(d => d && files.push(path.join(d, 'Dropbox', 'info.json')));
+	} else {
+		files.push(path.join(os.homedir(), '.dropbox', 'info.json'));
+	};
+
+	for (const f of files) {
+		try {
+			const data = JSON.parse(fs.readFileSync(f, 'utf8'));
+			Object.keys(data).forEach(k => {
+				if (data[k] && data[k].path) {
+					out.push(data[k].path);
+				};
+			});
+		} catch (e) {};
+	};
+	return out;
+};
+
+// Linux: resolve the fstype of the mount containing p via /proc/self/mounts.
+// Returns a remote-FS name, '' when the mount is a known local type, or null when undetermined.
+const linuxMountType = (p) => {
+	try {
+		const lines = fs.readFileSync('/proc/self/mounts', 'utf8').split('\n');
+		let best = '';
+		let bestType = '';
+
+		for (const line of lines) {
+			const parts = line.split(' ');
+			if (parts.length < 3) {
+				continue;
+			};
+
+			const mnt = parts[1].replace(/\\040/g, ' ').replace(/\\011/g, '\t');
+			const type = parts[2];
+			const pref = mnt.endsWith('/') ? mnt : (mnt + '/');
+
+			if (((p == mnt) || p.startsWith(pref)) && (mnt.length >= best.length)) {
+				best = mnt;
+				bestType = type;
+			};
+		};
+
+		if (!bestType) {
+			return null;
+		};
+		return LINUX_REMOTE_FSTYPES[bestType] || '';
+	} catch (e) {
+		return null;
+	};
+};
+
+const networkType = (p) => {
+	// Windows UNC path (\\server\share). Mapped network drive LETTERS are NOT detected in v1.
+	if ((process.platform == 'win32') && /^\\\\/.test(p)) {
+		return 'Network drive';
+	};
+
+	// Linux: fstype from the mount table is authoritative (distinguishes remote FUSE from local FUSE).
+	if (process.platform == 'linux') {
+		const t = linuxMountType(p);
+		if (null !== t) {
+			return t;
+		};
+	};
+
+	// Fallback: statfs f_type magic.
+	try {
+		if (typeof fs.statfsSync == 'function') {
+			const st = fs.statfsSync(p);
+			const t = Number(st.type) >>> 0;
+			if (NET_MAGIC[t]) {
+				return NET_MAGIC[t];
+			};
+		};
+	} catch (e) {};
+
+	// macOS: statfs.type is not a usable name — parse the mount table instead.
+	if (process.platform == 'darwin') {
+		try {
+			const out = execFileSync('/sbin/mount', { encoding: 'utf8', timeout: 2000 });
+			const NET = { smbfs: 'SMB', nfs: 'NFS', webdav: 'WebDAV', afpfs: 'AFP', ftp: 'FTP' };
+			let best = '';
+			let bestType = '';
+
+			out.split('\n').forEach(line => {
+				// "//u@host/share on /Volumes/x (smbfs, ...)" — greedy so mount points containing " (" parse correctly
+				const m = line.match(/ on (.+) \(([^,)]+)/);
+				if (!m) {
+					return;
+				};
+
+				const mnt = m[1];
+				const type = m[2];
+				const pref = mnt.endsWith('/') ? mnt : (mnt + '/');
+
+				if (((p == mnt) || p.startsWith(pref)) && (mnt.length > best.length)) {
+					best = mnt;
+					bestType = type;
+				};
+			});
+
+			if (NET[bestType]) {
+				return NET[bestType];
+			};
+		} catch (e) {};
+	};
+
+	return '';
+};
+
+// Classifies a path as a cloud-synced or network location.
+// Returns { unsafe, kind: ''|'cloud'|'network', provider, path }.
+const vaultPathClassify = (input) => {
+	let p = String(input || app.getPath('userData'));
+	try { p = fs.realpathSync.native(p); } catch (e) {};   // resolve symlinks — users symlink userData into synced folders
+
+	// Windows realpath can return long-path form: "\\?\C:\..." or "\\?\UNC\server\share".
+	// Normalize it or every Windows path would match the UNC test below.
+	p = p.replace(/^\\\\\?\\UNC\\/i, '\\\\').replace(/^\\\\\?\\/, '');
+
+	const result = { unsafe: false, kind: '', provider: '', path: p };
+	const home = os.homedir();
+	const sep = path.sep;
+	const lc = p.toLowerCase();
+	const startsWith = (base) => !!base && lc.startsWith(String(base).toLowerCase().replace(/[\/\\]+$/, '') + sep);
+
+	// Cloud: canonical macOS File Provider roots
+	const cloudStorage = path.join(home, 'Library', 'CloudStorage');    // Dropbox, GoogleDrive-*, OneDrive-*, Box
+	const mobileDocs = path.join(home, 'Library', 'Mobile Documents');  // iCloud Drive
+
+	if (startsWith(cloudStorage)) {
+		const seg = (p.slice(cloudStorage.length + 1).split(sep)[0]) || '';
+		return { ...result, unsafe: true, kind: 'cloud', provider: providerFromSegment(seg) || 'Cloud storage' };
+	};
+	if (startsWith(mobileDocs)) {
+		return { ...result, unsafe: true, kind: 'cloud', provider: 'iCloud Drive' };
+	};
+
+	// Cloud: OneDrive env vars (Windows)
+	for (const v of [ 'OneDrive', 'OneDriveConsumer', 'OneDriveCommercial' ]) {
+		if (startsWith(process.env[v])) {
+			return { ...result, unsafe: true, kind: 'cloud', provider: 'OneDrive' };
+		};
+	};
+
+	// Cloud: Dropbox info.json real path(s)
+	for (const dp of dropboxFolders()) {
+		if (startsWith(dp) || (lc == String(dp).toLowerCase())) {
+			return { ...result, unsafe: true, kind: 'cloud', provider: 'Dropbox' };
+		};
+	};
+
+	// Cloud: per-segment name markers (low-confidence fallback — warn, not block, so false positives are tolerable)
+	const provider = providerFromPath(p);
+	if (provider) {
+		return { ...result, unsafe: true, kind: 'cloud', provider };
+	};
+
+	// Network / remote filesystem
+	const net = networkType(p);
+	if (net) {
+		return { ...result, unsafe: true, kind: 'network', provider: net };
+	};
+
+	return result;
+};
+
+// Cached — networkType() can shell out to /sbin/mount on macOS and callers run in React render paths.
+const vaultPathCache = new Map();
+const VAULT_PATH_CACHE_TTL = 30000;
+
+const vaultPathInfo = (input) => {
+	const key = String(input || '');
+	const cached = vaultPathCache.get(key);
+
+	if (cached && ((Date.now() - cached.time) < VAULT_PATH_CACHE_TTL)) {
+		return cached.result;
+	};
+
+	const result = vaultPathClassify(input);
+
+	// Bound the cache — the path argument comes from the renderer
+	if (vaultPathCache.size >= 50) {
+		vaultPathCache.delete(vaultPathCache.keys().next().value);
+	};
+
+	vaultPathCache.set(key, { time: Date.now(), result });
+	return result;
 };
 
 contextBridge.exposeInMainWorld('Electron', {
@@ -43,6 +315,7 @@ contextBridge.exposeInMainWorld('Electron', {
 		return ret;
 	},
 	defaultPath: () => path.join(app.getPath('appData'), app.getName()),
+	checkVaultPath: p => vaultPathInfo(p),
 	getTheme: () => ipcRenderer.sendSync('getTheme'),
 	getBgColor: () => ipcRenderer.sendSync('getBgColor'),
 	getConfig: () => ipcRenderer.sendSync('getConfig'),

--- a/src/json/text.json
+++ b/src/json/text.json
@@ -1254,6 +1254,12 @@
 	"popupSettingsOnboardingLocalOnlyConfirmConfirm": "Yes, I accept risks",
 	"popupSettingsOnboardingLocalOnlyConfirmCancel": "No, don't use it",
 
+	"vaultLocationWarningTitle": "Risky data location",
+	"vaultLocationWarningLabel": "Your data is in a synced or network folder",
+	"vaultLocationWarningGeneric": "a synced or network folder",
+	"vaultLocationWarningTextLocal": "Your Vault is stored in %s. In local-only mode there is no backup, and databases in cloud-synced or network folders get corrupted when more than one device writes at the same time — this can permanently destroy your Vault and break search. The data folder also contains local indexes that are not encrypted and are not supposed to be synced, so a third-party sync tool leaks your data to the sync provider. Move the data to a regular local folder on this device.",
+	"vaultLocationWarningTextNetwork": "Your Vault is stored in %s. Anytype already syncs your objects securely via any-sync with end-to-end encryption — layering a second sync (cloud or network drive) on top can corrupt objects, cause inconsistencies, and in some cases lose data. The data folder also contains local indexes that are not encrypted and are not supposed to be synced, so a third-party sync tool leaks your data to the sync provider. Move the data to a regular local folder on this device.",
+
 	"popupSettingsDataLocalFiles": "Local files",
 	"popupSettingsDataOffloadWarningText": "All media files stored <b>in Anytype</b> will be deleted from your current device. They can be downloaded again from a backup node or another device.",
 	"popupSettingsDataOffloadWarningTextLocalOnly": "Be careful: your client is in local-only mode, and data is not backing up to external nodes. Ensure that your files are synced to your other devices before removing them.",

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -46,6 +46,14 @@ $easeSmooth: cubic-bezier(0.4, 0, 0.2, 1);
 
 @mixin pos-abs-mid { position: absolute; left: 50%; top: 50%; }
 
+@mixin dataLocationWarning {
+	display: flex; align-items: center; gap: 0px 8px; padding: 12px;
+	border-radius: 12px; background: var(--color-shape-highlight-medium);
+
+	.icon.warning { width: 20px; height: 20px; flex-shrink: 0; }
+	.label { @include text-small; color: var(--color-text-primary); flex-grow: 1; margin: 0px; padding: 0px; }
+}
+
 @mixin clamp { -webkit-box-orient: vertical; display: -webkit-box; overflow: hidden; }
 @mixin clamp1 { @include clamp; -webkit-line-clamp: 1; }
 @mixin clamp2 { @include clamp; -webkit-line-clamp: 2; }

--- a/src/scss/menu/syncStatus.scss
+++ b/src/scss/menu/syncStatus.scss
@@ -8,6 +8,8 @@
 		}
 		.syncPanel { height: 28px; padding: 0px 16px; display: flex; justify-content: space-between; align-items: center; }
 
+		.dataLocationWarning { @include dataLocationWarning; margin: 8px 16px 0px 16px; flex-shrink: 0; }
+
 		.title { @include text-paragraph; font-weight: 600; padding: 0; color: var(--color-text-primary); }
 		.ReactVirtualized__List { padding: 8px 0px; }
 

--- a/src/scss/page/main/settings.scss
+++ b/src/scss/page/main/settings.scss
@@ -360,6 +360,8 @@
                 .name { @include text-common; }
                 .type { @include text-small; color: var(--color-text-secondary); }
             }
+
+            .dataLocationWarning { @include dataLocationWarning; margin-top: 12px; }
         }
 
         .iconObject { background-color: var(--color-shape-tertiary); border-radius: 4px; }

--- a/src/scss/popup/settings.scss
+++ b/src/scss/popup/settings.scss
@@ -40,6 +40,8 @@
 				}
 				.actionItems:last-child { margin-bottom: 0px; }
 
+				.dataLocationWarning { @include dataLocationWarning; margin: 12px; }
+
 				.select {
 					background: none; border: solid 1px var(--color-shape-secondary); font-weight: 400; text-decoration: none;
 					min-height: 28px; padding: 3px 26px 3px 12px; border-radius: 8px; padding-left: 10px; max-width: 250px;

--- a/src/ts/app.tsx
+++ b/src/ts/app.tsx
@@ -346,6 +346,11 @@ const App: FC = () => {
 		S.Common.isPinnedSet(isPinned || false);
 		S.Common.singleTabSet(isSingleTab);
 
+		// One-time unsafe data location popup: gate on active tab (onInit runs per tab), delay past the boot loader
+		if (S.Common.isActiveTab) {
+			window.setTimeout(() => Action.vaultLocationWarningOnStart(), 3000);
+		};
+
 		U.Data.updateTabsDimmer();
 
 		Action.checkDefaultSpellingLang();

--- a/src/ts/component/menu/syncStatus.tsx
+++ b/src/ts/component/menu/syncStatus.tsx
@@ -4,6 +4,7 @@ import { Title, Icon, IconObject, ObjectName, EmptySearch, UpsellBanner, Label }
 import * as I from 'Interface';
 
 const HEIGHT = 28;
+const WARNING_HEIGHT = 52; // .dataLocationWarning: 44px padding box + 8px top margin
 const LIMIT = 12;
 const SUB_ID = 'syncStatusObjectsList';
 
@@ -341,10 +342,12 @@ const MenuSyncStatus = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		return { id, label, iconName, iconColor, title, message, buttons };
 	};
 
+	const vaultCheck = U.Common.checkVaultPath(S.Common.dataPath);
+
 	const beforePosition = () => {
 		const items = getItems().slice(0, LIMIT);
 		const content = U.Dom.select('.content', getContainer());
-		const height = items.length ? items.length * HEIGHT + 64 : 160;
+		const height = (items.length ? items.length * HEIGHT + 64 : 160) + (vaultCheck.unsafe ? WARNING_HEIGHT : 0);
 
 		U.Dom.css(content, { height: `${height}px` });
 	};
@@ -475,6 +478,13 @@ const MenuSyncStatus = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 					{icons.map((icon, idx) => <PanelIcon key={idx} {...icon} />)}
 				</div>
 			</div>
+
+			{vaultCheck.unsafe ? (
+				<div className="dataLocationWarning" onClick={() => Action.vaultLocationWarning(vaultCheck, { route: analytics.route.syncStatus })}>
+					<Icon name="popup/header/warning" className="warning" />
+					<Label text={translate('vaultLocationWarningLabel')} />
+				</div>
+			) : ''}
 
 			<UpsellBanner components={[ 'storage' ]} className="fromSyncMenu" route={analytics.route.syncStatus} />
 

--- a/src/ts/component/page/main/settings/data/index.tsx
+++ b/src/ts/component/page/main/settings/data/index.tsx
@@ -8,6 +8,7 @@ const PageMainSettingsDataIndex = forwardRef<I.PageRef, I.PageSettingsComponent>
 	const { localUsage } = spaceStorage;
 	const isLocalNetwork = U.Data.isLocalNetwork();
 	const suffix = isLocalNetwork ? 'LocalOnly' : '';
+	const dataCheck = U.Common.checkVaultPath(dataPath);
 	const MiB = 1048576;
 	const autoDownloadOptions = [
 		{ id: '-1', name: translate('commonOff') },
@@ -115,6 +116,13 @@ const PageMainSettingsDataIndex = forwardRef<I.PageRef, I.PageSettingsComponent>
 						<Button color="blank" size={28} text={translate(`commonOpen`)} onClick={onOpenDataLocation} />
 					</div>
 				</div>
+
+				{dataCheck.unsafe ? (
+					<div className="dataLocationWarning" onClick={() => Action.vaultLocationWarning(dataCheck, { isLocalOnly: isLocalNetwork, route: analytics.route.settings })}>
+						<Icon name="popup/header/warning" className="warning" />
+						<Label text={translate('vaultLocationWarningLabel')} />
+					</div>
+				) : ''}
 			</div>
 		</>
 	);

--- a/src/ts/component/popup/settings/onboarding.tsx
+++ b/src/ts/component/popup/settings/onboarding.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useRef, useState } from 'react';
-import { Title, Label, Select, Button, Error } from 'Component';
+import { Title, Label, Select, Button, Error, Icon } from 'Component';
 import * as I from 'Interface';
 
 const PopupSettingsOnboarding = forwardRef<{}, I.Popup>((props, ref) => {
@@ -74,6 +74,11 @@ const PopupSettingsOnboarding = forwardRef<{}, I.Popup>((props, ref) => {
 				onChange('userPath', paths[0]);
 
 				analytics.event('ChangeStorageLocation', { type: 'Change', route: analytics.route.onboarding });
+
+				const check = U.Common.checkVaultPath(paths[0]);
+				if (check.unsafe) {
+					Action.vaultLocationWarning(check, { isLocalOnly: config.mode == I.NetworkMode.Local, route: analytics.route.onboarding });
+				};
 			});
 		};
 
@@ -158,6 +163,8 @@ const PopupSettingsOnboarding = forwardRef<{}, I.Popup>((props, ref) => {
 
 	const isDefault = config.path == U.Common.getElectron().defaultPath();
 	const networkModes = getNetworkModes();
+	const storageCheck = U.Common.checkVaultPath(config.userPath);
+	const isLocalOnly = config.mode == I.NetworkMode.Local;
 
 	return (
 		<div className="mainSides">
@@ -204,6 +211,13 @@ const PopupSettingsOnboarding = forwardRef<{}, I.Popup>((props, ref) => {
 							{!isDefault ? <Button size={28} text={translate('commonReset')} onClick={onResetStorage} /> : ''}
 						</div>
 					</div>
+
+					{storageCheck.unsafe ? (
+						<div className="dataLocationWarning" onClick={() => Action.vaultLocationWarning(storageCheck, { isLocalOnly, route: analytics.route.onboarding })}>
+							<Icon name="popup/header/warning" className="warning" />
+							<Label text={translate('vaultLocationWarningLabel')} />
+						</div>
+					) : ''}
 
 					</div>
 

--- a/src/ts/lib/action.ts
+++ b/src/ts/lib/action.ts
@@ -1445,6 +1445,76 @@ class Action {
 		analytics.event('AddTab', { route: analyticsRoute, spaceType });
 	};
 
+	/**
+	 * Resolves the localized message for an unsafe vault location, adapting to network mode.
+	 * @param {any} check - Result of U.Common.checkVaultPath.
+	 * @param {boolean} isLocalOnly - Whether the account/config is local-only.
+	 */
+	vaultLocationWarningText (check: any, isLocalOnly: boolean): string {
+		const provider = check.provider || translate('vaultLocationWarningGeneric');
+		const key = isLocalOnly ? 'vaultLocationWarningTextLocal' : 'vaultLocationWarningTextNetwork';
+
+		return U.String.sprintf(translate(key), provider);
+	};
+
+	/**
+	 * Opens the explanation popup for an unsafe vault location.
+	 * @param {any} [check] - Result of U.Common.checkVaultPath; if omitted, checks the current data path.
+	 * @param {any} [param] - { isLocalOnly?, route?, onConfirm?, onCancel? }.
+	 */
+	vaultLocationWarning (check?: any, param?: any) {
+		check = check || U.Common.checkVaultPath('');
+		if (!check || !check.unsafe) {
+			return;
+		};
+
+		param = param || {};
+
+		// Post-login the account network is authoritative; pre-login (no account) use the selected network mode.
+		// U.Data.isLocalNetwork() returns true when there is no account, so it can't be used alone.
+		const isLocalOnly = (undefined !== param.isLocalOnly) ? param.isLocalOnly :
+			(S.Auth.account ? U.Data.isLocalNetwork() : (S.Auth.networkConfig.mode == I.NetworkMode.Local));
+
+		analytics.event('ScreenVaultLocationWarning', { type: check.kind, route: param.route });
+
+		S.Popup.open('confirm', {
+			className: 'vaultLocationWarning',
+			data: {
+				iconParam: { name: 'popup/header/warning', color: isLocalOnly ? 'red' : 'orange' },
+				title: translate('vaultLocationWarningTitle'),
+				text: this.vaultLocationWarningText(check, isLocalOnly),
+				textConfirm: translate('commonOk'),
+				colorConfirm: 'blank',
+				canCancel: false,
+				onConfirm: param.onConfirm,
+				onCancel: param.onCancel,
+			},
+		});
+	};
+
+	/**
+	 * One-time-per-location startup check. Shows the popup once, remembers the acknowledged path.
+	 * Re-warns if the user later moves data to a different unsafe location.
+	 */
+	vaultLocationWarningOnStart () {
+		const check = U.Common.checkVaultPath('');
+		if (!check.unsafe) {
+			return;
+		};
+
+		const ack = () => Storage.set('vaultLocationWarned', check.path);
+
+		if (Storage.get('vaultLocationWarned') == check.path) {
+			return;
+		};
+
+		this.vaultLocationWarning(check, {
+			route: analytics.route.app,
+			onConfirm: ack,
+			onCancel: ack,
+		});
+	};
+
 };
 
 export default new Action();

--- a/src/ts/lib/util/common.ts
+++ b/src/ts/lib/util/common.ts
@@ -40,6 +40,26 @@ class UtilCommon {
 	};
 
 	/**
+	 * Classifies a filesystem path as a cloud-synced or network location.
+	 * @param {string} [p] - The path to check; empty defaults to the current userData dir.
+	 * @returns {object} { unsafe, kind: ''|'cloud'|'network', provider, path }.
+	 */
+	checkVaultPath (p?: string) {
+		const fallback = { unsafe: false, kind: '', provider: '', path: String(p || '') };
+		const electron = this.getElectron();
+
+		if (!electron.checkVaultPath) {
+			return fallback; // web mode / non-electron
+		};
+
+		try {
+			return electron.checkVaultPath(p || '') || fallback;
+		} catch (e) {
+			return fallback;
+		};
+	};
+
+	/**
 	 * Returns the global configuration object from the window.
 	 */
 	getGlobalConfig () {


### PR DESCRIPTION
Resolves [JS-9831](https://linear.app/anytype/issue/JS-9831)

## Problem

The Vault (SQLite DBs + local indexes/blockstore) relies on OS file locking, which cloud-sync clients (Dropbox, iCloud, OneDrive, Google Drive, …) and network drives (SMB/NFS/WebDAV) don't honor — a sync daemon rewriting the DB or its `-wal`/`-shm` sidecars corrupts the store. Zotero and Obsidian both detect and warn against this same failure mode. Syncing the data folder via a third-party tool also uploads the unencrypted local indexes, leaking data to the sync provider (objects themselves are E2E-encrypted via any-sync).

## Solution

Detection lives in `electron/js/preload.cjs` (`checkVaultPath`, cached 30s, capped at 50 entries):
- **Cloud:** macOS `~/Library/CloudStorage` + `Mobile Documents` roots, OneDrive env vars (Windows), Dropbox `info.json` real paths, per-segment name markers (Zotero-style fallback; anchored to avoid `Sandbox`/`Inbox` false positives). Symlinks resolved via realpath (with Windows `\\?\` normalization).
- **Network:** UNC paths (Windows), `/proc/self/mounts` fstype (Linux — distinguishes remote FUSE like sshfs/rclone from local FUSE like ntfs-3g/gocryptfs), statfs magic fallback, mount table parse (macOS, 2s timeout).

Warnings on 4 surfaces, copy adapts to network mode (local-only = red/data-loss, networked = orange/inconsistency + index-leak):
1. Onboarding Preferences popup — inline row + popup when picking an unsafe dir
2. Settings → Data Management — inline row under Data location
3. Sync-status menu — non-dismissable row (menu height math adjusted)
4. One-time popup on app start (active tab only, +3s; acknowledged path persisted, re-warns on a different unsafe path)

Warn only — no hard block. Windows cloud/mapped drive letters (e.g. Google Drive File Stream `G:\`) are a documented v1 limitation (needs `GetDriveTypeW`, future Go-side work).

Design spec: `docs/plans/2026-07-22-vault-data-location-safety-warning.md` (not committed). Reviewed by 3 independent review passes (correctness / platform edge cases / conventions); typecheck + lint pass, detection logic smoke-tested on macOS paths.