### PR TITLE
JS-9842: fix crash when opening filter menu with a corrupt filter

### DIFF
--- a/src/ts/component/menu/dataview/filter/list.tsx
+++ b/src/ts/component/menu/dataview/filter/list.tsx
@@ -375,6 +375,12 @@ const MenuFilterList = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			);
 		} else {
 			const isAdvanced = Dataview.isAdvancedFilter(item);
+
+			// Advanced filters carry no relation, any other filter without one is corrupt
+			if (!isAdvanced && !item.relation) {
+				return null;
+			};
+
 			const cn = [ 'item', 'filterItem' ];
 
 			if (isAdvanced) {

--- a/src/ts/lib/dataview.test.ts
+++ b/src/ts/lib/dataview.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import * as I from 'Interface';
+import Dataview from './dataview';
+
+/**
+ * Regression coverage for JS-9842 "Editing filter on inline collection crashes".
+ *
+ * A corrupt filter persisted with an empty relationKey and operator None survived
+ * getFilteredFilters (the `it.relationKey ? ... : true` branch let it through), so the
+ * filter menu resolved `relation: null` and crashed on `item.relation.relationKey`
+ * in Component/menu/dataview/filter/list.tsx.
+ *
+ * Advanced (And/Or) filters legitimately carry an empty relationKey and must survive.
+ */
+
+const relations: any = {
+	name: { relationKey: 'name', isDeleted: false, isArchived: false },
+	deletedKey: { relationKey: 'deletedKey', isDeleted: true, isArchived: false },
+	archivedKey: { relationKey: 'archivedKey', isDeleted: false, isArchived: true },
+};
+
+(globalThis as any).S = {
+	Record: {
+		getRelationByKey: (relationKey: string) => relations[relationKey] || null,
+	},
+};
+
+describe('Dataview.getFilteredFilters', () => {
+
+	it('should keep a filter with a resolvable relation', () => {
+		const filters: any = [ { id: 'f1', relationKey: 'name', operator: I.FilterOperator.None } ];
+
+		expect(Dataview.getFilteredFilters(filters)).toEqual(filters);
+	});
+
+	it('should drop filters with deleted or archived relations', () => {
+		const filters: any = [
+			{ id: 'f1', relationKey: 'deletedKey', operator: I.FilterOperator.None },
+			{ id: 'f2', relationKey: 'archivedKey', operator: I.FilterOperator.None },
+		];
+
+		expect(Dataview.getFilteredFilters(filters)).toEqual([]);
+	});
+
+	it('should drop a filter with an unresolvable relation', () => {
+		const filters: any = [ { id: 'f1', relationKey: 'missingKey', operator: I.FilterOperator.None } ];
+
+		expect(Dataview.getFilteredFilters(filters)).toEqual([]);
+	});
+
+	it('should drop a corrupt filter with an empty relationKey and operator None', () => {
+		const filters: any = [
+			{ id: 'f1', relationKey: '', operator: I.FilterOperator.None },
+			{ id: 'f2', relationKey: 'name', operator: I.FilterOperator.None },
+		];
+
+		expect(Dataview.getFilteredFilters(filters)).toEqual([ filters[1] ]);
+	});
+
+	it('should drop a filter with a missing relationKey and operator None', () => {
+		const filters: any = [ { id: 'f1', operator: I.FilterOperator.None } ];
+
+		expect(Dataview.getFilteredFilters(filters)).toEqual([]);
+	});
+
+	it('should keep advanced filters with an empty relationKey', () => {
+		const filters: any = [
+			{
+				id: 'f1',
+				relationKey: '',
+				operator: I.FilterOperator.And,
+				nestedFilters: [ { id: 'n1', relationKey: 'name', operator: I.FilterOperator.None } ],
+			},
+			{ id: 'f2', relationKey: '', operator: I.FilterOperator.Or, nestedFilters: [] },
+		];
+
+		expect(Dataview.getFilteredFilters(filters)).toEqual(filters);
+	});
+
+	it('should not touch nested filters inside advanced groups', () => {
+		const filters: any = [
+			{
+				id: 'f1',
+				relationKey: '',
+				operator: I.FilterOperator.And,
+				nestedFilters: [
+					{ id: 'n1', relationKey: '', operator: I.FilterOperator.None },
+					{ id: 'n2', relationKey: 'deletedKey', operator: I.FilterOperator.None },
+				],
+			},
+		];
+
+		expect(Dataview.getFilteredFilters(filters)).toEqual(filters);
+	});
+
+	it('should handle empty input', () => {
+		expect(Dataview.getFilteredFilters(null as any)).toEqual([]);
+		expect(Dataview.getFilteredFilters(undefined as any)).toEqual([]);
+		expect(Dataview.getFilteredFilters([])).toEqual([]);
+	});
+
+});
+
+describe('Dataview.getFilteredSorts', () => {
+
+	it('should keep a sort with a resolvable relation', () => {
+		const sorts: any = [ { id: 's1', relationKey: 'name' } ];
+
+		expect(Dataview.getFilteredSorts(sorts)).toEqual(sorts);
+	});
+
+	it('should drop sorts with empty, missing or deleted relations', () => {
+		const sorts: any = [
+			{ id: 's1', relationKey: '' },
+			{ id: 's2' },
+			{ id: 's3', relationKey: 'deletedKey' },
+		];
+
+		expect(Dataview.getFilteredSorts(sorts)).toEqual([]);
+	});
+
+	it('should not throw on null entries', () => {
+		const sorts: any = [ null, { id: 's1', relationKey: 'name' } ];
+
+		expect(Dataview.getFilteredSorts(sorts)).toEqual([ sorts[1] ]);
+	});
+
+	it('should handle empty input', () => {
+		expect(Dataview.getFilteredSorts(null as any)).toEqual([]);
+	});
+
+});

--- a/src/ts/lib/dataview.ts
+++ b/src/ts/lib/dataview.ts
@@ -1239,11 +1239,11 @@ class Dataview {
 	};
 
 	getFilteredFilters (filters: I.Filter[]): I.Filter[] {
-		return (filters || []).filter(it => it.relationKey ? this.checkDeletedRelation(it.relationKey) : true);	
+		return (filters || []).filter(it => it && (this.isAdvancedFilter(it) || this.checkDeletedRelation(it.relationKey)));
 	};
 
 	getFilteredSorts (sorts: I.Sort[]): I.Sort[] {
-		return (sorts || []).filter(it => this.checkDeletedRelation(it.relationKey));	
+		return (sorts || []).filter(it => it && this.checkDeletedRelation(it.relationKey));
 	};
 
 	/**


### PR DESCRIPTION
Fixes [JS-9842](https://linear.app/anytype/issue/JS-9842/editing-filter-on-inline-collection-crashes).

Opening the filter menu on one specific inline collection crashed the app with `TypeError: Cannot read properties of null (reading 'relationKey')`. The crash survived restarts and was confined to a single collection, so it is a corrupt filter persisted in that dataview block's content — not a rendering race.

## Root cause

1. `src/ts/lib/dataview.ts:1242` — `getFilteredFilters`:

   ```ts
   return (filters || []).filter(it => it.relationKey ? this.checkDeletedRelation(it.relationKey) : true);
   ```

   A filter with an **empty** `relationKey` takes the `: true` branch, so `checkDeletedRelation` never runs and the corrupt entry survives filtering.

2. `src/ts/component/menu/dataview/filter/list.tsx:55` — every surviving filter is decorated with `relation: S.Record.getRelationByKey(it.relationKey)`, which returns `null` for an empty/unresolvable key (`src/ts/store/record.ts:709-716`).

3. `src/ts/component/menu/dataview/filter/list.tsx:408` — the row renderer dereferences `item.relation.relationKey` with no null guard. Only the "advanced" branch avoids it, and `Dataview.isAdvancedFilter` (`src/ts/lib/dataview.ts:1212`) is true only for `And`/`Or` operators. A plain filter has `operator: None = 0` (`src/ts/interface/block/dataview.ts:54-58`), so it takes the crashing branch → null deref.

Trigger shape: a persisted top-level filter with `relationKey: ''` and `operator: None`.

The newer filters panel already had this guard — `src/ts/component/block/dataview/filters/item.tsx:24` does `if (!relation) return null;`. Only the older menu was missing it.

## What changed

- `src/ts/lib/dataview.ts` — `getFilteredFilters` now drops any filter without a resolvable relation, with an explicit carve-out for advanced (`And`/`Or`) filters, which legitimately carry an empty `relationKey`. Nested filters inside advanced groups are untouched, as before.
- `src/ts/lib/dataview.ts` — `getFilteredSorts` gained the same `it &&` null-entry guard (it previously called `checkDeletedRelation(it.relationKey)` with no guard on `it` at all). Empty/missing sort relation keys were already dropped, since `getRelationByKey('')` returns `null`.
- `src/ts/component/menu/dataview/filter/list.tsx` — the row renderer returns `null` for a non-advanced filter with no relation, matching `filters/item.tsx`. Defense in depth: a corrupt filter now degrades gracefully instead of taking down the renderer.

No behaviour change for well-formed data: filters that already carried a `relationKey` went through `checkDeletedRelation` before and still do.

## Testing

New unit spec `src/ts/lib/dataview.test.ts` (12 cases) covering `getFilteredFilters` and `getFilteredSorts`, including the exact corrupt shape from this bug and the advanced-filter carve-out that must *not* regress.

Written test-first. Before the fix, 3 cases failed:

```
FAIL  Dataview.getFilteredFilters > should drop a corrupt filter with an empty relationKey and operator None
AssertionError: expected [ { id: 'f1', … }, … ] to deeply equal [ { id: 'f2', … } ]

FAIL  Dataview.getFilteredFilters > should drop a filter with a missing relationKey and operator None
AssertionError: expected [ { id: 'f1', operator: +0 } ] to deeply equal []

FAIL  Dataview.getFilteredSorts > should not throw on null entries
TypeError: Cannot read properties of null (reading 'relationKey')
 ❯ src/ts/lib/dataview.ts:1246:66
```

After the fix all 12 pass.

The `list.tsx` guard is not covered by an automated test: `vitest.config.ts` only picks up `src/**/*.test.ts` (not `.tsx`) and runs in the `node` environment with no DOM or auto-import plugin, so a component render test is not currently possible without changing the test harness. It is verified by inspection against the equivalent guard in `filters/item.tsx`.

- `npm test`: 658 tests, 568 pass / 90 fail. The 90 failures are **pre-existing on `develop`** (baseline at `10f2692ee`: 646 tests, 556 pass / 90 fail — same 7 files, all `ReferenceError: U is not defined` / similar, caused by `unplugin-auto-import` not being wired into `vitest.config.ts`). This PR adds 12 passing tests and fixes none of the pre-existing failures.
- `bunx tsc --noEmit` on both `tsconfig.json` and `tsconfig.electron.json`: clean.
- `biome lint` and `eslint` on the changed files: clean.

## Not a 0.56.0 regression

Reported on app 0.55.5. `getFilteredFilters` has carried the permissive `: true` branch and `list.tsx` has dereferenced `item.relation` unguarded well before the 0.56.0 cycle.
