### PR TITLE
fix: lazy-load web clipper iframe (#2290)

### DIFF
--- a/dist/extension/js/foreground.js
+++ b/dist/extension/js/foreground.js
@@ -1,26 +1,63 @@
 (() => {
 
 	const allowedOrigins = [ new URL(chrome.runtime.getURL('/')).origin ];
-	const body = document.querySelector('body');
-	const container = document.createElement('div');
-	const dimmer = document.createElement('div');
-	const iframe = document.createElement('iframe');
+	const containerId = [ 'anytypeWebclipper', 'container' ].join('-');
+	const iframeId = [ 'anytypeWebclipper', 'iframe' ].join('-');
+	let container = null;
+	let iframe = null;
+	let iframeReady = false;
+	let pendingMenu = null;
 
-	if (body && !document.getElementById(iframe.id)) {
-		body.appendChild(container);
+	const hide = () => {
+		if (container) {
+			container.style.display = 'none';
+		};
 	};
 
-	container.id = [ 'anytypeWebclipper', 'container' ].join('-');
-	container.appendChild(iframe);
-	container.appendChild(dimmer);
+	const forwardMenu = () => {
+		if (!iframe || !iframeReady || !pendingMenu || !iframe.contentWindow) {
+			return;
+		};
 
-	iframe.id = [ 'anytypeWebclipper', 'iframe' ].join('-');
-	iframe.src = chrome.runtime.getURL('iframe/index.html');
+		iframe.contentWindow.postMessage(pendingMenu, allowedOrigins[0]);
+		pendingMenu = null;
+	};
 
-	dimmer.className = 'dimmer';
-	dimmer.addEventListener('click', () => {
-		container.style.display = 'none';
-	});
+	const ensureClipper = () => {
+		if (container && iframe) {
+			return true;
+		};
+
+		const body = document.querySelector('body');
+		if (!body) {
+			return false;
+		};
+
+		container = document.getElementById(containerId);
+		iframe = document.getElementById(iframeId);
+		if (container && iframe) {
+			return true;
+		};
+
+		container = document.createElement('div');
+		const dimmer = document.createElement('div');
+		iframe = document.createElement('iframe');
+
+		container.id = containerId;
+		iframe.id = iframeId;
+		iframe.src = chrome.runtime.getURL('iframe/index.html');
+		dimmer.className = 'dimmer';
+		dimmer.addEventListener('click', hide);
+		iframe.addEventListener('load', () => {
+			iframeReady = true;
+			forwardMenu();
+		}, { once: true });
+
+		container.appendChild(iframe);
+		container.appendChild(dimmer);
+		body.appendChild(container);
+		return true;
+	};
 
 	chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 		if (sender.id !== chrome.runtime.id) {
@@ -32,14 +69,13 @@
 				let html = '';
 				const sel = window.getSelection();
 				if (sel && sel.rangeCount) {
-					const container = document.createElement('div');
+					const selectionContainer = document.createElement('div');
 					for (let i = 0, len = sel.rangeCount; i < len; ++i) {
-						container.appendChild(sel.getRangeAt(i).cloneContents());
+						selectionContainer.appendChild(sel.getRangeAt(i).cloneContents());
 					};
-					html = container.innerHTML;
+					html = selectionContainer.innerHTML;
 				};
 
-				// Avoid sending an empty html back to the background script
 				if (!html) {
 					return false;
 				};
@@ -49,12 +85,16 @@
 			};
 
 			case 'clickMenu': {
-				container.style.display = 'block';
+				pendingMenu = { type: 'clickMenu', source: 'foreground', html: msg.html, url: msg.url };
+				if (ensureClipper()) {
+					container.style.display = 'block';
+					forwardMenu();
+				};
 				break;
 			};
 
 			case 'hide': {
-				container.style.display = 'none';
+				hide();
 				break;
 			};
 		};
@@ -68,10 +108,9 @@
 			return;
 		};
 
-		const { data } = e;
-		switch (data.type) {
+		switch (e.data.type) {
 			case 'clickClose':
-				container.style.display = 'none';
+				hide();
 				break;
 		};
 	});

--- a/extension/iframe.tsx
+++ b/extension/iframe.tsx
@@ -51,8 +51,7 @@ const Iframe: FC = () => {
 		U.Router.init(history);
 		U.Smile.init();
 
-		/* @ts-ignore */
-		chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+		const handleMessage = (msg: any, sender: any, sendResponse: (response?: any) => void) => {
 			switch (msg.type) {
 				case 'initIframe':
 					const { appKey, gatewayPort, serverPort } = msg;
@@ -64,6 +63,10 @@ const Iframe: FC = () => {
 					break;
 
 				case 'clickMenu': {
+					if (msg.source !== 'foreground') {
+						break;
+					};
+
 					S.Extension.setTabUrl(msg.url);
 					S.Extension.setHtml(msg.html);
 
@@ -74,7 +77,15 @@ const Iframe: FC = () => {
 
 			};
 			return true;
-		});
+		};
+
+		const handleWindowMessage = (event: MessageEvent) => {
+			if (event.origin !== window.location.origin || event.data?.type !== 'clickMenu') {
+				return;
+			};
+
+			handleMessage(event.data, null, () => {});
+		};
 
 		const onBeforeUnload = () => {
 			if (!S.Auth.token) {
@@ -85,6 +96,17 @@ const Iframe: FC = () => {
 		};
 
 		window.addEventListener('beforeunload', onBeforeUnload);
+		window.addEventListener('message', handleWindowMessage);
+
+		/* @ts-ignore */
+		chrome.runtime.onMessage.addListener(handleMessage);
+
+		return () => {
+			/* @ts-ignore */
+			chrome.runtime.onMessage.removeListener(handleMessage);
+			window.removeEventListener('beforeunload', onBeforeUnload);
+			window.removeEventListener('message', handleWindowMessage);
+		};
 	}, []);
 
 	return (


### PR DESCRIPTION
## Summary

- create the Web Clipper iframe only after explicit `clickMenu` invocation
- prevent duplicate iframe instances with stable IDs
- queue click data until the iframe has finished loading
- clean up iframe runtime and window listeners on unmount

Fixes #2290

## Validation

- `node --check dist/extension/js/foreground.js`
- `bunx tsc --noEmit -p tsconfig.electron.json`
- Full extension build was not available in this environment because the checkout is missing the `mobx-react` dependency.