### PR TITLE
JS-9848: auto-hide dataview sticky horizontal scrollbar on macOS

### DIFF
--- a/docs/superpowers/specs/2026-08-03-sticky-scrollbar-autohide-design.md
+++ b/docs/superpowers/specs/2026-08-03-sticky-scrollbar-autohide-design.md
@@ -68,11 +68,21 @@ isEnabled = props.autoHide ?? (U.Common.isPlatformMac() && U.Common.hasOverlaySc
 
 visible = !isEnabled                                  // Win/Linux, or "Always" chosen
         || !hasScrolledOnce                           // suspend until first use
-        || isHoveringHost || isHoveringBar
+        || isHovering                                 // see host below
         || isRecentlyScrolled                         // see timer below
 ```
 
+**Hover host.** In both `grid.tsx:577-603` and `board.tsx`, the bar is rendered as a *sibling* of the scrolling element, under a shared view-root wrapper. That wrapper — reachable as `nodeRef.current.parentElement` — is used as the hover target, because it spans the block content *and* the bar. A single `isHovering` flag therefore covers hovering the bar itself, with no second listener pair and no gap when the pointer crosses from content onto the bar.
+
+Listeners are `mouseover` (rather than `mouseenter`) and `mouseleave`. `mouseover` bubbles from descendants, so hover state self-heals on the next pointer movement if listeners are re-attached while the pointer is already inside — which happens when `rebind()` fires on a column add.
+
+`unbind()` deliberately does **not** clear `isHovering`. Because `bind()` calls `unbind()` first, clearing it there would hide the bar out from under a resting pointer on every column add, until the pointer moved again. Leaving it set fails visible, which is the safe direction; the unbound window between `unbind()` and `bind()` is a few microseconds inside one effect, so a missed `mouseleave` is not reachable in practice.
+
 `isRecentlyScrolled` is **timer-driven, not polled**: every scroll event sets it true and restarts a single 1300ms `setTimeout` that sets it false. Reusing one timer handle means rapid scrolling does not accumulate timers.
+
+**Programmatic scrolls must not count as activity.** `grid.tsx:48-61` calls `onScrollHorizontal()` directly from a `useEffect` keyed on `[ relations.length, view?.id ]`, so `sync()` fires on mount and on every view or column-count change with no user involvement. Treating that as a scroll sets `hasScrolledOnce` at mount and silently deletes the entire suspend clause — the bar would fade ~1300ms after open, having never been scrolled, reintroducing the JS-9811 discoverability bug on grid while board (whose `onScrollHorizontal` is only ever a real listener) kept the intended behavior.
+
+Activity is therefore gated on the scroll position actually moving. The component tracks `lastScrollLeft`; the first observation after `bind()` only establishes a baseline and returns, and an unchanged position is ignored. Real user scrolls change `scrollLeft` and register normally. `lastScrollLeft` resets in `unbind()` so each bind re-establishes its own baseline.
 
 `isEnabled` accepts an optional `autoHide` prop that overrides platform detection. Call sites omit it and get the detected default; Storybook sets it explicitly to exercise both states. This follows the CLAUDE.md rule that component variations are separate props rather than implicit behavior.
 
@@ -162,8 +172,10 @@ One `setTimeout` handle and two hover listeners, all torn down in `unbind()` and
 | File | Change |
 | --- | --- |
 | `src/ts/component/util/stickyScrollbar.tsx` | Optional `autoHide` prop, visibility state, hover listeners, idle timer, motion-driven opacity |
+| `src/ts/lib/util/stickyScrollbar.ts` | Add `StickyScrollbarState` and the pure `isVisible()` predicate |
+| `src/ts/lib/util/stickyScrollbar.test.ts` | New — unit tests for the visibility truth table |
 | `src/ts/lib/util/common.ts` | Add memoized `hasOverlayScrollbars()` |
-| `src/scss/component/stickyScrollbar.scss` | Add `pointer-events` handling for the hidden state |
-| `src/ts/component/util/stickyScrollbar.stories.tsx` | Story exercising `autoHide` in both states |
+| `src/scss/component/stickyScrollbar.scss` | Add `.isHidden { pointer-events: none; }` |
+| `src/ts/component/util/stickyScrollbar.stories.tsx` | Stories exercising `autoHide` in both states |
 
 `grid.tsx` and `board.tsx` are untouched.

--- a/docs/superpowers/specs/2026-08-03-sticky-scrollbar-autohide-design.md
+++ b/docs/superpowers/specs/2026-08-03-sticky-scrollbar-autohide-design.md
@@ -1,0 +1,169 @@
+# Design: Auto-hide the dataview sticky horizontal scrollbar on macOS
+
+**Date:** 2026-08-03
+**Branch:** `develop`
+**Status:** Draft for review
+
+## Problem
+
+`StickyScrollbar` (`src/ts/component/util/stickyScrollbar.tsx`) renders a permanently visible 10px bar at the bottom of any dataview grid or board whose columns overflow. On macOS this reads as foreign: the OS hides scroll indicators when they are not in use, and has done so by default since Ventura.
+
+The bar is visible at all times because `src/scss/component/stickyScrollbar.scss` styles `::-webkit-scrollbar` unconditionally. In Chromium, styling that pseudo-element opts the element out of macOS overlay scrollbars and forces a classic, always-drawn bar. The track additionally paints `--color-shape-secondary` across the full width, so even a fully transparent thumb would leave a grey strip.
+
+This contradicts a policy the codebase already holds. `src/scss/common.scss:227-232` scopes the app's custom `::-webkit-scrollbar` styling to `platformWindows, platformLinux`:
+
+```scss
+&.platformWindows, &.platformLinux {
+	::-webkit-scrollbar { width: 10px; height: 10px; }
+	::-webkit-scrollbar-thumb { background: var(--color-control-active); border-radius: 5px; }
+	...
+}
+```
+
+macOS is deliberately excluded so it keeps native overlay scrollbars. `StickyScrollbar` is unscoped and breaks that rule. **This change restores an existing intent rather than introducing a new preference.**
+
+### Why the bar exists
+
+Two recent commits added it, and their reasoning constrains the fix:
+
+- `3aea4aa75a` — `fix(dataview): inline board sizing, scrollbar and instant card insert (JS-9714)`
+- `85c72cd551` — `fix(dataview): sticky horizontal scrollbar for inline grid (JS-9811)`
+
+JS-9811's message states the problem it solved: wide inline queries "could only be scrolled with shift+wheel, which is undiscoverable and unusable without a horizontal-axis pointer." A naive full auto-hide would reintroduce exactly that bug. The design below preserves discoverability explicitly.
+
+## Research basis
+
+| Source | Bearing on this design |
+| --- | --- |
+| [Apple HIG — Scroll views](https://developerguidelines.com/human-interface-guidelines/version/8/scroll-views/) | Indicators are transient, appearing "after people begin scrolling." But the HIG pairs this with a requirement to "make it apparent when content is scrollable" by other means — auto-hide alone is only half the pattern. |
+| [Adrian Roselli — Baseline Rules for Scrollbar Usability](https://adrianroselli.com/2019/01/baseline-rules-for-scrollbar-usability.html) | "Do not make it disappear using your own custom styles because *you* prefer it." The stated reason is that developers cannot detect the user's scrollbar preference. Also cites SC 1.4.11 (3:1 non-text contrast) and SC 2.5.8 (24x24 target size). |
+| [NN/g — Scrolling and Scrollbars](https://www.nngroup.com/articles/scrolling-and-scrollbars/) | "Offer a scrollbar if an area has scrolling content." Horizontal scrolling is singled out as cognitively taxing and easy to miss, so discoverability matters more here, not less. |
+| [OverlayScrollbars](https://kingsora.github.io/OverlayScrollbars/) | Industry-standard modes `never` / `scroll` / `leave` / `move`; default `autoHideDelay` 1300ms. Its `autoHideSuspend` option keeps the bar visible until the user's first scroll; the docs say the `false` default exists only for backwards compatibility and `true` is "recommended for better accessibility." |
+
+Two conclusions shaped the design:
+
+1. **Roselli's objection is answerable here.** In Chromium the preference *is* detectable: an offscreen `overflow: scroll` probe reports `offsetWidth - clientWidth == 0` under macOS overlay scrollbars, and ~15px when the user has set **Show scroll bars: Always**. Respecting that turns this from an author-preference override into preference-respecting behavior.
+2. **`autoHideSuspend` resolves the NN/g conflict.** Keeping the bar visible until first use retains JS-9811's discoverability fix while still decluttering afterwards.
+
+## Design
+
+### Boundary
+
+All logic lands in two places:
+
+- `src/ts/component/util/stickyScrollbar.tsx` — visibility state and listeners
+- `src/ts/lib/util/common.ts` — one memoized `hasOverlayScrollbars()` probe
+
+**`grid.tsx` and `board.tsx` require no changes.** The existing `I.StickyScrollbarRef` API already supplies both signals the feature needs:
+
+- `bind(scrollElement, status)` receives the horizontally-scrolling container — the hover host.
+- `sync(element, isSyncing)` is already invoked from `onScrollHorizontal` (`grid.tsx:122`) on every horizontal scroll — the activity signal.
+
+The component therefore owns its auto-hide state entirely, and both call sites inherit the behavior. `src/scss/component/stickyScrollbar.scss` gains one property; no colors or sizes change.
+
+### Visibility rule
+
+```
+isEnabled = props.autoHide ?? (U.Common.isPlatformMac() && U.Common.hasOverlayScrollbars())
+
+visible = !isEnabled                                  // Win/Linux, or "Always" chosen
+        || !hasScrolledOnce                           // suspend until first use
+        || isHoveringHost || isHoveringBar
+        || isRecentlyScrolled                         // see timer below
+```
+
+`isRecentlyScrolled` is **timer-driven, not polled**: every scroll event sets it true and restarts a single 1300ms `setTimeout` that sets it false. Reusing one timer handle means rapid scrolling does not accumulate timers.
+
+`isEnabled` accepts an optional `autoHide` prop that overrides platform detection. Call sites omit it and get the detected default; Storybook sets it explicitly to exercise both states. This follows the CLAUDE.md rule that component variations are separate props rather than implicit behavior.
+
+| State | Bar |
+| --- | --- |
+| Not macOS, or user chose "Show scroll bars: Always" | Visible — today's behavior exactly |
+| Before the first horizontal scroll of that view | Visible (suspend) |
+| Pointer over the dataview block, or over the bar | Visible |
+| Scrolling, or within 1300ms of the last scroll | Visible |
+| Idle, unhovered, after first scroll | Faded out |
+| No overflow | `display: none` via existing `resize()` |
+
+`hasScrolledOnce` is per-instance and flips on the first `sync()` or first scroll of the bar itself.
+
+Non-macOS users and macOS users who chose "Always" short-circuit on the first clause, so they see no behavior change at all. Regression risk is confined to the target platform.
+
+### Two independent visibility axes
+
+`resize()` already writes `display` to hide the bar when content does not overflow (`grid.tsx:426`, `:437`, `:440`, `:466`). Auto-hide **must not** reuse `display`, or the two mechanisms will overwrite each other on every resize — and `resize()` is called on every column drag and scroll.
+
+Auto-hide therefore uses **opacity only**. `display` stays exclusively owned by `resize()`. The two compose correctly: `display: none` wins regardless of opacity, and when a view becomes overflowing again the suspend clause makes the bar visible.
+
+### Fade mechanism
+
+The fade must be driven through motion, not CSS. `U.Common.animationProps()` (`common.ts:781-794`) already has `motion` writing an inline `opacity` on the node:
+
+```ts
+animate: { opacity: 1, ...param.animate },
+```
+
+An inline style set by motion beats any stylesheet rule, so a CSS class toggling opacity would silently do nothing. The fix is to drive `animate={{ opacity: visible ? 1 : 0 }}` from component state, keeping the existing 0.2s tween. The current mount-time `delay: 0.2` is dropped for state-driven transitions — the 1300ms idle timer already provides the delay, and a delayed *reveal* would feel unresponsive.
+
+Fading the node fades track and thumb together, which matches macOS drawing no groove when idle. No color values are touched, satisfying the CLAUDE.md rule against unrequested style changes.
+
+### SCSS
+
+One addition: `pointer-events: none` while faded out, so the invisible 10px strip does not swallow wheel and click events. Restored when visible, keeping the bar grabbable the moment it appears.
+
+### Probe
+
+```ts
+hasOverlayScrollbars (): boolean {
+	// memoized on first call
+	const el = document.createElement('div');
+
+	el.style.cssText = 'position:absolute;top:-9999px;width:100px;height:100px;overflow:scroll;';
+	document.body.appendChild(el);
+
+	const result = (el.offsetWidth - el.clientWidth) == 0;
+
+	el.remove();
+	return result;
+};
+```
+
+Valid on macOS specifically because `common.scss:227-232` scopes the app's `::-webkit-scrollbar` override to Windows and Linux, so no app stylesheet perturbs the measurement. Placed next to `isPlatformMac()` in `U.Common`.
+
+### Cleanup
+
+One `setTimeout` handle and two hover listeners, all torn down in `unbind()` and on unmount, following the existing `scrollHandler` ref discipline in the same file. `bind()` must clear any prior timer and listeners before re-attaching, as it already does for `scrollHandler`. This codebase has previously shipped a class of bug where leaked listeners survived unmount, so teardown is treated as a correctness requirement, not hygiene.
+
+## Out of scope
+
+- **`prefers-reduced-motion`.** The codebase honors it nowhere today (zero hits across `src/scss` and `src/ts`). Adding it to this one component would be inconsistent; it belongs in a separate app-wide task.
+- **Explicit resize/drag pinning.** During a column resize the pointer is over the block, so the hover clause already keeps the bar visible. No `keyboard.isResizing` wiring needed.
+- **Target size (WCAG SC 2.5.8).** The bar is 10px tall, below the 24x24 guidance. This is pre-existing and unchanged by this work. Enlarging it, or mirroring the macOS expand-on-hover behavior, is a design decision requiring explicit sign-off per CLAUDE.md.
+- **Runtime preference changes.** The probe runs once, so toggling **Show scroll bars** in System Settings takes effect on app restart. Re-probing on window focus is possible but deliberately omitted.
+
+## Testing
+
+**Automated** — unit-testable pure logic: extract the visibility rule as a pure predicate over `(isEnabled, hasScrolledOnce, isHoveringHost, isHoveringBar, msSinceScroll)` so the truth table above can be asserted directly without DOM or timers.
+
+**Manual, macOS with Show scroll bars: When scrolling** (the default):
+1. Wide inline grid — bar visible on first render; scroll horizontally; bar remains while the pointer is over the block; move the pointer away; bar fades after ~1300ms.
+2. Return the pointer to the block — bar fades back in immediately.
+3. Hover the bar itself and drag the thumb — grabbable, and stays visible for the whole drag.
+4. Narrow the view so columns fit — bar `display: none`; widen again — bar returns visible.
+5. Resize a column with the pointer inside the block — bar stays visible throughout.
+6. Repeat 1-5 on a wide inline board and on a full-page grid.
+
+**Manual, macOS with Show scroll bars: Always** — bar is permanently visible in every case above; no fading at any point.
+
+**Manual, Windows or Linux** — behavior byte-for-byte identical to today.
+
+## Files
+
+| File | Change |
+| --- | --- |
+| `src/ts/component/util/stickyScrollbar.tsx` | Optional `autoHide` prop, visibility state, hover listeners, idle timer, motion-driven opacity |
+| `src/ts/lib/util/common.ts` | Add memoized `hasOverlayScrollbars()` |
+| `src/scss/component/stickyScrollbar.scss` | Add `pointer-events` handling for the hidden state |
+| `src/ts/component/util/stickyScrollbar.stories.tsx` | Story exercising `autoHide` in both states |
+
+`grid.tsx` and `board.tsx` are untouched.

--- a/src/scss/component/stickyScrollbar.scss
+++ b/src/scss/component/stickyScrollbar.scss
@@ -4,6 +4,7 @@
 	position: sticky; bottom: 0px; left: 0px; overflow-x: auto; overflow-y: hidden; z-index: 2; height: 10px; 
 	box-sizing: border-box;
 }
+.stickyScrollbar.isHidden { pointer-events: none; }
 .stickyScrollbar::-webkit-scrollbar { height: 10px; }
 .stickyScrollbar::-webkit-scrollbar-track { background: var(--color-shape-secondary); border-radius: 5px; }
 .stickyScrollbar::-webkit-scrollbar-thumb { background: var(--color-control-active); border-radius: 5px; }

--- a/src/ts/component/util/stickyScrollbar.stories.tsx
+++ b/src/ts/component/util/stickyScrollbar.stories.tsx
@@ -27,3 +27,17 @@ export const Inline: Story = {
 		isInline: true,
 	},
 };
+
+// Always visible, as on Windows/Linux or with macOS "Show scroll bars: Always"
+export const AutoHideOff: Story = {
+	args: {
+		autoHide: false,
+	},
+};
+
+// Hides once idle, as on macOS with overlay scrollbars
+export const AutoHideOn: Story = {
+	args: {
+		autoHide: true,
+	},
+};

--- a/src/ts/component/util/stickyScrollbar.tsx
+++ b/src/ts/component/util/stickyScrollbar.tsx
@@ -1,21 +1,72 @@
-import React, { forwardRef, useRef, useImperativeHandle } from 'react';
+import React, { forwardRef, useRef, useState, useEffect, useImperativeHandle } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import * as I from 'Interface';
 
 interface Props {
 	isInline?: boolean;
+	autoHide?: boolean;
 };
+
+const HIDE_DELAY = 1300;
 
 const StickyScrollbar = forwardRef<I.StickyScrollbarRef, Props>((props, ref) => {
 
+	const { autoHide } = props;
 	const nodeRef = useRef<HTMLDivElement>(null);
 	const trackRef = useRef<HTMLDivElement>(null);
 	const scrollElementRef = useRef<HTMLElement>(null);
+	const hostRef = useRef<HTMLElement>(null);
 	const isSyncing = useRef(false);
 	const scrollHandler = useRef<(() => void) | null>(null);
+	const hostHandlers = useRef<[ string, EventListener ][]>([]);
+	const lastScrollLeft = useRef<number | null>(null);
+	const timeout = useRef(0);
+
+	const [ hasScrolledOnce, setHasScrolledOnce ] = useState(false);
+	const [ isHovering, setIsHovering ] = useState(false);
+	const [ isRecentlyScrolled, setIsRecentlyScrolled ] = useState(false);
+
+	// Auto-hide only where the OS hides scrollbars itself, so Windows, Linux and
+	// anyone who picked "Show scroll bars: Always" keep a permanently visible bar
+	const isEnabled = autoHide ?? (U.Common.isPlatformMac() && U.Common.hasOverlayScrollbars());
+	const isEnabledRef = useRef(isEnabled);
+
+	isEnabledRef.current = isEnabled;
+
+	const isVisible = U.StickyScrollbar.isVisible({ isEnabled, hasScrolledOnce, isHovering, isRecentlyScrolled });
 
 	const toPx = (v: any): any => {
 		return typeof v == 'number' ? `${v}px` : v;
+	};
+
+	// Reveals the bar on scroll and restarts the idle countdown.
+	// Only a real change of position counts: grid calls onScrollHorizontal()
+	// programmatically on mount and on view/column changes, and that must not
+	// consume the initial reveal that makes the bar discoverable
+	const onActivity = () => {
+		if (!isEnabledRef.current) {
+			return;
+		};
+
+		const scrollLeft = scrollElementRef.current?.scrollLeft ?? 0;
+		const isFirst = lastScrollLeft.current === null;
+
+		if (lastScrollLeft.current === scrollLeft) {
+			return;
+		};
+
+		lastScrollLeft.current = scrollLeft;
+
+		// The first observation only establishes the baseline
+		if (isFirst) {
+			return;
+		};
+
+		setHasScrolledOnce(true);
+		setIsRecentlyScrolled(true);
+
+		window.clearTimeout(timeout.current);
+		timeout.current = window.setTimeout(() => setIsRecentlyScrolled(false), HIDE_DELAY);
 	};
 
 	const resize = (config) => {
@@ -37,12 +88,10 @@ const StickyScrollbar = forwardRef<I.StickyScrollbarRef, Props>((props, ref) => 
 			return;
 		};
 
+		unbind();
+
 		scrollElementRef.current = scrollElement;
 		isSyncing.current = status;
-
-		if (scrollHandler.current) {
-			U.Dom.removeEvent(nodeRef.current, 'scroll', scrollHandler.current);
-		};
 
 		scrollHandler.current = () => {
 			if (scrollElementRef.current && nodeRef.current) {
@@ -52,23 +101,57 @@ const StickyScrollbar = forwardRef<I.StickyScrollbarRef, Props>((props, ref) => 
 					isSyncing.current
 				);
 			};
+
+			onActivity();
 		};
 
 		U.Dom.addEvent(nodeRef.current, 'scroll', scrollHandler.current);
+
+		// The bar is a sibling of the scroll area, so their shared parent is the
+		// hover target that covers both the content and the bar itself
+		hostRef.current = nodeRef.current.parentElement;
+
+		if (hostRef.current) {
+			hostHandlers.current = [
+				[ 'mouseover', () => setIsHovering(true) ],
+				[ 'mouseleave', () => setIsHovering(false) ],
+			];
+
+			U.Dom.addEvents(hostRef.current, hostHandlers.current);
+		};
 	};
 
 	const unbind = () => {
 		if (nodeRef.current && scrollHandler.current) {
 			U.Dom.removeEvent(nodeRef.current, 'scroll', scrollHandler.current);
 		};
+		if (hostRef.current && hostHandlers.current.length) {
+			U.Dom.removeEvents(hostRef.current, hostHandlers.current);
+		};
+
+		window.clearTimeout(timeout.current);
+
+		timeout.current = 0;
+		hostHandlers.current = [];
+		hostRef.current = null;
 		scrollHandler.current = null;
 		scrollElementRef.current = null;
+		lastScrollLeft.current = null;
 		isSyncing.current = null;
+
+		// Hover state is deliberately left alone: rebind() runs on a column add,
+		// and clearing it there would hide the bar out from under a resting pointer
+		// until it moved again
+		setIsRecentlyScrolled(false);
 	};
 
 	const sync = (element, isSyncing) => {
+		onActivity();
+
 		return U.StickyScrollbar.syncFromMain(element, nodeRef.current, isSyncing);
 	};
+
+	useEffect(() => () => unbind(), []);
 
 	useImperativeHandle(ref, () => ({
 		resize,
@@ -77,13 +160,16 @@ const StickyScrollbar = forwardRef<I.StickyScrollbarRef, Props>((props, ref) => 
 		sync,
 	}));
 
+	const cn = [ 'stickyScrollbar', (isVisible ? '' : 'isHidden') ];
+
 	return (
 		<AnimatePresence mode="popLayout">
 			<motion.div
-				ref={nodeRef} 
-				className="stickyScrollbar"
+				ref={nodeRef}
+				className={cn.join(' ')}
 				{...U.Common.animationProps({
-					transition: { duration: 0.2, delay: 0.2 },
+					animate: { opacity: isVisible ? 1 : 0 },
+					transition: { duration: 0.2 },
 				})}
 			>
 				<div className="stickyScrollbarTrack" ref={trackRef}></div>

--- a/src/ts/lib/util/common.ts
+++ b/src/ts/lib/util/common.ts
@@ -21,6 +21,8 @@ const getKatex = (): any => {
 getKatex();
 const iconCache: Map<string, string> = new Map();
 
+let _hasOverlayScrollbars: boolean | null = null;
+
 class UtilCommon {
 
 	/**
@@ -487,6 +489,31 @@ class UtilCommon {
 	 */
 	isPlatformLinux (): boolean {
 		return this.getPlatform() == I.Platform.Linux;
+	};
+
+	/**
+	 * Checks whether the OS draws overlay scrollbars, which appear only while scrolling
+	 * and take up no layout space. True on macOS unless the user selected
+	 * "Show scroll bars: Always" in System Settings.
+	 * Measured once and cached; a preference change applies after restart.
+	 * @returns {boolean} True if scrollbars are overlaid, false if they reserve space.
+	 */
+	hasOverlayScrollbars (): boolean {
+		if (_hasOverlayScrollbars === null) {
+			if (typeof document == 'undefined') {
+				return false;
+			};
+
+			const el = document.createElement('div');
+
+			el.style.cssText = 'position:absolute;top:-9999px;width:100px;height:100px;overflow:scroll;';
+			document.body.appendChild(el);
+
+			_hasOverlayScrollbars = (el.offsetWidth - el.clientWidth) == 0;
+			el.remove();
+		};
+
+		return _hasOverlayScrollbars;
 	};
 
 	/**

--- a/src/ts/lib/util/stickyScrollbar.test.ts
+++ b/src/ts/lib/util/stickyScrollbar.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import U, { StickyScrollbarState } from './stickyScrollbar';
+
+const state = (param?: Partial<StickyScrollbarState>): StickyScrollbarState => ({
+	isEnabled: true,
+	hasScrolledOnce: true,
+	isHovering: false,
+	isRecentlyScrolled: false,
+	...param,
+});
+
+describe('UtilStickyScrollbar.isVisible', () => {
+
+	it('hides when auto-hide is enabled and nothing is active', () => {
+		expect(U.isVisible(state())).toBe(false);
+	});
+
+	it('always shows when auto-hide is disabled, whatever else is false', () => {
+		expect(U.isVisible(state({ isEnabled: false }))).toBe(true);
+	});
+
+	it('shows before the first scroll, so the bar stays discoverable', () => {
+		expect(U.isVisible(state({ hasScrolledOnce: false }))).toBe(true);
+	});
+
+	it('shows while the pointer is over the block', () => {
+		expect(U.isVisible(state({ isHovering: true }))).toBe(true);
+	});
+
+	it('shows during and shortly after scrolling', () => {
+		expect(U.isVisible(state({ isRecentlyScrolled: true }))).toBe(true);
+	});
+
+	it('hides only once hover and scroll activity have both ended', () => {
+		expect(U.isVisible(state({ isHovering: true, isRecentlyScrolled: true }))).toBe(true);
+		expect(U.isVisible(state({ isHovering: true, isRecentlyScrolled: false }))).toBe(true);
+		expect(U.isVisible(state({ isHovering: false, isRecentlyScrolled: true }))).toBe(true);
+		expect(U.isVisible(state({ isHovering: false, isRecentlyScrolled: false }))).toBe(false);
+	});
+
+	it('keeps the bar visible on non-mac even when idle after scrolling', () => {
+		expect(U.isVisible(state({ isEnabled: false, hasScrolledOnce: true }))).toBe(true);
+	});
+
+});

--- a/src/ts/lib/util/stickyScrollbar.ts
+++ b/src/ts/lib/util/stickyScrollbar.ts
@@ -1,10 +1,35 @@
 
 
 /**
+ * Inputs to the auto-hide visibility rule
+ */
+export interface StickyScrollbarState {
+	isEnabled: boolean;
+	hasScrolledOnce: boolean;
+	isHovering: boolean;
+	isRecentlyScrolled: boolean;
+};
+
+/**
  * Utility class for managing sticky horizontal scrollbar synchronization
  * Used in dataview grid and board views
  */
 class UtilStickyScrollbar {
+
+	/**
+	 * Decides whether the sticky scrollbar should be visible.
+	 * Auto-hide only applies where it is enabled (macOS with overlay scrollbars);
+	 * everywhere else the bar stays permanently visible.
+	 * The bar also stays visible until the first scroll, so wide views keep
+	 * an initial affordance that they scroll horizontally.
+	 * @param {StickyScrollbarState} state - Current auto-hide inputs.
+	 * @returns {boolean} True if the bar should be visible.
+	 */
+	isVisible (state: StickyScrollbarState): boolean {
+		const { isEnabled, hasScrolledOnce, isHovering, isRecentlyScrolled } = state;
+
+		return !isEnabled || !hasScrolledOnce || isHovering || isRecentlyScrolled;
+	};
 
 	/**
 	 * Synchronizes the sticky scrollbar position based on the main scroll position


### PR DESCRIPTION
Closes JS-9848. Follow-up to JS-9811 / JS-9714, which added the bar.

## Problem

The dataview sticky horizontal scrollbar is drawn permanently. On macOS that is foreign to the platform — the OS hides scroll indicators when idle.

It also breaks a policy the codebase already holds: `common.scss:227-232` scopes the custom `::-webkit-scrollbar` styling to `platformWindows, platformLinux` so macOS keeps native overlay scrollbars. `stickyScrollbar.scss` was unscoped, and styling `::-webkit-scrollbar` opts an element out of overlay behavior in Chromium. This restores that intent rather than introducing a new preference.

## Behavior

| State | Bar |
| --- | --- |
| Not macOS, or user chose **Show scroll bars: Always** | Visible — unchanged from today |
| Before the first real scroll | Visible |
| Pointer over the block, or scrolling | Visible |
| Idle and unhovered after first scroll | Faded out (1300ms) |
| No overflow | `display: none`, as before |

Auto-hide engages only where the OS hides scrollbars itself. A one-time probe measures whether scrollbars reserve layout space, so anyone who set **Always** — and every Windows/Linux user — sees no change at all.

The bar stays visible until first use, so a wide grid still advertises that it scrolls. That is the discoverability JS-9811 was filed to fix; `OverlayScrollbars` calls this `autoHideSuspend` and recommends it for accessibility.

## Implementation notes

- **Opacity only.** `display` stays owned by `resize()`, which already hides the bar when content does not overflow. Sharing one property would make the two clobber each other on every column drag.
- **Fade via motion, not CSS.** `animationProps()` already has motion writing an inline `opacity` that beats any stylesheet rule.
- **Activity is gated on `scrollLeft` actually changing.** `grid.tsx:48-61` calls `onScrollHorizontal()` programmatically on mount and on view/column changes; counting that as a scroll would consume the initial reveal and make grid diverge from board.
- **Hover host is the shared parent.** The bar is a sibling of the scroll element, so their parent covers both the content and the bar. `mouseover` rather than `mouseenter`, so hover self-heals when `rebind()` re-attaches listeners on a column add.

`grid.tsx` and `board.tsx` are unchanged — `bind()` already supplies the element and `sync()` already fires on horizontal scroll.

## Verification

- `bun run typecheck` — clean, both tsconfigs
- `bun run lint` — clean
- 7 new unit tests for the visibility predicate — passing
- Probe validated in real Chromium on macOS: overlay mode measures `0`, a space-reserving scrollbar measures `15`
- Dark mode audit — no colors touched, no theme overrides needed

**Not yet done:** end-to-end manual verification in the running app. The 6-step plan is in `docs/superpowers/specs/2026-08-03-sticky-scrollbar-autohide-design.md`; step 1 (bar stays visible until first scroll) is the one worth exercising, since it is component-internal and not covered by the unit tests.

## Out of scope

- **JS-9794** (scrollbar hitbox too small) — the bar is 10px, under WCAG SC 2.5.8. Pre-existing; enlarging it is a design decision.
- `prefers-reduced-motion` — honored nowhere in the app today; belongs in its own task.
- Runtime preference changes: the probe runs once, so toggling the system setting applies on restart.