### PR TITLE
fix(lightbox): close the image preview when opening the file as object

### DIFF
--- a/src/ts/component/menu/object.tsx
+++ b/src/ts/component/menu/object.tsx
@@ -555,6 +555,7 @@ const MenuObject = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 			};
 
 			case 'openAsObject': {
+				S.Popup.close('preview');
 				U.Object.openAuto(object);
 				break;
 			};


### PR DESCRIPTION
Closes JS-9849

## Problem

The image lightbox's three-dot menu offers **Open as Object**. Choosing it opens the object, but the lightbox stays on screen and covers the result — you have to close the lightbox manually to notice anything happened.

## Cause

`src/ts/component/menu/object.tsx` — the `openAsObject` case called `U.Object.openAuto(object)` without closing the `preview` popup. Two variants of the same symptom:

- **Lightbox opened from an object that is itself in a popup** → `openAuto` → `openPopup` → `S.Popup.open('page', …)`. A `page` popup already exists, so `PopupStore.open` takes the `update()` branch and keeps its original index in `popupList` — before `preview`. All popups share `z-index: 101`, so DOM order decides stacking and the object renders behind the lightbox.
- **Lightbox opened from a full-page editor** → `keyboard.isPopup()` is false → `openRoute` → the page underneath navigates while the lightbox still covers the screen.

## Fix

Close the preview popup first, matching the pattern the neighbouring `editType` case already uses.

Ordering works out: `close()` schedules removal at `J.Constant.delay.popup`, and `openPopup` schedules `S.Popup.open('page')` at `S.Popup.getTimeout()` (same delay), registered afterwards — the lightbox fades out first, then the object appears in front.

The rest of the file-preview menu was checked for the same gap: `editType` already closes the preview, trash/delete go through the `onArchive`/`onDelete` callbacks that call the popup's own `close()`, and the remaining items (favorite, pin, link-to, add-to-collection, copy link, download, copy to clipboard) don't navigate. `openAsObject` was the only one.

## Testing

- `bun run typecheck` — passes (both tsconfigs)
- `bun run lint` — clean

Manual check: open an image in the lightbox (chat attachment, comment, or image block), three-dot menu → **Open as Object**. The lightbox should close and the object should be in the foreground.