### PR TITLE
JS-9848: start the dataview sticky scrollbar hidden on macOS

### DIFF
--- a/docs/superpowers/specs/2026-08-03-sticky-scrollbar-autohide-design.md
+++ b/docs/superpowers/specs/2026-08-03-sticky-scrollbar-autohide-design.md
@@ -43,7 +43,7 @@ JS-9811's message states the problem it solved: wide inline queries "could only 
 Two conclusions shaped the design:
 
 1. **Roselli's objection is answerable here.** In Chromium the preference *is* detectable: an offscreen `overflow: scroll` probe reports `offsetWidth - clientWidth == 0` under macOS overlay scrollbars, and ~15px when the user has set **Show scroll bars: Always**. Respecting that turns this from an author-preference override into preference-respecting behavior.
-2. **`autoHideSuspend` resolves the NN/g conflict.** Keeping the bar visible until first use retains JS-9811's discoverability fix while still decluttering afterwards.
+2. **`autoHideSuspend` looked like it resolved the NN/g conflict.** Keeping the bar visible until first use should have retained JS-9811's discoverability fix while still decluttering afterwards. It was implemented and shipped, then removed — see the revision note under *Visibility rule*. The theory did not survive contact with the actual interaction: a bar that disappears the first time you use it reads as breakage, not as a hint.
 
 ## Design
 
@@ -67,10 +67,13 @@ The component therefore owns its auto-hide state entirely, and both call sites i
 isEnabled = props.autoHide ?? (U.Common.isPlatformMac() && U.Common.hasOverlayScrollbars())
 
 visible = !isEnabled                                  // Win/Linux, or "Always" chosen
-        || !hasScrolledOnce                           // suspend until first use
         || isHovering                                 // see host below
         || isRecentlyScrolled                         // see timer below
 ```
+
+> **Revised 2026-08-03, after the first version shipped.** The original rule carried a fourth clause, `|| !hasScrolledOnce` — the bar stayed visible until the user's first real scroll, following OverlayScrollbars' `autoHideSuspend`. In use this read as a bug rather than an affordance: a freshly opened object showed a bar that then vanished the first time you scrolled and moved away, which looks like a glitch rather than a deliberate hint. The clause was removed; the bar now starts hidden.
+>
+> The cost is real and accepted: a wide grid no longer advertises that it scrolls until hovered. That is a partial walk-back of JS-9811, mitigated by the fact that hovering a table is the normal precondition to interacting with it, so the reveal happens before anyone needs the bar.
 
 **Hover host.** In both `grid.tsx:577-603` and `board.tsx`, the bar is rendered as a *sibling* of the scrolling element, under a shared view-root wrapper. That wrapper — reachable as `nodeRef.current.parentElement` — is used as the hover target, because it spans the block content *and* the bar. A single `isHovering` flag therefore covers hovering the bar itself, with no second listener pair and no gap when the pointer crosses from content onto the bar.
 
@@ -80,7 +83,9 @@ Listeners are `mouseover` (rather than `mouseenter`) and `mouseleave`. `mouseove
 
 `isRecentlyScrolled` is **timer-driven, not polled**: every scroll event sets it true and restarts a single 1300ms `setTimeout` that sets it false. Reusing one timer handle means rapid scrolling does not accumulate timers.
 
-**Programmatic scrolls must not count as activity.** `grid.tsx:48-61` calls `onScrollHorizontal()` directly from a `useEffect` keyed on `[ relations.length, view?.id ]`, so `sync()` fires on mount and on every view or column-count change with no user involvement. Treating that as a scroll sets `hasScrolledOnce` at mount and silently deletes the entire suspend clause — the bar would fade ~1300ms after open, having never been scrolled, reintroducing the JS-9811 discoverability bug on grid while board (whose `onScrollHorizontal` is only ever a real listener) kept the intended behavior.
+**Programmatic scrolls must not count as activity.** `grid.tsx:48-61` calls `onScrollHorizontal()` directly from a `useEffect` keyed on `[ relations.length, view?.id ]`, so `sync()` fires on mount and on every view or column-count change with no user involvement. Without a guard, opening any object with a wide grid would flash the bar visible for 1300ms and then fade it — and board, whose `onScrollHorizontal` is only ever a real listener, would not flash, so the two views would visibly disagree.
+
+(Under the original suspend rule this same defect had a different symptom: it set `hasScrolledOnce` at mount and deleted the suspend clause outright. The guard is what makes both rules behave, and it matters more now that the bar starts hidden.)
 
 Activity is therefore gated on the scroll position actually moving. The component tracks `lastScrollLeft`; the first observation after `bind()` only establishes a baseline and returns, and an unchanged position is ignored. Real user scrolls change `scrollLeft` and register normally. `lastScrollLeft` resets in `unbind()` so each bind re-establishes its own baseline.
 
@@ -89,13 +94,11 @@ Activity is therefore gated on the scroll position actually moving. The componen
 | State | Bar |
 | --- | --- |
 | Not macOS, or user chose "Show scroll bars: Always" | Visible — today's behavior exactly |
-| Before the first horizontal scroll of that view | Visible (suspend) |
+| Freshly opened, pointer elsewhere | Hidden |
 | Pointer over the dataview block, or over the bar | Visible |
 | Scrolling, or within 1300ms of the last scroll | Visible |
-| Idle, unhovered, after first scroll | Faded out |
+| Idle and unhovered | Faded out |
 | No overflow | `display: none` via existing `resize()` |
-
-`hasScrolledOnce` is per-instance and flips on the first `sync()` or first scroll of the bar itself.
 
 Non-macOS users and macOS users who chose "Always" short-circuit on the first clause, so they see no behavior change at all. Regression risk is confined to the target platform.
 
@@ -103,7 +106,7 @@ Non-macOS users and macOS users who chose "Always" short-circuit on the first cl
 
 `resize()` already writes `display` to hide the bar when content does not overflow (`grid.tsx:426`, `:437`, `:440`, `:466`). Auto-hide **must not** reuse `display`, or the two mechanisms will overwrite each other on every resize — and `resize()` is called on every column drag and scroll.
 
-Auto-hide therefore uses **opacity only**. `display` stays exclusively owned by `resize()`. The two compose correctly: `display: none` wins regardless of opacity, and when a view becomes overflowing again the suspend clause makes the bar visible.
+Auto-hide therefore uses **opacity only**. `display` stays exclusively owned by `resize()`. The two compose correctly: `display: none` wins regardless of opacity, and when a view becomes overflowing again the bar returns to whatever the hover/scroll rule says.
 
 ### Fade mechanism
 
@@ -153,15 +156,18 @@ One `setTimeout` handle and two hover listeners, all torn down in `unbind()` and
 
 ## Testing
 
-**Automated** — unit-testable pure logic: extract the visibility rule as a pure predicate over `(isEnabled, hasScrolledOnce, isHoveringHost, isHoveringBar, msSinceScroll)` so the truth table above can be asserted directly without DOM or timers.
+**Automated** — unit-testable pure logic: the visibility rule is a pure predicate over `(isEnabled, isHovering, isRecentlyScrolled)`, so the truth table above is asserted directly without DOM or timers.
+
+Note what the unit tests do **not** reach: the `lastScrollLeft` baseline guard lives in component state, and this repo has no React component test setup (vitest runs in `node` with no jsdom). Step 1 below is the only coverage it has.
 
 **Manual, macOS with Show scroll bars: When scrolling** (the default):
-1. Wide inline grid — bar visible on first render; scroll horizontally; bar remains while the pointer is over the block; move the pointer away; bar fades after ~1300ms.
-2. Return the pointer to the block — bar fades back in immediately.
-3. Hover the bar itself and drag the thumb — grabbable, and stays visible for the whole drag.
-4. Narrow the view so columns fit — bar `display: none`; widen again — bar returns visible.
-5. Resize a column with the pointer inside the block — bar stays visible throughout.
-6. Repeat 1-5 on a wide inline board and on a full-page grid.
+1. Open an object with a wide inline grid, pointer away from the block — **no bar appears at any point**, including no brief flash on open. Repeat by switching views and by adding a column, which also trigger the programmatic scroll path.
+2. Move the pointer over the block — bar fades in; move it away — bar fades out after ~1300ms.
+3. Scroll horizontally, then move the pointer off the block — bar stays for ~1300ms, then fades.
+4. Hover the bar itself and drag the thumb — grabbable, and stays visible for the whole drag.
+5. Narrow the view so columns fit — bar `display: none`; widen again — bar returns, still hidden until hovered.
+6. Resize a column with the pointer inside the block — bar stays visible throughout.
+7. Repeat 1-6 on a wide inline board and on a full-page grid; grid and board must behave identically.
 
 **Manual, macOS with Show scroll bars: Always** — bar is permanently visible in every case above; no fading at any point.
 

--- a/src/ts/component/util/stickyScrollbar.tsx
+++ b/src/ts/component/util/stickyScrollbar.tsx
@@ -22,7 +22,6 @@ const StickyScrollbar = forwardRef<I.StickyScrollbarRef, Props>((props, ref) => 
 	const lastScrollLeft = useRef<number | null>(null);
 	const timeout = useRef(0);
 
-	const [ hasScrolledOnce, setHasScrolledOnce ] = useState(false);
 	const [ isHovering, setIsHovering ] = useState(false);
 	const [ isRecentlyScrolled, setIsRecentlyScrolled ] = useState(false);
 
@@ -33,7 +32,7 @@ const StickyScrollbar = forwardRef<I.StickyScrollbarRef, Props>((props, ref) => 
 
 	isEnabledRef.current = isEnabled;
 
-	const isVisible = U.StickyScrollbar.isVisible({ isEnabled, hasScrolledOnce, isHovering, isRecentlyScrolled });
+	const isVisible = U.StickyScrollbar.isVisible({ isEnabled, isHovering, isRecentlyScrolled });
 
 	const toPx = (v: any): any => {
 		return typeof v == 'number' ? `${v}px` : v;
@@ -41,8 +40,8 @@ const StickyScrollbar = forwardRef<I.StickyScrollbarRef, Props>((props, ref) => 
 
 	// Reveals the bar on scroll and restarts the idle countdown.
 	// Only a real change of position counts: grid calls onScrollHorizontal()
-	// programmatically on mount and on view/column changes, and that must not
-	// consume the initial reveal that makes the bar discoverable
+	// programmatically on mount and on view/column changes, which would
+	// otherwise flash the bar open every time an object is opened
 	const onActivity = () => {
 		if (!isEnabledRef.current) {
 			return;
@@ -62,7 +61,6 @@ const StickyScrollbar = forwardRef<I.StickyScrollbarRef, Props>((props, ref) => 
 			return;
 		};
 
-		setHasScrolledOnce(true);
 		setIsRecentlyScrolled(true);
 
 		window.clearTimeout(timeout.current);

--- a/src/ts/lib/util/stickyScrollbar.test.ts
+++ b/src/ts/lib/util/stickyScrollbar.test.ts
@@ -3,7 +3,6 @@ import U, { StickyScrollbarState } from './stickyScrollbar';
 
 const state = (param?: Partial<StickyScrollbarState>): StickyScrollbarState => ({
 	isEnabled: true,
-	hasScrolledOnce: true,
 	isHovering: false,
 	isRecentlyScrolled: false,
 	...param,
@@ -11,16 +10,12 @@ const state = (param?: Partial<StickyScrollbarState>): StickyScrollbarState => (
 
 describe('UtilStickyScrollbar.isVisible', () => {
 
-	it('hides when auto-hide is enabled and nothing is active', () => {
+	it('starts hidden when auto-hide is enabled and nothing is active', () => {
 		expect(U.isVisible(state())).toBe(false);
 	});
 
 	it('always shows when auto-hide is disabled, whatever else is false', () => {
 		expect(U.isVisible(state({ isEnabled: false }))).toBe(true);
-	});
-
-	it('shows before the first scroll, so the bar stays discoverable', () => {
-		expect(U.isVisible(state({ hasScrolledOnce: false }))).toBe(true);
 	});
 
 	it('shows while the pointer is over the block', () => {
@@ -38,8 +33,8 @@ describe('UtilStickyScrollbar.isVisible', () => {
 		expect(U.isVisible(state({ isHovering: false, isRecentlyScrolled: false }))).toBe(false);
 	});
 
-	it('keeps the bar visible on non-mac even when idle after scrolling', () => {
-		expect(U.isVisible(state({ isEnabled: false, hasScrolledOnce: true }))).toBe(true);
+	it('keeps the bar visible on non-mac even when idle and unhovered', () => {
+		expect(U.isVisible(state({ isEnabled: false, isHovering: false, isRecentlyScrolled: false }))).toBe(true);
 	});
 
 });

--- a/src/ts/lib/util/stickyScrollbar.ts
+++ b/src/ts/lib/util/stickyScrollbar.ts
@@ -5,7 +5,6 @@
  */
 export interface StickyScrollbarState {
 	isEnabled: boolean;
-	hasScrolledOnce: boolean;
 	isHovering: boolean;
 	isRecentlyScrolled: boolean;
 };
@@ -20,15 +19,15 @@ class UtilStickyScrollbar {
 	 * Decides whether the sticky scrollbar should be visible.
 	 * Auto-hide only applies where it is enabled (macOS with overlay scrollbars);
 	 * everywhere else the bar stays permanently visible.
-	 * The bar also stays visible until the first scroll, so wide views keep
-	 * an initial affordance that they scroll horizontally.
+	 * Where it is enabled the bar starts hidden and is revealed by hovering the
+	 * block or by scrolling, matching how the OS draws its own indicators.
 	 * @param {StickyScrollbarState} state - Current auto-hide inputs.
 	 * @returns {boolean} True if the bar should be visible.
 	 */
 	isVisible (state: StickyScrollbarState): boolean {
-		const { isEnabled, hasScrolledOnce, isHovering, isRecentlyScrolled } = state;
+		const { isEnabled, isHovering, isRecentlyScrolled } = state;
 
-		return !isEnabled || !hasScrolledOnce || isHovering || isRecentlyScrolled;
+		return !isEnabled || isHovering || isRecentlyScrolled;
 	};
 
 	/**


### PR DESCRIPTION
Follow-up to #2325 (JS-9848), fixing feedback from using it.

## Problem

#2325 shipped with an `autoHideSuspend` clause: the bar stayed visible until the user's first real scroll, so a wide grid kept advertising that it scrolled.

In practice that reads as a bug rather than an affordance. A freshly opened object shows a bar, and the first time you scroll and move the pointer away it vanishes — which looks like breakage, not a deliberate hint.

## Change

Drop the clause. On macOS the bar now starts hidden and is revealed by hovering the block or scrolling.

```
- visible = !isEnabled || !hasScrolledOnce || isHovering || isRecentlyScrolled
+ visible = !isEnabled || isHovering || isRecentlyScrolled
```

| State | Bar |
| --- | --- |
| Not macOS, or **Show scroll bars: Always** | Visible — unchanged |
| Freshly opened, pointer elsewhere | Hidden |
| Pointer over the block, or scrolling | Visible |
| Idle and unhovered | Faded out after 1300ms |
| No overflow | `display: none`, as before |

## Trade-off

Accepted and recorded in the spec: a wide grid no longer advertises horizontal scroll until hovered, a partial walk-back of JS-9811. Hovering a table is the normal precondition to interacting with it, so the reveal happens before the bar is needed.

## The guard that has to stay

`lastScrollLeft` is kept and matters more now. `grid.tsx:48-61` calls `onScrollHorizontal()` programmatically on mount and on view/column changes; without the guard that would flash the bar open for 1300ms every time an object is opened — and board, whose handler is only ever a real listener, would not flash, so grid and board would visibly disagree.

## Verification

- `bun run typecheck` — clean, both tsconfigs
- `eslint` — clean
- Predicate tests updated to the new rule — 6 passing
- No stale `hasScrolledOnce` references remain in `src/`

**Not verified in the running app.** The `lastScrollLeft` guard is component state and this repo has no React component test setup, so step 1 of the manual plan in `docs/superpowers/specs/2026-08-03-sticky-scrollbar-autohide-design.md` — open a wide grid with the pointer away and confirm **no flash at all**, including after a view switch or column add — is the check worth doing before merge.