### PR TITLE
JS-9843: indent cross-block text selection with tab

### DIFF
--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -11,6 +11,7 @@ import { focus } from 'Lib/focus';
 import { virtualBlock } from 'Lib/virtualBlock';
 import { useScrollRestore } from 'Hook';
 import { computeRestoreScrollTop } from 'Lib/util/scrollAnchor';
+import { getTopLevelIds } from 'Lib/util/blockSelection';
 
 interface Props extends I.PageComponent {
 	onOpen?(): void;
@@ -711,6 +712,25 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 				handled = true;
 			});
 
+			// Tab/Shift+Tab indents every block the selection covers (JS-9843). A cross-block text
+			// selection leaves the block selection empty, so it is converted into a block selection
+			// first — which is also what dragging across blocks produced before 0.56
+			keyboard.shortcut('indent, outdent', e, (pressed: string) => {
+				e.preventDefault();
+
+				if (!readonly) {
+					const list = getTextSelectionBlockIds();
+
+					if (list.length) {
+						selection.clearTextSelection();
+						selection.set(I.SelectType.Block, list);
+						onTabEditor(e, list, pressed);
+					};
+				};
+
+				handled = true;
+			});
+
 			// Clear the text selection and let the default handling run
 			keyboard.shortcut('selectAll, undo, redo, history', e, () => {
 				selection.clearTextSelection();
@@ -1294,6 +1314,15 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 	};
 
 	const onKeyUpBlock = (e: any, text: string, marks: I.Mark[], range: I.TextRange, props: any) => {
+	};
+
+	// Blocks covered by a cross-block text selection, reduced to the topmost ids: the raw list is a
+	// document-order slice, so it can contain both a parent and its children (JS-9843)
+	const getTextSelectionBlockIds = (): string[] => {
+		const selection = S.Common.getRef('selectionProvider');
+		const list = selection?.getTextSelectionIds() || [];
+
+		return getTopLevelIds(list, (id: string) => S.Block.getParentLeaf(rootId, id)?.id || '');
 	};
 
 	// Indentation

--- a/src/ts/lib/util/blockSelection.test.ts
+++ b/src/ts/lib/util/blockSelection.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { getTopLevelIds } from './blockSelection';
+
+// parentOf helper built from a flat { child: parent } map
+const parentOf = (map: any) => (id: string) => String(map[id] || '');
+
+describe('getTopLevelIds', () => {
+
+	it('keeps a flat list of siblings untouched and in order', () => {
+		const map = { a: 'root', b: 'root', c: 'root' };
+
+		expect(getTopLevelIds([ 'a', 'b', 'c' ], parentOf(map))).toEqual([ 'a', 'b', 'c' ]);
+	});
+
+	it('drops children whose parent is in the list', () => {
+		// a
+		//   a1
+		//   a2
+		// b
+		const map = { a: 'root', a1: 'a', a2: 'a', b: 'root' };
+
+		expect(getTopLevelIds([ 'a', 'a1', 'a2', 'b' ], parentOf(map))).toEqual([ 'a', 'b' ]);
+	});
+
+	it('drops deeply nested descendants, not just direct children', () => {
+		const map = { a: 'root', a1: 'a', a11: 'a1', a111: 'a11' };
+
+		expect(getTopLevelIds([ 'a', 'a1', 'a11', 'a111' ], parentOf(map))).toEqual([ 'a' ]);
+	});
+
+	it('keeps a child when its parent is not selected', () => {
+		const map = { a: 'root', a1: 'a', b: 'root' };
+
+		expect(getTopLevelIds([ 'a1', 'b' ], parentOf(map))).toEqual([ 'a1', 'b' ]);
+	});
+
+	it('keeps an intermediate node when only its grandparent is missing', () => {
+		const map = { a: 'root', a1: 'a', a11: 'a1' };
+
+		expect(getTopLevelIds([ 'a1', 'a11' ], parentOf(map))).toEqual([ 'a1' ]);
+	});
+
+	it('removes duplicates and preserves first occurrence order', () => {
+		const map = { a: 'root', b: 'root' };
+
+		expect(getTopLevelIds([ 'b', 'a', 'b' ], parentOf(map))).toEqual([ 'b', 'a' ]);
+	});
+
+	it('returns an empty list for empty input', () => {
+		expect(getTopLevelIds([], parentOf({}))).toEqual([]);
+	});
+
+	it('ignores empty ids', () => {
+		expect(getTopLevelIds([ '', 'a' ], parentOf({ a: 'root' }))).toEqual([ 'a' ]);
+	});
+
+	it('does not hang on a cyclic parent chain', () => {
+		const map = { a: 'b', b: 'a', c: 'root' };
+
+		expect(getTopLevelIds([ 'a', 'c' ], parentOf(map))).toEqual([ 'a', 'c' ]);
+	});
+
+});

--- a/src/ts/lib/util/blockSelection.ts
+++ b/src/ts/lib/util/blockSelection.ts
@@ -1,0 +1,34 @@
+/**
+ * Reduces a list of block ids to the topmost ones: any id that already has an ancestor
+ * in the list is dropped, because structural operations (indent/outdent, move) carry
+ * children along with their parent — passing both would move the child twice.
+ *
+ * This is the same normalisation the selection provider applies to a block selection
+ * (see `get(I.SelectType.Block, false)`), extracted as pure logic so the cross-block
+ * text selection, whose id list is a raw document-order slice, can reuse it.
+ *
+ * @param ids block ids in document order
+ * @param parentOf resolves the parent id of a block, empty string when there is none
+ * @returns deduplicated topmost ids, input order preserved
+ */
+export const getTopLevelIds = (ids: string[], parentOf: (id: string) => string): string[] => {
+	const list = [ ...new Set((ids || []).filter(it => it)) ];
+	const set = new Set(list);
+
+	return list.filter(id => {
+		const visited = new Set([ id ]);
+
+		let cur = parentOf(id);
+
+		while (cur && !visited.has(cur)) {
+			if (set.has(cur)) {
+				return false;
+			};
+
+			visited.add(cur);
+			cur = parentOf(cur);
+		};
+
+		return true;
+	});
+};


### PR DESCRIPTION
Confirmed 0.56.0 regression. Reporter: "Before v0.56.0, I could select text across multiple bullet list items and press Tab to indent all of the corresponding list items. Since v0.56.0, this no longer works."

## Root cause

`JS-9803` (commit `2a43d402de`, PR #2247) made a drag that starts inside a text block produce a *cross-block text selection* instead of a block selection. That state lives entirely in the selection provider's `crossState` ref — the block-selection id set is never populated:

- `src/ts/component/selection/provider.tsx:618` — `startCrossSelect` turns the `.blocks` wrapper into one editing host, clears focus and sets `allowRect = false`; no block ids are added.
- `src/ts/component/selection/provider.tsx:742-766` — `finalizeCrossSelect` stores only `crossState = { from, to }`.
- `src/ts/component/selection/provider.tsx:905` — `getTextSelectionIds()` is the only way to learn which blocks are covered.

In the editor keydown path `ids = selection.get(I.SelectType.Block)` is therefore empty (`src/ts/component/editor/page.tsx:655`). The cross-block branch (`src/ts/component/editor/page.tsx:663`) handles copy/cut, escape, backspace/delete, arrows, enter and typing — but had no indent/outdent handler, so Tab fell through to the generic handler at `src/ts/component/editor/page.tsx:962-963`, which calls `onTabEditor(e, [], pressed)`; that returns immediately at `src/ts/component/editor/page.tsx:1334` (`if (!ids.length || readonly)`). Result: Tab does nothing.

Shift+Tab shares the exact same path — `indent, outdent` is a single `keyboard.shortcut` call and the ids are registered as `tab` / `shift+tab` in `src/json/shortcut.ts:123-124` — so it was broken identically and is fixed by the same change.

## What changed

- `src/ts/lib/util/blockSelection.ts` (new) — `getTopLevelIds(ids, parentOf)`: pure reduction of an id list to its topmost members. `getTextSelectionIds()` returns a raw document-order slice, so it can contain both a parent and its children; passing both to a move would move the child twice. This mirrors what the provider's `get(I.SelectType.Block, false)` already does for block selections.
- `src/ts/component/editor/page.tsx:718` — new `indent, outdent` handler inside the cross-block branch: resolve the covered blocks (`getTextSelectionBlockIds`, page.tsx:1321), clear the text selection, set them as the block selection, call the existing `onTabEditor`. Converting to a block selection is deliberate — it is exactly the state a drag produced before 0.56, so the visual result and any follow-up Tab/Shift+Tab presses behave as they used to.

## Why JS-9803 still works

None of the cross-selection mechanics changed: the contenteditable wrapper, anchor re-application, `selectionchange` remapping, `getCrossCoverage`, the beforeinput/cut/dragstart guards and `Block.Copy`/`Block.Cut` with `selectedTextRangeLastBlock` are untouched. The only new behaviour is one extra key binding inside the existing `textSel` branch, for a key that was previously unhandled there. Copy, cut, quote-in-discussion, backspace, typing and paste over the selection are unaffected.

## Testing

- `src/ts/lib/util/blockSelection.test.ts` — 9 unit tests for the new pure function (flat siblings, direct children, deep descendants, unselected parents, dedup/order, empty input, cyclic parent guard). Written first; it failed with `Failed to resolve import './blockSelection'` before the implementation existed.
- The rest of the fix is in the DOM/keyboard event layer (`onKeyDownEditor` reading the live selection provider ref). The vitest harness here is node-env, collects only `.test.ts`, and does not register the auto-import plugin providing the `S`/`U` globals, so that path is not unit-testable in this repo and is **not** covered by a test.
- Full suite: 90 failed / 577 passed. Baseline on `develop` before the change: 90 failed / 568 passed (7 files, all `ReferenceError: U is not defined`). No new failures; +9 new passing tests.
- `npx tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.electron.json`; `biome lint` and `eslint` clean on the changed files.
- Not manually verified in the running app.

## Related

GO-7411 ("text highlight across multiple blocks doesn't select blocks on move") has the **same root cause**: `onDragStart` in `src/ts/component/block/index.tsx:114` uses `selection.getForClick(block.id, false, true)`, which reads the empty block-selection set and falls back to the single dragged block. Not fixed here.

Other multi-block operations are equally dead during a cross-block text selection, for the same reason — turn-into and mark-up shortcuts, duplicate, action/add menus and Ctrl+Shift+Arrow move are all gated on `idsWithChildren` / `ids` (`src/ts/component/editor/page.tsx:810`, `:878`). Backspace/delete is the exception: it is explicitly handled by `deleteTextSelection`. Reported, not fixed, per scope.
