### PR TITLE
feat(widget): merge home widget with its pinned widget

### DIFF
--- a/src/ts/component/menu/widget.tsx
+++ b/src/ts/component/menu/widget.tsx
@@ -96,6 +96,16 @@ const MenuWidget = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		// Section 2: Actions
 		const actionChildren: any[] = [];
 
+		// canModerate matches the gate on the same control in Space settings.
+		if (isPinned && canModerate && U.Space.isHomeObject(target?.id)) {
+			actionChildren.push({
+				id: 'changeHome',
+				iconParam: { name: 'settings/home' },
+				name: translate('widgetHomeChange'),
+				arrow: true,
+			});
+		};
+
 		if (!isSystem) {
 			actionChildren.push({ id: 'pageLink', iconParam: { name: 'menu/action/pageLink' }, name: translate('commonCopyLink') });
 		};
@@ -306,6 +316,20 @@ const MenuWidget = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 				break;
 			};
 
+			case 'changeHome': {
+				const data = U.Menu.dashboardSelectData(false);
+
+				menuId = 'searchObject';
+				menuParam.data = {
+					...data,
+					onSelect: (el: any) => {
+						data.onSelect(el);
+						close();
+					},
+				};
+				break;
+			};
+
 			case 'linkTo': {
 				if (!target) {
 					break;
@@ -368,6 +392,11 @@ const MenuWidget = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		};
 
 		if (menuId && !S.Menu.isOpen(menuId, item.id) && !S.Menu.isAnimating(menuId)) {
+			// Fires once per open, unlike the onOver body above, which runs on every hover.
+			if (item.id == 'changeHome') {
+				analytics.event('ClickChangeSpaceDashboard');
+			};
+
 			S.Menu.closeAll(J.Menu.widget, () => {
 				S.Menu.open(menuId, menuParam);
 			});

--- a/src/ts/component/sidebar/page/widget.tsx
+++ b/src/ts/component/sidebar/page/widget.tsx
@@ -20,6 +20,10 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 	const spaceview = U.Space.getSpaceview();
 	const canWrite = U.Space.canMyParticipantWrite();
 	const canModerate = U.Space.canMyParticipantModerate();
+	const home = U.Space.getHomeObject();
+
+	// When the homepage is also pinned, the pinned widget carries the home icon instead.
+	const isHomePinned = !!home && (S.Block.getWidgetsForTarget(home.id).length > 0);
 	const bodyRef = useRef<HTMLDivElement>(null);
 	const dropTargetIdRef = useRef<string>('');
 	const positionRef = useRef<I.BlockPosition>(null);
@@ -51,7 +55,9 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 			};
 		};
 
-		if (pinned.length) {
+		// The standalone home widget is the section's content when nothing is pinned,
+		// so it has to keep the section alive on its own.
+		if (pinned.length || (home && !isHomePinned)) {
 			ret.push(I.WidgetSection.Pin);
 		};
 
@@ -860,7 +866,7 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 											};
 										}}
 									>
-										{isSectionPin && !isLinksView ? <WidgetHome /> : ''}
+										{isSectionPin && !isLinksView && !isHomePinned ? <WidgetHome /> : ''}
 
 										{list.map((block, i) => (
 											<Widget
@@ -869,6 +875,7 @@ const SidebarPageWidget = forwardRef<{}, I.SidebarPageComponent>((props, ref) =>
 												block={block}
 												index={i}
 												rootId={isFavWidgets ? personalRootId : undefined}
+												homeId={isSectionPin ? home?.id : undefined}
 												canEdit={canWrite}
 												canRemove={isSectionPin}
 												onDragStart={isFavWidgets ? undefined : onDragStartStable}

--- a/src/ts/component/widget/home.tsx
+++ b/src/ts/component/widget/home.tsx
@@ -12,7 +12,9 @@ const WidgetHome: FC = () => {
 	};
 
 	const spaceview = U.Space.getSpaceview();
-	const canChangeHome = spaceview && !spaceview.isOneToOne;
+
+	// canModerate matches the gate on the same control in Space settings.
+	const canChangeHome = spaceview && !spaceview.isOneToOne && U.Space.canMyParticipantModerate();
 
 	const onClick = (e: MouseEvent) => {
 		e.preventDefault();

--- a/src/ts/component/widget/index.tsx
+++ b/src/ts/component/widget/index.tsx
@@ -14,6 +14,7 @@ import Storage from 'Lib/storage';
 interface Props extends I.WidgetComponent {
 	name?: string;
 	icon?: string;
+	homeId?: string;
 	disableContextMenu?: boolean;
 	className?: string;
 	onDragStart?: (e: MouseEvent, block: I.Block) => void;
@@ -42,6 +43,13 @@ const WidgetIndex = forwardRef<{}, Props>((props, ref) => {
 	const object = getObject(targetId);
 	const isSystemTarget = U.Menu.isSystemWidget(targetId);
 	const isChat = U.Object.isChatLayout(object?.layout);
+	/*
+	 * homeId is resolved once by the sidebar and passed down. Reading the spaceview here
+	 * instead would make every widget observe the whole spaceview record, so any detail
+	 * write on it (sync status, order, push settings) would re-render the entire list —
+	 * defeating the stable-block/stable-getObject memo caching the sidebar sets up.
+	 */
+	const isHome = !props.rootId && !!props.homeId && (props.homeId == targetId);
 	const hasDiscussion = !isChat && !!object?.discussionId;
 	const counterTargetId = isChat ? object?.id : (hasDiscussion ? object?.discussionId : '');
 	const hasUnreadSection = S.Common.checkWidgetSection(I.WidgetSection.Unread);
@@ -746,6 +754,9 @@ const WidgetIndex = forwardRef<{}, Props>((props, ref) => {
 	};
 
 	if (hasChild) {
+		if (isHome) {
+			icon = <Icon name="settings/home" color="red" className="headerIcon" />;
+		} else
 		if (object?.isSystem) {
 			icon = <Icon name={object.iconName} className={[ 'headerIcon', object.icon ].join(' ')} />;
 		} else {

--- a/src/ts/lib/util/menu.ts
+++ b/src/ts/lib/util/menu.ts
@@ -688,7 +688,11 @@ class UtilMenu {
 		return U.Common.arrayUniqueObjects(sections, 'id');
 	};
 
-	dashboardSelect (element: string, openRoute?: boolean, menuParam?: Omit<Partial<I.MenuParam>, 'data'>) {
+	/**
+	 * Builds the searchObject menu data for picking a new space homepage.
+	 * Split out of dashboardSelect so it can also be used as a submenu.
+	 */
+	dashboardSelectData (openRoute?: boolean) {
 		const { space } = S.Common;
 		const spaceview = U.Space.getSpaceview();
 
@@ -712,36 +716,40 @@ class UtilMenu {
 			});
 		};
 
+		return {
+			withPlural: true,
+			filters: [
+				{ relationKey: 'resolvedLayout', condition: I.FilterCondition.NotIn, value: U.Object.getFileAndSystemLayouts().concat(I.ObjectLayout.Participant).filter(it => !U.Object.isTypeLayout(it)) },
+				{ relationKey: 'type.uniqueKey', condition: I.FilterCondition.NotEqual, value: J.Constant.typeKey.template },
+			],
+			dataChange: (_ctx: any, items: any) => {
+				const head: any[] = [
+					{ id: I.HomePredefinedId.Widget, iconParam: { name: 'settings/home' }, name: translate('commonNoHome') },
+				];
+
+				if (items.length) {
+					head.push({ isDiv: true });
+				};
+
+				return head.concat(items);
+			},
+			onSelect: el => {
+				onSelect(el, true);
+
+				const type = U.Space.isSystemDashboard(el.id) ? el.id : I.HomePredefinedId.Existing;
+				analytics.event('ChangeSpaceDashboard', { type });
+			},
+		};
+	};
+
+	dashboardSelect (element: string, openRoute?: boolean, menuParam?: Omit<Partial<I.MenuParam>, 'data'>) {
 		analytics.event('ClickChangeSpaceDashboard');
 
 		S.Menu.open('searchObject', {
 			element,
 			horizontal: I.MenuDirection.Right,
 			...menuParam,
-			data: {
-				withPlural: true,
-				filters: [
-					{ relationKey: 'resolvedLayout', condition: I.FilterCondition.NotIn, value: U.Object.getFileAndSystemLayouts().concat(I.ObjectLayout.Participant).filter(it => !U.Object.isTypeLayout(it)) },
-					{ relationKey: 'type.uniqueKey', condition: I.FilterCondition.NotEqual, value: J.Constant.typeKey.template },
-				],
-				dataChange: (_ctx: any, items: any) => {
-					const head: any[] = [
-						{ id: I.HomePredefinedId.Widget, iconParam: { name: 'settings/home' }, name: translate('commonNoHome') },
-					];
-
-					if (items.length) {
-						head.push({ isDiv: true });
-					};
-
-					return head.concat(items);
-				},
-				onSelect: el => {
-					onSelect(el, true);
-
-					const type = U.Space.isSystemDashboard(el.id) ? el.id : I.HomePredefinedId.Existing;
-					analytics.event('ChangeSpaceDashboard', { type });
-				},
-			}
+			data: this.dashboardSelectData(openRoute),
 		});
 	};
 

--- a/src/ts/lib/util/space.ts
+++ b/src/ts/lib/util/space.ts
@@ -210,6 +210,32 @@ class UtilSpace {
 	};
 
 	/**
+	 * Gets the homepage when it points at a real object, otherwise null.
+	 * The isOneToOne check is not redundant with isSystemDashboard: in 1-on-1 spaces
+	 * getDashboard returns the chat, whose id is the workspace id — a real object id.
+	 * @returns {I.DashboardObject|null} The homepage object or null.
+	 */
+	getHomeObject (): I.DashboardObject | null {
+		const spaceview = this.getSpaceview();
+		if (!spaceview || spaceview.isOneToOne) {
+			return null;
+		};
+
+		const home = this.getDashboard();
+		return (home && !this.isSystemDashboard(home.id)) ? home : null;
+	};
+
+	/**
+	 * Checks whether the given object is the space homepage.
+	 * @param {string} id - The object id.
+	 * @returns {boolean} True if the object is the homepage.
+	 */
+	isHomeObject (id: string): boolean {
+		const home = this.getHomeObject();
+		return !!id && !!home && (home.id == id);
+	};
+
+	/**
 	 * Gets the graph dashboard object.
 	 * @returns {I.DashboardObject} The graph dashboard object.
 	 */


### PR DESCRIPTION
Closes JS-9846. Desktop counterpart of DROID-4467, scoped to the sidebar widget panel.

## Problem

When the space homepage points at a real object and that object is also pinned as a widget, the sidebar shows it twice — the standalone home link row at the top of the Pin section, plus the pinned widget itself.

Separately: with a homepage set but **zero** pinned widgets, the home row disappeared entirely. It renders inside the Pin section's items, and that section was only emitted when `pinned.length` was non-zero (added in 14114a81f8 to hide an empty section header — it took the home row down with it).

Links view already merged the two via `getWidgetObjects(widgets, isLinksView)`. This brings Widgets view to parity, keeping the **widget** rather than flattening it to a link row.

## Changes

- `U.Space.getHomeObject()` / `isHomeObject()` — the homepage only when it points at a real object. The `isOneToOne` guard is not redundant with `isSystemDashboard`: in 1-on-1 spaces `getDashboard()` returns the chat, whose id is the workspace id, which `isSystemDashboard` never matches.
- The pinned widget whose target is the homepage renders the red `settings/home` icon instead of its object icon. It keeps its drag position — no hoisting to the top.
- The standalone `WidgetHome` row is suppressed when the homepage is pinned.
- The merged widget's context menu gains **Change Home**, opening the homepage picker as a submenu. `U.Menu.dashboardSelect` is split into `dashboardSelectData()` + a thin opener so the picker can be used both as a top-level menu and as a submenu.
- The Pin section now stays alive when the standalone home row is its only content.

Scoped deliberately to the Pin section — a homepage object in My Favorites keeps its plain icon. Links view is untouched.

## Review-driven fixes

An Opus review agent caught three things worth calling out:

- **1:1 regression.** The first version widened the Pin gate via `getWidgetObjects(widgets, true)`. That flag's `withHome` branch resolves the homepage with `getDashboard()`, not `getHomeObject()`, so in a 1-on-1 space it injects the chat and `pinned.length >= 1` becomes unconditional — every 1:1 space would grow a Pin section with a "Chat" row that is hidden today. Replaced with `if (pinned.length || (home && !isHomePinned))`, which also closes a window where the section could render empty while the home object is still resolving in the `widgets` root.
- **Permissions.** The menu opens for anyone with `canEdit` (writer, admin, owner), but the same control in Space settings requires `canModerate` — owner/admin only. Both the new item and `WidgetHome`'s pre-existing right-click menu are now `canModerate`-gated, so the action doesn't appear or disappear for a Writer depending on whether the homepage happens to be pinned.
- **Render churn.** Calling `isHomeObject` per widget made every widget observe the whole spaceview record, so any detail write on it (sync status, space order, push settings) re-rendered the entire list — undoing the stable-`block`/stable-`getObject` memo caching the sidebar sets up on purpose. The home id is now resolved once by the sidebar and passed down as `homeId`.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint` — 0 errors; 29 pre-existing warnings, none in the touched files
- [x] Manually verified by @requilence
- [ ] Pin the homepage object → standalone row gone, widget shows the red home icon
- [ ] Merged widget's menu → **Change Home** is the first action and opens the picker
- [ ] Change home to another object → icon moves, or the standalone row returns if the new home isn't pinned
- [ ] Unpin the merged widget → standalone row returns
- [ ] Remove every pinned widget with a home still set → home row remains
- [ ] Home set to Graph / "No home" → no home icon anywhere, no **Change Home**
- [ ] 1-on-1 space with nothing pinned → no Pin section, no home row (unchanged)
- [ ] As a Writer in a shared space → no **Change Home** on either surface
- [ ] Links view → behavior unchanged
