### PR TITLE
JS-9850: clear the pin on logout and add a reset path to the lock screen

### DIFF
--- a/src/json/text.json
+++ b/src/json/text.json
@@ -529,6 +529,9 @@
 
 	"authPinCheckTitle": "Enter Pin",
 	"authPinCheckError": "Incorrect Pin",
+	"authPinCheckForgot": "I forgot my Pin",
+	"authPinCheckForgotTitle": "Reset your Pin?",
+	"authPinCheckForgotText": "You will be logged out on this device and your Pin will be removed. To log back in you will need your Key. Your data stays on this device.",
 
 	"authOnboardPhraseTitle": "This is your Key",
 	"authOnboardPhraseLabel": "It replaces login and password. Keep it safe — only you are responsible for your data. You can find this Key later in app settings.",

--- a/src/scss/page/auth.scss
+++ b/src/scss/page/auth.scss
@@ -136,6 +136,7 @@ html.bodyAuthDeleted {
 
 .pageAuthPinCheck {
 	.title { @include text-header1; font-weight: 600; margin: 0px 0px 24px 0px; }
+	.buttons { margin: 24px 0px 0px 0px; }
 	.pin { display: flex; gap: 0px 8px; flex-direction: row; }
 	.pin {
 		.input { 

--- a/src/ts/component/page/auth/pinCheck.tsx
+++ b/src/ts/component/page/auth/pinCheck.tsx
@@ -28,6 +28,20 @@ const PageAuthPinCheck = forwardRef<I.PageRef, I.PageComponent>(() => {
 		setError(translate('authPinCheckError'));
 	};
 
+	const onForgot = () => {
+		S.Popup.open('confirm', {
+			data: {
+				title: translate('authPinCheckForgotTitle'),
+				text: translate('authPinCheckForgotText'),
+				textConfirm: translate('commonLogout'),
+				onConfirm: () => {
+					S.Auth.logout(true, false);
+					U.Router.go('/auth/select', { replace: true });
+				},
+			},
+		});
+	};
+
 	const onSuccess = () => {
 		const { account } = S.Auth;
 		const { redirect } = S.Common;
@@ -60,6 +74,10 @@ const PageAuthPinCheck = forwardRef<I.PageRef, I.PageComponent>(() => {
 					onError={onError} 
 				/>
 				<Error text={error} />
+
+				<div className="buttons">
+					<div className="small" onClick={onForgot}>{translate('authPinCheckForgot')}</div>
+				</div>
 			</Frame>
 		</>
 	);

--- a/src/ts/store/auth.ts
+++ b/src/ts/store/auth.ts
@@ -261,6 +261,13 @@ class AuthStore {
 			analytics.profile('', '');
 			analytics.removeContext();
 
+			// The pin only locks the signed-in session on this device, so it goes with the session.
+			// Otherwise the keychain entry outlives the logout and locks the account out on re-login.
+			// Secondary tabs log out through the same path, so only the initiator touches the keychain
+			if (mainWindow && S.Common.pin) {
+				S.Common.pinClear();
+			};
+
 			keyboard.setPinChecked(false);
 
 			S.Common.spaceSet('');

--- a/src/ts/store/common.ts
+++ b/src/ts/store/common.ts
@@ -725,6 +725,22 @@ class CommonStore {
 	};
 
 	/**
+	 * Drops the pin along with the session it locks, on logout.
+	 * Unlike pinRemove it leaves the checked state alone: the session is going away, so there is
+	 * nothing left to unlock, and marking it checked would broadcast pin-unlocked to every tab.
+	 */
+	pinClear () {
+		const id = this.pinId();
+
+		if (id) {
+			Renderer.send('keytarDelete', id);
+		};
+
+		Renderer.send('setHasPinSet', false);
+		this.pinValue = null;
+	};
+
+	/**
 	 * Initializes the pin value, optionally calling a callback.
 	 * @param {() => void} callBack - The callback function to call after initialization.
 	 */


### PR DESCRIPTION
Closes JS-9850. Reported in [the community](https://community.anytype.io/t/forgotten-the-desktop-pin/31144) by a user who had their key, reinstalled the app, and was still locked out.

## Problem

The pin is `sha1(pin)` in the OS keychain under `<accountId>-pin`. Logout cleared the local `accountId`/`pin` storage keys but never the keychain entry, and the account id is derived from the key — so re-login read the same value back and the lock screen returned. Reinstalling did not help either, since the value lives in the OS keychain rather than app data.

The lock screen does show a Logout button, which is what users click first, so it looked like an escape hatch that quietly wasn't one. The only real way out was deleting the keychain entry by hand.

## Changes

- **`store/auth.ts`** — `logout()` clears the pin. It only locks the signed-in session on this device, so it goes with the session. Guarded on `mainWindow`: secondary tabs log out through the same path via the `logout` broadcast, and only the initiator should touch the keychain.
- **`store/common.ts`** — new `pinClear()` rather than reusing `pinRemove()`. `pinRemove()` marks the pin checked, which makes main broadcast `pin-unlocked` to every tab; mid-teardown that navigates tabs still finishing logout and leaves `keyboard.isPinChecked` stuck `true`, which could skip the lock screen on a later login. `pinClear()` also sends `setHasPinSet(false)` explicitly, because `setPinChecked(false)` short-circuits when the value is already `false` (it is, on the lock screen) and main would otherwise keep `hasPinSet: true` and go on hiding the tab bar and disabling menus on the login screen.
- **`page/auth/pinCheck.tsx`** — an "I forgot my Pin" action that confirms before acting: *You will be logged out on this device and your Pin will be removed. To log back in you will need your Key. Your data stays on this device.* Reuses the existing `.buttons` / `.small` auth-page pattern from `login.tsx`; no `Animation.from` here, since it early-returns while another animation is in flight and would strand the user after `logout()` had already run.
- **`text.json`** — three strings, following existing copy ("Pin", "Key"). The confirm button reuses `commonLogout`.
- **`auth.scss`** — one `margin` line to space the new element.

## Behavior change worth noting

Any logout now clears the pin, including a routine one from Settings. A local screen lock on a signed-out session protects nothing, and logging back in requires the key, which is stronger. `popupLogoutText` doesn't mention it — say the word if it should.

## Test plan

- [x] Set a pin, quit, reopen → lock screen appears; "I forgot my Pin" → confirm → login screen; sign in with the key → app opens with no pin.
- [x] Same via the header Logout button on the lock screen → also no pin after re-login (this is the path that was broken).
- [x] Set a pin, log out from Settings, log back in → no pin.
- [x] Set a pin, lock via timeout, enter the correct pin → unlocks as before; wrong pin → error as before.
- [x] After logout from the lock screen, the login screen has a working tab bar and menus (`hasPinSet` cleared in main).
- [x] Multi-tab: with several tabs open, log out from one → all tabs log out, keychain entry deleted once.