### PR TITLE
JS-9841: add time editing to the calendar menu

### DIFF
--- a/src/json/text.json
+++ b/src/json/text.json
@@ -250,6 +250,7 @@
 	"commonDescription": "Description",
 	"commonYourName": "Your Name",
 	"commonIncludeTime": "Include time",
+	"commonTime": "Time",
 	"commonShowHide": "Show / Hide",
 	"commonShowKey": "Show and copy Key",
 	"commonPasteLink": "Paste link",

--- a/src/scss/component/calendarSelect.scss
+++ b/src/scss/component/calendarSelect.scss
@@ -59,6 +59,16 @@
 		content: ''; position: absolute; left: 0px; top: 0px; width: 100%; height: 100%; border-radius: inherit; background-color: var(--color-shape-highlight-medium);
 	}
 
+	.time { padding: 8px 16px 0px 16px; margin-top: 8px; border-top: 1px solid var(--color-shape-secondary); }
+	.time {
+		display: flex; align-items: center; justify-content: space-between; gap: 0px 8px;
+
+		.label { color: var(--color-text-secondary); }
+		.input { width: 72px; text-align: right; }
+	}
+
+	.time + .foot { border-top: 0px; margin-top: 4px; }
+
 	.foot { padding: 8px 16px 0px 16px; margin-top: 8px; border-top: 1px solid var(--color-shape-secondary); }
 	.foot {
 		.btn { display: inline-block; vertical-align: top; margin-right: 16px; transition: $transitionAllCommon; }

--- a/src/ts/component/cell/index.tsx
+++ b/src/ts/component/cell/index.tsx
@@ -204,6 +204,11 @@ const Cell = forwardRef<I.CellRef, Props>((props, ref) => {
 				param.data = Object.assign(param.data, {
 					value: param.data.value || U.Date.now(),
 					noKeyboard: true,
+
+					// Without inplace editing the calendar menu is the only editor available,
+					// so it has to offer the time input as well (JS-9841). With inplace
+					// editing the masked input in component/cell/text.tsx already handles time.
+					includeTime: !!noInplace && !!relation.includeTime,
 				});
 					
 				menuId = 'calendar';

--- a/src/ts/component/menu/calendar.tsx
+++ b/src/ts/component/menu/calendar.tsx
@@ -7,7 +7,7 @@ const MenuCalendar = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 
 	const { param, position, getId, close } = props;
 	const { data, className, classNameWrap } = param;
-	const { value, isEmpty, relationKey, canEdit, canClear = true, noKeyboard, getDotMap, onChange } = data;
+	const { value, isEmpty, relationKey, canEdit, canClear = true, noKeyboard, includeTime, getDotMap, onChange } = data;
 	const calendarRef = useRef<CalendarSelectRefProps>(null);
 
 	const onDayClick = (item: CalendarDay, ts: number): boolean => {
@@ -29,6 +29,17 @@ const MenuCalendar = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		S.Menu.updateData(props.id, { value: ts });
 		onChange?.(ts);
 		close();
+	};
+
+	// Unlike a day click, editing the time must not close the menu, the user is
+	// still typing into it
+	const onTimeChange = (ts: number): void => {
+		if (!canEdit) {
+			return;
+		};
+
+		S.Menu.updateData(props.id, { value: ts });
+		onChange?.(ts);
 	};
 
 	const onDayContextMenu = (e: MouseEvent, item: CalendarDay): void => {
@@ -64,6 +75,8 @@ const MenuCalendar = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			enableKeyboard={!noKeyboard}
 			enableHoverState={true}
 			showFooter={canEdit}
+			showTime={!!canEdit && !!includeTime}
+			onTimeChange={onTimeChange}
 			getDotMap={getDotMap}
 			onDayClick={onDayClick}
 			onDayContextMenu={onDayContextMenu}

--- a/src/ts/component/util/menu/calendarSelect.tsx
+++ b/src/ts/component/util/menu/calendarSelect.tsx
@@ -1,7 +1,13 @@
 import React, { forwardRef, useRef, useState, useEffect, useImperativeHandle, MouseEvent } from 'react';
 
-import { Select, Icon } from 'Component';
+import { Select, Icon, Input } from 'Component';
 import * as I from 'Interface';
+
+// The time editor reads and writes 24h values, matching the inline date cell editor
+// in component/cell/text.tsx, which masks and parses the time part as H:i as well.
+const TIME_FORMAT = 'H:i';
+const TIME_MASK = '99:99';
+const TIME_PLACEHOLDER = 'hh:mm';
 
 export interface CalendarDay {
 	d: number;
@@ -25,6 +31,8 @@ interface Props {
 	enableKeyboard?: boolean;
 	enableHoverState?: boolean;
 	showFooter?: boolean;
+	showTime?: boolean;
+	onTimeChange?: (value: number) => void;
 	getDotMap?: (start: number, end: number, cb: (map: Map<string, boolean>) => void) => void;
 	onDayClick?: (item: CalendarDay, ts: number) => boolean | void;
 	onDayContextMenu?: (e: MouseEvent, item: CalendarDay) => void;
@@ -44,7 +52,8 @@ const CalendarSelect = forwardRef<CalendarSelectRefProps, Props>((props, ref) =>
 
 	const {
 		value, onChange, isReadonly, canClear = true, position, menuClassNameWrap, className,
-		isEmpty, enableKeyboard, enableHoverState, showFooter, getDotMap, onDayClick, onDayContextMenu, rebind, unbind,
+		isEmpty, enableKeyboard, enableHoverState, showFooter, showTime, onTimeChange,
+		getDotMap, onDayClick, onDayContextMenu, rebind, unbind,
 	} = props;
 
 	const [ displayValue, setDisplayValue ] = useState(value || U.Date.now());
@@ -53,6 +62,7 @@ const CalendarSelect = forwardRef<CalendarSelectRefProps, Props>((props, ref) =>
 	const selectedDateRef = useRef<CalendarDay | null>(null);
 	const monthRef = useRef(null);
 	const yearRef = useRef(null);
+	const timeRef = useRef(null);
 
 	const { m, y } = U.Date.getCalendarDateParam(displayValue);
 	const valueParam = value ? U.Date.getCalendarDateParam(value) : null;
@@ -110,6 +120,14 @@ const CalendarSelect = forwardRef<CalendarSelectRefProps, Props>((props, ref) =>
 			setDisplayValue(value);
 		};
 	}, [ value ]);
+
+	useEffect(() => {
+		// Keep the time input in sync with external value changes (day click, today/tomorrow),
+		// but never overwrite what the user is currently typing
+		if (showTime && timeRef.current && !timeRef.current.isFocused()) {
+			timeRef.current.setValue(getTimeValue());
+		};
+	}, [ value, showTime ]);
 
 	const keydownHandler = useRef(null);
 
@@ -193,12 +211,62 @@ const CalendarSelect = forwardRef<CalendarSelectRefProps, Props>((props, ref) =>
 		setDisplayValue(U.Date.timestamp(nY, nM, 1));
 	};
 
+	const getTimeValue = (): string => {
+		return value ? U.Date.date(TIME_FORMAT, value) : '';
+	};
+
+	const applyTime = (v: string): void => {
+		const ts = U.Date.withTime(value || U.Date.now(), v);
+
+		if ((ts !== null) && (ts != value)) {
+			onTimeChange?.(ts);
+		};
+	};
+
+	const onTimeKeyDown = (e: any): void => {
+		// The calendar menu binds window level keyboard handlers, they must not
+		// react to keys typed into the time input
+		e.stopPropagation();
+
+		keyboard.shortcut('enter', e, () => {
+			e.preventDefault();
+			timeRef.current?.blur();
+		});
+	};
+
+	const onTimeKeyUp = (e: any, v: string): void => {
+		// Only save once the mask is completely filled, otherwise every keystroke
+		// would write a half typed time to the record
+		if (isReadonly || String(v || '').match(/_/)) {
+			return;
+		};
+
+		applyTime(v);
+	};
+
+	const onTimeBlur = (e: any, v: string): void => {
+		if (isReadonly) {
+			return;
+		};
+
+		if (U.Date.parseTime(v) === null) {
+			timeRef.current?.setValue(getTimeValue());
+			return;
+		};
+
+		applyTime(v);
+	};
+
 	const onClick = (item: CalendarDay): void => {
 		if (!item) {
 			return;
 		};
 
-		const ts = U.Date.timestamp(item.y, item.m, item.d);
+		const day = U.Date.timestamp(item.y, item.m, item.d);
+
+		// With time editing enabled a day click must keep the time part instead of
+		// resetting the value to midnight
+		const ts = (showTime && value) ? U.Date.mergeTimeWithDate(day, value) : day;
 
 		if (onDayClick) {
 			const shouldContinue = onDayClick(item, ts);
@@ -370,6 +438,28 @@ const CalendarSelect = forwardRef<CalendarSelectRefProps, Props>((props, ref) =>
 					);
 				})}
 			</div>
+
+			{showTime ? (
+				<div className="time">
+					<div className="label">{translate('commonTime')}</div>
+					<Input
+						ref={timeRef}
+						id="calendar-time"
+						value={getTimeValue()}
+						placeholder={TIME_PLACEHOLDER}
+						maskOptions={{
+							mask: TIME_MASK,
+							separator: ':',
+							hourFormat: 24,
+							alias: 'datetime',
+						}}
+						readonly={isReadonly}
+						onKeyDown={onTimeKeyDown}
+						onKeyUp={onTimeKeyUp}
+						onBlur={onTimeBlur}
+					/>
+				</div>
+			) : ''}
 
 			{(showFooter ?? !isReadonly) ? (
 				<div className="foot">

--- a/src/ts/lib/util/date.test.ts
+++ b/src/ts/lib/util/date.test.ts
@@ -204,6 +204,71 @@ describe('UtilDate', () => {
 		});
 	});
 
+	describe('parseTime', () => {
+		it('should parse a 24h hh:mm string', () => {
+			expect(UtilDate.parseTime('14:30')).toEqual({ h: 14, i: 30 });
+			expect(UtilDate.parseTime('00:00')).toEqual({ h: 0, i: 0 });
+			expect(UtilDate.parseTime('23:59')).toEqual({ h: 23, i: 59 });
+		});
+
+		it('should parse single digit components', () => {
+			expect(UtilDate.parseTime('9:5')).toEqual({ h: 9, i: 5 });
+		});
+
+		it('should ignore inputmask placeholders and whitespace', () => {
+			expect(UtilDate.parseTime(' 14:30 ')).toEqual({ h: 14, i: 30 });
+			expect(UtilDate.parseTime('14:3_')).toEqual({ h: 14, i: 3 });
+		});
+
+		it('should parse 12h strings with a meridiem suffix', () => {
+			expect(UtilDate.parseTime('2:30 PM')).toEqual({ h: 14, i: 30 });
+			expect(UtilDate.parseTime('2:30am')).toEqual({ h: 2, i: 30 });
+			expect(UtilDate.parseTime('12:15 AM')).toEqual({ h: 0, i: 15 });
+			expect(UtilDate.parseTime('12:15 PM')).toEqual({ h: 12, i: 15 });
+		});
+
+		it('should return null for incomplete or invalid values', () => {
+			expect(UtilDate.parseTime('')).toBe(null);
+			expect(UtilDate.parseTime(null)).toBe(null);
+			expect(UtilDate.parseTime('__:__')).toBe(null);
+			expect(UtilDate.parseTime('14:')).toBe(null);
+			expect(UtilDate.parseTime('1430')).toBe(null);
+			expect(UtilDate.parseTime('24:00')).toBe(null);
+			expect(UtilDate.parseTime('12:60')).toBe(null);
+			expect(UtilDate.parseTime('13:00 PM')).toBe(null);
+		});
+	});
+
+	describe('withTime', () => {
+		it('should apply a time string to the date part of a timestamp', () => {
+			const ts = Math.floor(new Date(2024, 6, 15, 8, 0, 0).getTime() / 1000);
+			const d = new Date(UtilDate.withTime(ts, '14:30') * 1000);
+
+			expect(d.getFullYear()).toBe(2024);
+			expect(d.getMonth()).toBe(6);
+			expect(d.getDate()).toBe(15);
+			expect(d.getHours()).toBe(14);
+			expect(d.getMinutes()).toBe(30);
+			expect(d.getSeconds()).toBe(0);
+		});
+
+		it('should keep the date when the time is midnight', () => {
+			const ts = Math.floor(new Date(2024, 6, 15, 23, 45, 0).getTime() / 1000);
+			const d = new Date(UtilDate.withTime(ts, '00:00') * 1000);
+
+			expect(d.getDate()).toBe(15);
+			expect(d.getHours()).toBe(0);
+			expect(d.getMinutes()).toBe(0);
+		});
+
+		it('should return null for an invalid time string', () => {
+			const ts = Math.floor(new Date(2024, 6, 15).getTime() / 1000);
+
+			expect(UtilDate.withTime(ts, '__:__')).toBe(null);
+			expect(UtilDate.withTime(ts, '25:00')).toBe(null);
+		});
+	});
+
 	describe('getCalendarDateParam', () => {
 		it('should extract day, month, year from timestamp', () => {
 			const ts = Math.floor(new Date(2024, 6, 15).getTime() / 1000);

--- a/src/ts/lib/util/date.ts
+++ b/src/ts/lib/util/date.ts
@@ -421,6 +421,66 @@ class UtilDate {
 	};
 
 	/**
+	 * Parses a time string into hour and minute components.
+	 * Accepts 24h values (14:30) and 12h values with a meridiem suffix (2:30 PM).
+	 * Inputmask placeholders (_) are stripped, so partially typed values simply fail to parse.
+	 * @param {string} value - The time string.
+	 * @returns {{ h: number, i: number } | null} The parsed components, or null when the value is not a complete valid time.
+	 */
+	parseTime (value: string): { h: number, i: number } | null {
+		const v = String(value || '').replace(/_/g, '').trim();
+		const match = v.match(/^(\d{1,2}):(\d{1,2})\s*(am|pm)?$/i);
+
+		if (!match) {
+			return null;
+		};
+
+		const meridiem = String(match[3] || '').toLowerCase();
+		const i = Number(match[2]);
+
+		let h = Number(match[1]);
+
+		if ((i < 0) || (i > 59)) {
+			return null;
+		};
+
+		if (meridiem) {
+			if ((h < 1) || (h > 12)) {
+				return null;
+			};
+
+			h = h % 12;
+
+			if (meridiem == 'pm') {
+				h += 12;
+			};
+		} else
+		if ((h < 0) || (h > 23)) {
+			return null;
+		};
+
+		return { h, i };
+	};
+
+	/**
+	 * Applies a time string to the date part of a timestamp, dropping seconds.
+	 * @param {number} t - The base Unix timestamp.
+	 * @param {string} value - The time string, see parseTime.
+	 * @returns {number | null} The new Unix timestamp, or null when the time string is invalid.
+	 */
+	withTime (t: number, value: string): number | null {
+		const time = this.parseTime(value);
+
+		if (!time) {
+			return null;
+		};
+
+		const { d, m, y } = this.getCalendarDateParam(t);
+
+		return this.timestamp(y, m, d, time.h, time.i, 0);
+	};
+
+	/**
 	 * Returns the calendar date parameters (day, month, year) for a timestamp.
 	 * @param {number} t - The Unix timestamp.
 	 * @returns {{ d: number, m: number, y: number }} The date parameters.


### PR DESCRIPTION
Fixes [JS-9841](https://linear.app/anytype/issue/JS-9841/cant-select-time-for-properties-in-object-header-with-line-layout).

## Root cause

A date property with **Include time** enabled cannot have its time set when the cell is rendered without inplace editing:

1. `src/ts/component/block/featured.tsx:727` — the Inline ("Line") header layout renders its cells with `noInplace={true}`. The Column layout renders a `<Block type=Relation>` instead and does not.
2. `src/ts/component/cell/index.tsx:111` — `setOn()` early-returns when `noInplace`, so the cell never enters inline edit mode.
3. `src/ts/component/cell/text.tsx:213-217` — the `99:99` / `hh:mm` mask is appended only in that inline edit mode, gated on `relation.includeTime`. It was the only place a time could be typed.
4. `src/ts/component/menu/calendar.tsx` — the fallback opened for `noInplace` date cells (`cell/index.tsx:203-211`) had no time input at all, and never received `includeTime`.

On top of that, `CalendarSelect.onClick` built the timestamp with `U.Date.timestamp(y, m, d)`, so a day click reset the time part to midnight.

**This is not a 0.56.0 regression.** The header layout feature is JS-7095 (v0.46.x), `noInplace` in `featured.tsx` dates to 2025-06-23, and none of the four files above changed in `v0.55.0..v0.56.0`.

## What changed

- `src/ts/lib/util/date.ts` — new `U.Date.parseTime(value)` and `U.Date.withTime(t, value)` helpers. `parseTime` accepts 24h (`14:30`) and 12h with a meridiem suffix (`2:30 PM`), strips inputmask `_` placeholders, and returns `null` for anything incomplete or out of range so a half-typed value is never saved.
- `src/ts/component/util/menu/calendarSelect.tsx` — new `showTime` / `onTimeChange` props. When `showTime` is set the component renders a masked `hh:mm` `Input` (`mask: '99:99'`, `alias: 'datetime'` — the same convention as the inline date editor in `cell/text.tsx`) above the Today/Tomorrow/Clear footer. It saves only on a fully filled mask or on blur/Enter, and is kept in sync with external value changes but never overwritten while focused. `onClick` now merges the existing time into the clicked day via `U.Date.mergeTimeWithDate` when `showTime` is on.
- `src/ts/component/menu/calendar.tsx` — reads `includeTime` from `param.data`, passes `showTime={canEdit && includeTime}`, and handles time changes with a variant of `handleChange` that does **not** close the menu (the user is still typing).
- `src/ts/component/cell/index.tsx` — passes `includeTime: !!noInplace && !!relation.includeTime` in the Date branch's `param.data`. Scoped to `noInplace` so the inplace/grid path is untouched — there the masked inline input already handles time.
- `src/json/text.json` — new `commonTime` label.
- `src/scss/component/calendarSelect.scss` — styles for the new row.

The time editor reads and writes 24h values. That matches the existing inline date editor, which also formats the time part as `H:i` regardless of the 12h/24h display preference (`cell/text.tsx:375-379`); `parseTime` additionally accepts an `AM`/`PM` suffix so a pasted 12h value is not rejected. The date part continues to follow the user's date-format preference — the calendar grid is unaffected by it.

## Affected surfaces (all fixed by the same change)

All three route through `cell/index.tsx` → `menuId = 'calendar'`:

- object header with **Line** relation layout — `component/block/featured.tsx:727` (`noInplace={true}`)
- kanban card cells — `component/block/dataview/view/board/card.tsx:137` (`noInplace={!isName}`)
- list view row cells — `component/block/dataview/view/list/row.tsx:162` (`noInplace={!isName}`)

Persistence was traced end to end: `CalendarSelect` → `menu/calendar` `onTimeChange` → `cell/index` `onChange` → `Relation.formatValue` (the Date branch only does `parseFloat`, no truncation) → `ObjectListSetDetails`, via `featured.tsx:473` for the header and `dataview.tsx:866` for kanban/list. A non-midnight timestamp survives.

## Testing

- New unit tests in `src/ts/lib/util/date.test.ts` for `parseTime` (24h, single digits, mask placeholders, 12h meridiem, invalid/incomplete input) and `withTime` (applies time, keeps the date, rejects invalid). Written first, confirmed red with `TypeError: default.parseTime is not a function`, then green.
- `npx vitest run`: 564 passed / 90 failed, against a `develop` baseline of 556 passed / 90 failed (7 files fail with a pre-existing `ReferenceError: U is not defined` — the harness does not register the auto-import plugin). No new failures; +8 passing.
- `npx tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.electron.json`.
- `biome lint` and `eslint` clean on the changed files.
- The render path is **not** covered by tests: the vitest harness is `environment: 'node'`, only collects `.test.ts`, and does not provide the `S`/`U`/`Relation` globals, so component tests are not possible without changing the harness. The menu rendering, the input focus/mask behaviour and the three surfaces were verified by reading the code paths, not by running the app.
