### PR TITLE
JS-9832: fix oversized role dropdown arrow and explain disabled invite controls

### DIFF
--- a/src/json/text.json
+++ b/src/json/text.json
@@ -1567,6 +1567,7 @@
 	"popupInviteManageShare": "Everyone in the channel can share this invite",
 	"popupInviteManageShareDisabled": "Anyone with this link joins as an editor, without approval. Only you can share it.",
 	"popupInviteManageShareLocked": "This invite is already shared. To take it back, reset the link.",
+	"popupInviteManageEditorDisabled": "This invite is shared with the channel, so it can only grant viewer access.",
 	"popupInviteManageShareConfirmTitle": "Share this invite with the channel?",
 	"popupInviteManageShareConfirmText": "All channel members will be able to see this invite link and share it with anyone. To make it private again, you'll need to reset the link.",
 	"popupInviteManageShareConfirmButton": "Share invite",

--- a/src/scss/form/switch.scss
+++ b/src/scss/form/switch.scss
@@ -15,6 +15,8 @@
 		.inner { width: 20px; height: 20px; }
 	}
 
+	&.isReadonly { opacity: 0.4; }
+
 	&.active { background: var(--color-text-secondary); }
 	&.active {
 		.inner { left: auto; right: 2px; }

--- a/src/ts/component/form/switch.tsx
+++ b/src/ts/component/form/switch.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, useRef, useState, useEffect, useImperativeHandle } from 'react';
+import * as I from 'Interface';
 
 interface Props {
 	id?: string;
@@ -6,6 +7,7 @@ interface Props {
 	color?: 'grey' | 'yellow' | 'orange' | 'red' | 'pink' | 'purple' | 'blue' | 'ice' | 'teal' | 'lime';
 	className?: string;
 	readonly?: boolean;
+	tooltipParam?: Partial<I.TooltipParam>;
 	onChange?(e: any, value: boolean): void;
 };
 
@@ -20,9 +22,10 @@ const Switch = forwardRef<SwitchRefProps, Props>(({
 	color = 'blue',
 	className = '',
 	readonly = false,
+	tooltipParam = {},
 	onChange,
 }, ref: any) => {
-	
+
 	const nodeRef = useRef(null);
 	const [ value, setValue ] = useState(initialValue);
 	const cn = [ 'switch', color, className ];
@@ -46,19 +49,38 @@ const Switch = forwardRef<SwitchRefProps, Props>(({
 		};
 	};
 
+	const onMouseEnterHandler = () => {
+		const { text = '', caption = '' } = tooltipParam;
+		const t = Preview.tooltipCaption(text, caption);
+
+		if (t) {
+			Preview.tooltipShow({ ...tooltipParam, text: t, element: nodeRef.current });
+		};
+	};
+
+	const onMouseLeaveHandler = () => {
+		Preview.tooltipHide(false);
+	};
+
 	useEffect(() => setValue(initialValue), []);
+
+	useEffect(() => {
+		return () => Preview.tooltipHide(false);
+	}, []);
 
 	useImperativeHandle(ref, () => ({
 		getValue: () => value,
 		setValue: (value: boolean) => setValue(value),
 	}));
-	
+
 	return (
-		<div 
+		<div
 			ref={nodeRef}
-			id={id} 
-			className={cn.join(' ')} 
+			id={id}
+			className={cn.join(' ')}
 			onClick={onChangeHandler}
+			onMouseEnter={onMouseEnterHandler}
+			onMouseLeave={onMouseLeaveHandler}
 		>
 			<div className="inner" />
 		</div>

--- a/src/ts/component/popup/invite/add.tsx
+++ b/src/ts/component/popup/invite/add.tsx
@@ -142,7 +142,7 @@ const PopupInviteAdd = forwardRef<{}, I.Popup>((props, ref) => {
 							<div className="item">
 								<div className="name">{translate(`participantPermissions${permissions}`)}</div>
 							</div>
-							<Icon name="arrow/small" className="arrow dark" />
+							<Icon name="arrow/small" className="arrow dark" size={8} />
 						</div>
 					</div>
 

--- a/src/ts/component/popup/invite/manage.tsx
+++ b/src/ts/component/popup/invite/manage.tsx
@@ -109,7 +109,12 @@ const PopupInviteManage = forwardRef<{}, I.Popup>((props, ref) => {
 	const onPermissions = () => {
 		const options = [
 			{ id: String(I.ParticipantPermissions.Reader), name: translate('participantPermissions0') },
-			{ id: String(I.ParticipantPermissions.Writer), name: translate('participantPermissions1'), disabled: isShared },
+			{
+				id: String(I.ParticipantPermissions.Writer),
+				name: translate('participantPermissions1'),
+				disabled: isShared,
+				tooltipParam: isShared ? { text: translate('popupInviteManageEditorDisabled'), className: 'menuNote' } : undefined,
+			},
 		];
 
 		S.Menu.open('select', {
@@ -241,7 +246,14 @@ const PopupInviteManage = forwardRef<{}, I.Popup>((props, ref) => {
 						<Label className="name" text={translate('popupInviteManageShare')} />
 						{shareHint ? <Label className="descr" text={shareHint} /> : ''}
 					</div>
-					<Switch ref={shareRef} className="big" value={isShared} readonly={isShared || !canShare} onChange={onShareWithinSpace} />
+					<Switch
+						ref={shareRef}
+						className="big"
+						value={isShared}
+						readonly={isShared || !canShare}
+						tooltipParam={shareHint ? { text: shareHint } : {}}
+						onChange={onShareWithinSpace}
+					/>
 				</div>
 			</div>
 


### PR DESCRIPTION
## Summary

Fixes UI/UX issues in the invite popups.

### Add members
- The **Select role** dropdown arrow rendered at the default 20×20 and overflowed its 8×8 CSS container, appearing oversized. Now passes `size={8}` so it matches the arrow's 8×8 viewBox — consistent with the equivalent dropdown in **Manage invite link**.

### Manage invite link
Shared invites cannot grant Editor access, but the disabled controls gave no explanation. Now:
- The disabled **Editor** option in the role select shows a hover tooltip: *"This invite is shared with the channel, so it can only grant viewer access."*
- The disabled **Share** toggle shows a hover tooltip with the reason it is locked (reuses the existing description text).
- The readonly **Switch** is now visibly faded (`opacity: 0.4`); previously a locked toggle looked identical to an active one.

### Component
- Added optional `tooltipParam` support to the shared `Switch` component (backward-compatible; defaults to `{}`).

## Notes
- New translation key `popupInviteManageEditorDisabled` will need to flow through the text.json → Crowdin localization pipeline.

Closes JS-9832