### PR TITLE
fix: append bookmark URLs to clipboard on copy (#2212)

### DIFF
--- a/src/ts/lib/action.ts
+++ b/src/ts/lib/action.ts
@@ -679,9 +679,30 @@ class Action {
 				return;
 			};
 
+			let text = String(message.textSlot || '');
+			let html = String(message.htmlSlot || '');
+
+			// The middleware's textSlot/htmlSlot do not include content from
+			// non-text blocks (e.g. bookmarks). Append bookmark URLs so they
+			// appear in the clipboard when pasted into external apps.
+			const bookmarkBlocks = blocks.filter(it =>
+				(it.type == I.BlockType.Bookmark) && it.content?.url
+			);
+			if (bookmarkBlocks.length) {
+				const urls = bookmarkBlocks.map(it => it.content.url);
+				if (text) {
+					text += '\n';
+				};
+				text += urls.join('\n');
+				if (html) {
+					html += '<br/>';
+				};
+				html += urls.map(u => `<a href="${U.String.htmlSpecialChars(u)}">${U.String.htmlSpecialChars(u)}</a>`).join('<br/>');
+			};
+
 			U.Common.clipboardCopy({
-				text: message.textSlot,
-				html: message.htmlSlot,
+				text,
+				html,
 				anytype: {
 					range,
 					blocks: (message.anySlot || []).map(Mapper.From.Block),


### PR DESCRIPTION
## Description

Fixes #2212 — when a user copies blocks that include bookmarks, the bookmark URLs are now included in the clipboard text and HTML content.

## Root cause

The `BlockCopy` gRPC command sends all selected blocks (including bookmarks) to the anytype-heart middleware. The middleware returns three slots:

- `textSlot` — plain text representation
- `htmlSlot` — HTML representation  
- `anySlot` — serialized block objects (for internal Anytype paste)

The middleware does not generate text/HTML content for non-text blocks such as bookmarks. So when pasting into an external app (terminal, text editor), only text block content appears. The `anySlot` already preserves bookmark blocks correctly for internal paste.

## Fix

In `Action.copyBlocks`, after the middleware callback returns, scan the original `blocks` array for `BlockType.Bookmark` blocks that have a URL. Append their URLs to the `textSlot` (newline-separated) and to the `htmlSlot` (as `<a>` links). This ensures bookmark URLs reach the system clipboard in both plain text and HTML formats.

The fix is purely additive — it does not modify or remove any existing clipboard content. If no bookmark blocks are present, the behavior is unchanged.

## Verification

- Unit tests pass (same set of pre-existing failures unrelated to this change)
- When no bookmark blocks are copied, behavior is identical to before
- The `U.String.htmlSpecialChars` helper is used for safe HTML escaping of URLs
