### PR TITLE
JS-9844: do not reorder a first child on tab

### DIFF
--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -11,7 +11,7 @@ import { focus } from 'Lib/focus';
 import { virtualBlock } from 'Lib/virtualBlock';
 import { useScrollRestore } from 'Hook';
 import { computeRestoreScrollTop } from 'Lib/util/scrollAnchor';
-import { getTopLevelIds } from 'Lib/util/blockSelection';
+import { getTopLevelIds, getIndentTargetId } from 'Lib/util/blockSelection';
 
 interface Props extends I.PageComponent {
 	onOpen?(): void;
@@ -1351,9 +1351,10 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 			return;
 		};
 
-		const idx = parentElement.childrenIds.indexOf(first.id);
-		const nextId = parentElement.childrenIds[idx - 1];
-		const next = nextId ? S.Block.getLeaf(rootId, nextId) : S.Block.getNextBlock(rootId, first.id, -1);
+		// Indent nests under the previous sibling only, so a first child is a no-op (JS-9844).
+		// Outdent ignores this and targets the parent, which a first child always has.
+		const nextId = getIndentTargetId(parentElement.childrenIds, first.id);
+		const next = nextId ? S.Block.getLeaf(rootId, nextId) : null;
 		const obj = shift ? parent : next;
 		const canTab = obj && !first.isTextTitle() && !first.isTextDescription() && obj.canHaveChildren() && first.isIndentable();
 		

--- a/src/ts/lib/util/blockSelection.test.ts
+++ b/src/ts/lib/util/blockSelection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getTopLevelIds } from './blockSelection';
+import { getTopLevelIds, getIndentTargetId } from './blockSelection';
 
 // parentOf helper built from a flat { child: parent } map
 const parentOf = (map: any) => (id: string) => String(map[id] || '');
@@ -58,6 +58,45 @@ describe('getTopLevelIds', () => {
 		const map = { a: 'b', b: 'a', c: 'root' };
 
 		expect(getTopLevelIds([ 'a', 'c' ], parentOf(map))).toEqual([ 'a', 'c' ]);
+	});
+
+});
+
+describe('getIndentTargetId', () => {
+
+	it('returns the previous sibling for a middle child', () => {
+		expect(getIndentTargetId([ 'a', 'b', 'c' ], 'b')).toEqual('a');
+	});
+
+	it('returns the previous sibling for the last child', () => {
+		expect(getIndentTargetId([ 'a', 'b', 'c' ], 'c')).toEqual('b');
+	});
+
+	// JS-9844: a first child has no previous sibling, so Tab must do nothing.
+	// Falling back to the previous block in document order resolved to the parent,
+	// and re-inserting into the parent the blocks already sat in appended them at its end.
+	it('returns nothing for a first child', () => {
+		expect(getIndentTargetId([ 'a', 'b', 'c' ], 'a')).toEqual('');
+	});
+
+	it('returns nothing for an only child', () => {
+		expect(getIndentTargetId([ 'a' ], 'a')).toEqual('');
+	});
+
+	it('returns nothing when the block is not among the children', () => {
+		expect(getIndentTargetId([ 'a', 'b' ], 'z')).toEqual('');
+	});
+
+	it('returns nothing for an empty children list', () => {
+		expect(getIndentTargetId([], 'a')).toEqual('');
+	});
+
+	it('tolerates a missing children list', () => {
+		expect(getIndentTargetId(null, 'a')).toEqual('');
+	});
+
+	it('returns nothing when the previous sibling id is empty', () => {
+		expect(getIndentTargetId([ '', 'b' ], 'b')).toEqual('');
 	});
 
 });

--- a/src/ts/lib/util/blockSelection.ts
+++ b/src/ts/lib/util/blockSelection.ts
@@ -32,3 +32,25 @@ export const getTopLevelIds = (ids: string[], parentOf: (id: string) => string):
 		return true;
 	});
 };
+
+/**
+ * Resolves the block an indent (Tab) should nest the selection under: the previous sibling
+ * inside the same parent, and nothing else.
+ *
+ * A first child has no previous sibling, so indenting it is not a valid operation and must
+ * be a no-op. Resolving it to the previous block in document order instead (JS-9844) yields
+ * the parent the blocks already live in, and moving them Inner to it re-appends them at the
+ * end of its child list — a silent reorder rather than an indent.
+ *
+ * Only meaningful for indent. Outdent targets the parent and never consults this.
+ *
+ * @param childrenIds the parent's child ids, in order
+ * @param id id of the first selected block
+ * @returns id of the previous sibling, or an empty string when there is none
+ */
+export const getIndentTargetId = (childrenIds: string[], id: string): string => {
+	const list = childrenIds || [];
+	const idx = list.indexOf(id);
+
+	return idx > 0 ? String(list[idx - 1] || '') : '';
+};


### PR DESCRIPTION
Closes JS-9844.

**Stacked on #2319** (`js-9843-tab-indent-cross-block-selection`) — this PR targets that branch, not `develop`, because both touch `onTabEditor`. Merge #2319 first.

## The bug

Select two blocks starting at the **first child** of a parent and press Tab. Instead of doing nothing, the blocks jump to the end of the parent's child list.

Before:
```
• dsfsf
    • ffdsfdsfds      <- select these two
    • fdsfdsf         <-
    • sdfsfds
```

After one Tab — indentation unchanged, order scrambled:
```
• dsfsf
    • sdfsfds
    • ffdsfdsfds
    • fdsfdsf
```

Pressing Tab a second time then indents normally, because by then a previous sibling exists. Reproduces with a plain area block selection too, so it is not specific to the cross-block text selection path.

Expected: nothing happens. A first child has no previous sibling to nest under.

## Root cause

`src/ts/component/editor/page.tsx:1354-1356` (pre-fix):

```ts
const idx = parentElement.childrenIds.indexOf(first.id);
const nextId = parentElement.childrenIds[idx - 1];
const next = nextId ? S.Block.getLeaf(rootId, nextId) : S.Block.getNextBlock(rootId, first.id, -1);
```

For a first child `idx` is `0`, so `childrenIds[-1]` is `undefined` and it falls through to `getNextBlock(..., -1)` — the previous block in *document order*. That function's backward branch (`src/ts/store/block.ts:503-506`) explicitly returns the **parent** when there is no previous sibling. So `obj` becomes the parent the blocks already live in, `parent.canHaveChildren()` passes, `canTab` is true, and `Action.move(..., I.BlockPosition.Inner, ...)` re-inserts them into that same parent — appending them at the end of its children.

Pre-existing, **not a 0.56.0 regression**: the fallback was introduced in `4073261a92` ("Store refactoring, blockStore", 2024-06-18, first released in v0.41.6-alpha). #2319 only added call sites into `onTabEditor` and did not modify its body.

## What changed

New pure helper `getIndentTargetId(childrenIds, id)` in `src/ts/lib/util/blockSelection.ts` — returns the previous sibling id, or `''` when there is none. `onTabEditor` uses it and drops the `getNextBlock(..., -1)` fallback.

That fallback could only ever fire when `idx <= 0`:
- `idx == 0` (first child) — returns the parent, i.e. exactly this bug. When the parent is the root it returns `null`, which was already a no-op.
- `idx == -1` — the selected block is absent from its own parent map element's `childrenIds`, i.e. an inconsistent block map. A no-op is the right answer there too.

So it served no legitimate case; every path it covered was either this bug or already a no-op.

**Outdent is unaffected.** `const obj = shift ? parent : next;` — the outdent branch reads `parent` and never `next`, and a first child always has a parent (already guarded above). A `null` `next` stays harmless on the shift path.

One deliberate behavioural side effect on outdent: the post-move callback `if (next && next.canToggle()) S.Block.toggle(...)` previously received the *parent* when outdenting a first child, and would expand it if it happened to be a toggle. It now receives `null`. That expand was spurious — the callback exists to reveal the target of an **indent** into a collapsed toggle, and on outdent the block moves out from under the parent, so there is nothing to reveal.

`first.isIndentable()` and `first.isTextTitle()` / `isTextDescription()` are properties of the selected block, independent of the target, so they are unchanged. `obj.canHaveChildren()` still guards the target.

## Testing

`src/ts/lib/util/blockSelection.test.ts` — 8 new cases for `getIndentTargetId`: middle child, last child, first child (no-op), only child (no-op), id absent from `childrenIds`, empty list, null list, empty previous-sibling id. Written first and confirmed RED (`TypeError: getIndentTargetId is not a function`) before implementing.

- `npx vitest run`: 585 passed / 90 failed, against a 577 / 90 baseline on the parent commit — +8 passing, zero new failures. The 90 failures are pre-existing (`ReferenceError: U is not defined` across 7 files; the harness has no `unplugin-auto-import`).
- `npx tsc --noEmit` on both `tsconfig.json` and `tsconfig.electron.json`: clean.
- `biome lint` and `eslint` on all three changed files: clean.

**Not verified:** `onTabEditor` itself lives in a `.tsx`, and the vitest harness only collects `src/**/*.test.ts` under `environment: 'node'` with no `S` / `U` globals, so it cannot be tested directly. The wiring in `page.tsx` — and the outdent-path and toggle-callback reasoning above — is covered by inspection only. No Electron build was run, so there is no manual in-app verification of the fix.
