### PR TITLE
ci: name nightly diff-check step for readability

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,7 +38,8 @@ jobs:
         with:
           fetch-depth: 0
       - run: git fetch --tags --force --prune
-      - id: diff_check
+      - name: Check for changes since last nightly tag
+        id: diff_check
         run: |
           LAST_TAG=$(git describe --tags --match 'v*-nightly' --abbrev=0 2>/dev/null || echo "")
           if [ -z "$LAST_TAG" ]; then


### PR DESCRIPTION
## Problem

In `.github/workflows/nightly.yml`, the `diff-check` job has an unnamed `run` step longer than **300 characters**. In the GitHub Actions UI that collapses into a generic label, which hurts readability when nightly change detection fails.

## Changes

Semantics are unchanged: same step `id`, same `GITHUB_OUTPUT` keys, and the same job output wiring (`steps.diff_check.outputs.changed` / `last_tag`).

- Add `name: Check for changes since last nightly tag` to `id: diff_check`

## Test plan
- [ ] Confirm later jobs still use `needs.diff-check.outputs.changed`
- [ ] Confirm the step shows the new name in the Actions UI
