### PR TITLE
feat(dataview): add Split master-detail layout for sets and collections

### DIFF
--- a/docs/src/ts/component/block/README.md
+++ b/docs/src/ts/component/block/README.md
@@ -36,6 +36,7 @@ Database-like component with multiple views. Supports filtering, sorting, groupi
 - `list.tsx` — List with `list/row.tsx`
 - `graph.tsx` — Graph view (uses GraphProvider)
 - `timeline.tsx` — Timeline view
+- `split.tsx` — Master-detail split: `list.tsx` in a resizable left pane, the selected record's `EditorPage` on the right. Sizes itself to the viewport so each pane scrolls internally; pane width and selection persist locally via `Lib/storage` (experimental)
 
 ### Table (`table/` — main file ~1,990 lines)
 Spreadsheet-style tables with `cell.tsx` and `row.tsx`.

--- a/src/json/size.ts
+++ b/src/json/size.ts
@@ -57,6 +57,10 @@ export default {
 			small: 70,
 			medium: 120,
 		},
+
+		split: {
+			master: { min: 240, max: 640, default: 320 },
+		},
 	},
 
 	store: {

--- a/src/json/text.json
+++ b/src/json/text.json
@@ -470,6 +470,7 @@
 	"viewName4": "Calendar",
 	"viewName5": "Graph",
 	"viewName6": "Timeline",
+	"viewName7": "Split",
 
 	"progressDropFiles": "Copying files...",
 	"progressImport": "Import in progress...",
@@ -843,6 +844,8 @@
 	"blockDataviewEmptyTargetButton": "Select Source",
 
 	"blockDataviewEmptyViewDescription": "Create your first one to begin",
+
+	"blockDataviewSplitEmptyDetail": "Select an object to open it here",
 
 	"blockDataviewControlsFilters": "Filters",
 	"blockDataviewControlsSorts": "Sorts",

--- a/src/json/text.json
+++ b/src/json/text.json
@@ -846,6 +846,7 @@
 	"blockDataviewEmptyViewDescription": "Create your first one to begin",
 
 	"blockDataviewSplitEmptyDetail": "Select an object to open it here",
+	"blockDataviewNestedInSplit": "This collection can only be viewed in full screen mode",
 
 	"blockDataviewControlsFilters": "Filters",
 	"blockDataviewControlsSorts": "Sorts",

--- a/src/json/text.json
+++ b/src/json/text.json
@@ -846,6 +846,7 @@
 	"blockDataviewEmptyViewDescription": "Create your first one to begin",
 
 	"blockDataviewSplitEmptyDetail": "Select an object to open it here",
+	"blockDataviewSplitChatDetail": "Chats can only be opened as a full page",
 	"blockDataviewNestedInSplit": "This collection can only be viewed in full screen mode",
 
 	"blockDataviewControlsFilters": "Filters",

--- a/src/scss/block/common.scss
+++ b/src/scss/block/common.scss
@@ -136,6 +136,7 @@
 @import "./dataview/view/calendar";
 @import "./dataview/view/graph";
 @import "./dataview/view/timeline";
+@import "./dataview/view/split";
 @import "./dataview/filters/group";
 @import "./div";
 @import "./featured";

--- a/src/scss/block/dataview.scss
+++ b/src/scss/block/dataview.scss
@@ -94,7 +94,7 @@
 
 		.dataviewControls { font-weight: 500; color: var(--color-control-active); position: relative; overflow: hidden; }
 		.dataviewControls::after { content: ''; display: none; height: 1px; width: 100%; background: var(--color-shape-secondary); position: absolute; bottom: 0px; }
-		.dataviewControls.viewGrid::after, .dataviewControls.viewList::after { display: block; }
+		.dataviewControls.viewGrid::after, .dataviewControls.viewList::after, .dataviewControls.viewSplit::after { display: block; }
 
 		.dataviewControls {
 			> .sides { gap: 0px 16px; display: flex; flex-direction: row; align-items: center; justify-content: stretch; width: 100%; }

--- a/src/scss/block/dataview/view/split.scss
+++ b/src/scss/block/dataview/view/split.scss
@@ -104,6 +104,12 @@
 				.splitDetailEmpty {
 					.label { @include text-common; color: var(--color-text-secondary); text-align: center; }
 				}
+
+				/* Stands in for an object whose page cannot render inside the panel (chats). */
+				.splitDetailUnsupported { display: flex; align-items: center; justify-content: center; height: 100%; }
+				.splitDetailUnsupported {
+					.label { @include text-common; color: var(--color-text-secondary); text-align: center; }
+				}
 			}
 		}
 	}

--- a/src/scss/block/dataview/view/split.scss
+++ b/src/scss/block/dataview/view/split.scss
@@ -4,10 +4,21 @@
 	.block.blockDataview {
 		.viewContent.viewSplit { position: relative; height: 100%; display: flex; align-items: stretch; }
 		.viewContent.viewSplit {
-			.splitMaster { position: relative; flex-shrink: 0; height: 100%; overflow-x: hidden; overflow-y: auto; }
+			/*
+			 * resize() breaks the container out to the full page width with a -48px left
+			 * margin (the ViewGraph technique). The detail pane wants that extra width, but
+			 * the master pane's rows would then start 48px left of where a regular List
+			 * layout puts them — so give it back here.
+			 */
+			.splitMaster { position: relative; flex-shrink: 0; height: 100%; overflow-x: hidden; overflow-y: auto; padding-left: 48px; }
 			.splitMaster {
 				.wrap { height: 100%; }
 				#scroll { height: 100%; }
+
+				/* Match the regular (non-inline) List layout's top offset, so the first row sits
+				 * the same distance below the controls bar as it does in a plain List view. */
+				.viewContent.viewList { padding: 8px 0px 0px 0px; }
+				.viewContent.viewList.isRegular { padding: 9px 0px 0px 0px; }
 			}
 
 			.resize-h { width: 12px; height: 100%; cursor: col-resize; z-index: 2; flex-shrink: 0; position: relative; }
@@ -31,23 +42,43 @@
 
 			.splitDetail { position: relative; flex-grow: 1; height: 100%; display: flex; flex-direction: column; min-width: 0px; border-left: 1px solid var(--color-shape-secondary); }
 			.splitDetail {
-				.splitDetailHead { display: flex; align-items: center; justify-content: space-between; gap: 0px 8px; padding: 8px 12px; flex-shrink: 0; }
-				.splitDetailHead {
-					.side { display: flex; align-items: center; gap: 0px 8px; min-width: 0px; }
-					.side.left { flex-grow: 1; }
-					.name { @include text-common; @include text-overflow-nw; color: var(--color-text-primary); }
-				}
+				/* Floats over the top-right of the pane, level with the editor's title and
+				 * aligned to the same 16px gutter as the content below it. */
+				.icon.splitDetailExpand { position: absolute; right: 16px; top: 12px; z-index: 2; width: 24px; height: 24px; }
 
 				.splitDetailBody { position: relative; flex-grow: 1; overflow-x: hidden; overflow-y: auto; min-height: 0px; }
 				.splitDetailBody {
 					/*
-					 * EditorPage.getWidth measures the page container, not this pane, and writes
-					 * the result as an inline width. max-width beats an inline width, so this keeps
-					 * the embedded editor inside the pane at any resizer position.
+					 * EditorPage.getWidth measures the page container, not this pane, and caps the
+					 * result at J.Size.editor (704px), writing it as an inline width. In a pane wider
+					 * than that it left a dead column beside the text, so let the editor fill the
+					 * pane instead — !important is the only way to beat an inline style.
 					 */
-					.editorWrapper { max-width: 100%; }
+					.editorWrapper { width: 100% !important; max-width: 100%; }
 					.editorWrapper {
+						/* The add-cover / show-description toolbar is redundant here — the object
+						 * is reachable as a full page via the expand control. */
+						.editorControls { display: none; }
+
 						.editor { max-width: 100%; }
+
+						/* Pulls the title to the top of the pane: the 48px gutter the full page
+						 * reserves for block drag handles is dead space at this width. The
+						 * horizontal padding keeps content off the panel divider and the
+						 * pane's right edge. */
+						.blocks { margin-left: 0px; padding: 12px 16px 0px 16px; }
+						.blocks {
+							.block {
+								.wrapMenu { display: none; }
+								.wrapContent { width: 100%; }
+							}
+						}
+
+						.blockLast { margin-left: 0px; height: 60px; }
+
+						/* The discussion section sits outside .blocks, so it needs the same
+						 * gutter applied to it directly or it renders flush to both edges. */
+						.commentSection { padding-left: 16px; padding-right: 16px; }
 					}
 				}
 

--- a/src/scss/block/dataview/view/split.scss
+++ b/src/scss/block/dataview/view/split.scss
@@ -1,0 +1,65 @@
+@import "~scss/_mixins";
+
+.blocks {
+	.block.blockDataview {
+		.viewContent.viewSplit { position: relative; height: 100%; display: flex; align-items: stretch; }
+		.viewContent.viewSplit {
+			.splitMaster { position: relative; flex-shrink: 0; height: 100%; overflow-x: hidden; overflow-y: auto; }
+			.splitMaster {
+				.wrap { height: 100%; }
+				#scroll { height: 100%; }
+			}
+
+			.resize-h { width: 12px; height: 100%; cursor: col-resize; z-index: 2; flex-shrink: 0; position: relative; }
+			.resize-h {
+				.resize-handle { position: absolute; left: 0px; top: 50%; margin: -16px 0px 0px 0px; width: 100%; height: 32px; transition: $transitionAllCommon; }
+				.resize-handle::after {
+					content: ''; position: absolute; left: 50%; top: 0px; width: 6px; height: 100%; margin-left: -3px;
+					background-color: var(--color-shape-secondary); border-radius: 3px; opacity: 0; transition: $transitionAllCommon;
+				}
+
+				&:hover, &:active {
+					.resize-handle::after { opacity: 1; }
+				}
+
+				&:active {
+					.resize-handle { height: 64px; margin-top: -32px; }
+				}
+
+				.resize-handle:hover::after, .resize-handle:active::after { background-color: var(--color-shape-primary); }
+			}
+
+			.splitDetail { position: relative; flex-grow: 1; height: 100%; display: flex; flex-direction: column; min-width: 0px; border-left: 1px solid var(--color-shape-secondary); }
+			.splitDetail {
+				.splitDetailHead { display: flex; align-items: center; justify-content: space-between; gap: 0px 8px; padding: 8px 12px; flex-shrink: 0; }
+				.splitDetailHead {
+					.side { display: flex; align-items: center; gap: 0px 8px; min-width: 0px; }
+					.side.left { flex-grow: 1; }
+					.name { @include text-common; @include text-overflow-nw; color: var(--color-text-primary); }
+				}
+
+				.splitDetailBody { position: relative; flex-grow: 1; overflow-x: hidden; overflow-y: auto; min-height: 0px; }
+				.splitDetailBody {
+					/*
+					 * EditorPage.getWidth measures the page container, not this pane, and writes
+					 * the result as an inline width. max-width beats an inline width, so this keeps
+					 * the embedded editor inside the pane at any resizer position.
+					 */
+					.editorWrapper { max-width: 100%; }
+					.editorWrapper {
+						.editor { max-width: 100%; }
+					}
+				}
+
+				.splitDetailEmpty { display: flex; align-items: center; justify-content: center; height: 100%; }
+				.splitDetailEmpty {
+					.label { @include text-common; color: var(--color-text-secondary); text-align: center; }
+				}
+			}
+		}
+	}
+
+	.block.blockDataview.isInline {
+		.viewContent.viewSplit { height: 500px; }
+	}
+}

--- a/src/scss/block/dataview/view/split.scss
+++ b/src/scss/block/dataview/view/split.scss
@@ -8,7 +8,8 @@
 			 * resize() breaks the container out to the full page width with a -48px left
 			 * margin (the ViewGraph technique). The detail pane wants that extra width, but
 			 * the master pane's rows would then start 48px left of where a regular List
-			 * layout puts them — so give it back here.
+			 * layout puts them — so give it back here. Paired with resize(), so the inline
+			 * branch below drops it: inline never breaks out, so there is nothing to pay back.
 			 */
 			.splitMaster { position: relative; flex-shrink: 0; height: 100%; overflow-x: hidden; overflow-y: auto; padding-left: 48px; }
 			.splitMaster {
@@ -75,11 +76,16 @@
 						}
 
 						.blockLast { margin-left: 0px; height: 60px; }
-
-						/* The discussion section sits outside .blocks, so it needs the same
-						 * gutter applied to it directly or it renders flush to both edges. */
-						.commentSection { padding-left: 16px; padding-right: 16px; }
 					}
+				}
+
+				/* Stands in for a dataview that is not mounted inside the panel. */
+				.dataviewNested {
+					display: flex; align-items: center; justify-content: center; padding: 24px 0px;
+					border-top: 1px solid var(--color-shape-secondary); border-bottom: 1px solid var(--color-shape-secondary);
+				}
+				.dataviewNested {
+					.label { @include text-common; color: var(--color-text-secondary); text-align: center; }
 				}
 
 				.splitDetailEmpty { display: flex; align-items: center; justify-content: center; height: 100%; }
@@ -92,5 +98,11 @@
 
 	.block.blockDataview.isInline {
 		.viewContent.viewSplit { height: 500px; }
+		.viewContent.viewSplit {
+			/* resize() bails out when inline, so the container never breaks out of the block
+			 * and there is no negative margin to compensate for. Keeping the 48px would push
+			 * the rows right of where an inline List puts them. */
+			.splitMaster { padding-left: 0px; }
+		}
 	}
 }

--- a/src/scss/block/dataview/view/split.scss
+++ b/src/scss/block/dataview/view/split.scss
@@ -57,10 +57,39 @@
 			.splitDetail {
 				/* Floats over the top-right of the pane, level with the editor's title and
 				 * aligned to the same 16px gutter as the content below it. */
-				.icon.splitDetailExpand { position: absolute; right: 16px; top: 12px; z-index: 2; width: 24px; height: 24px; }
+				.splitDetailControls { position: absolute; right: 16px; top: 12px; z-index: 2; display: flex; align-items: center; gap: 0px 4px; }
+				.splitDetailControls {
+					.icon { width: 24px; height: 24px; }
+				}
 
-				.splitDetailBody { position: relative; flex-grow: 1; overflow-x: hidden; overflow-y: auto; min-height: 0px; }
+				/* z-index makes this a stacking context, containing the embedded editor's own
+				 * positioned descendants — text blocks give #value position: relative; z-index: 2
+				 * (block/text.scss), so the title's editable would otherwise stack directly
+				 * against .splitDetailControls here and, being a later sibling at equal z-index,
+				 * paint over the controls and take their clicks. */
+				.splitDetailBody { position: relative; z-index: 1; flex-grow: 1; overflow-x: hidden; overflow-y: auto; min-height: 0px; }
 				.splitDetailBody {
+					/*
+					 * The right sidebar's properties page, rendered as a section between the
+					 * object's title and its content (the editor's afterHead slot). It keeps its
+					 * own .sidebarPage classes because that is where all of its styling is scoped —
+					 * what has to be undone here is the panel geometry: .sidebarPage is a
+					 * full-height flex column whose body owns the scroll, while here it is one
+					 * block inside a pane that scrolls as a whole.
+					 */
+					.splitDetailProperties { border-bottom: 1px solid var(--color-shape-secondary); }
+					.splitDetailProperties {
+						.sidebarPage { height: auto; flex-grow: 0; overflow: visible; }
+						.sidebarPage {
+							/* The panel header carries a "Properties" title and an Edit Type button.
+							 * The control that opened this section already names it, and Edit Type
+							 * drives the right sidebar — which belongs to the host page, not the pane. */
+							> .head { display: none; }
+
+							> .body { padding: 0px 0px 12px 0px; overflow: visible; flex-grow: 0; }
+						}
+					}
+
 					/*
 					 * EditorPage.getWidth measures the page container, not this pane, and caps the
 					 * result at J.Size.editor (704px), writing it as an inline width. In a pane wider

--- a/src/scss/block/dataview/view/split.scss
+++ b/src/scss/block/dataview/view/split.scss
@@ -20,6 +20,18 @@
 				 * the same distance below the controls bar as it does in a plain List view. */
 				.viewContent.viewList { padding: 8px 0px 0px 0px; }
 				.viewContent.viewList.isRegular { padding: 9px 0px 0px 0px; }
+
+				/* The inline row markup skips the DropTarget / SelectionTarget wrappers, and
+				 * those are what carry the regular List layout's flex centering — so the row
+				 * content sat at the top of the box behind the inline top padding, which also
+				 * made the hover highlight read as offset from the title. Centering the row
+				 * itself is the treatment the inline branch already uses at Regular size. */
+				.viewContent.viewList {
+					.row { display: flex; align-items: center; padding-top: 0px; }
+					.row.add {
+						.btn { padding-top: 0px; }
+					}
+				}
 			}
 
 			.resize-h { width: 12px; height: 100%; cursor: col-resize; z-index: 2; flex-shrink: 0; position: relative; }

--- a/src/scss/component/sidebar/common.scss
+++ b/src/scss/component/sidebar/common.scss
@@ -9,9 +9,15 @@
 	display: flex; flex-direction: column;
 }
 
-.sidebar {
+/* Sidebar pages are not exclusive to the sidebar: the Split dataview panel renders the
+ * object-properties page inline, so its styles have to be reachable from there too. Kept as a
+ * shared parent rather than a second copy of the import — the output is one extra selector,
+ * not a duplicate of the rules. */
+.sidebar, .splitDetailProperties {
 	@import "./page/common";
+}
 
+.sidebar {
 	.pageWrapper, .subPageWrapper { flex-shrink: 0; position: relative; flex-direction: column; }
 	.pageWrapper, .subPageWrapper {
 		&.sidebarAnimation {

--- a/src/ts/component/block/dataview.tsx
+++ b/src/ts/component/block/dataview.tsx
@@ -18,6 +18,7 @@ import ViewList from './dataview/view/list';
 import ViewCalendar from './dataview/view/calendar';
 import ViewGraph from './dataview/view/graph';
 import ViewTimeline from './dataview/view/timeline';
+import ViewSplit from './dataview/view/split';
 import * as I from 'Interface';
 import Storage from 'Lib/storage';
 import { focus } from 'Lib/focus';
@@ -1342,7 +1343,8 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 		let inner: any = null;
 
 		switch (type) {
-			case I.ViewType.List: {
+			case I.ViewType.List:
+			case I.ViewType.Split: {
 				inner = <AddRow onClick={onAdd} />;
 				break;
 			};
@@ -1725,6 +1727,10 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 		case I.ViewType.Timeline:
 			ViewComponent = ViewTimeline;
+			break;
+
+		case I.ViewType.Split:
+			ViewComponent = ViewSplit;
 			break;
 	};
 

--- a/src/ts/component/block/dataview/view/list/row.tsx
+++ b/src/ts/component/block/dataview/view/list/row.tsx
@@ -11,7 +11,7 @@ const ListRow = forwardRef<I.RowRef, Props>((props, ref) => {
 
 	const {
 		rootId, block, recordId, style, getRecord, getView, onRefCell, onContext, getIdPrefix, isInline, isCollection,
-		onDragRecordStart, onSelectToggle, onEditModeClick, canCellEdit, onCellClick,
+		onDragRecordStart, onSelectToggle, onEditModeClick, canCellEdit, onCellClick, onRecordClick,
 	} = props;
 	const [ isEditing, setIsEditing ] = useState(false);
 	const nodeRef = useRef(null);
@@ -97,6 +97,12 @@ const ListRow = forwardRef<I.RowRef, Props>((props, ref) => {
 			return;
 		};
 
+		// Split view selects the record in place instead of navigating; a modified click
+		// still falls through to the default open-in-tab/window behaviour.
+		if ((e.button == 0) && !keyboard.withCommand(e) && onRecordClick?.(e, record.id)) {
+			return;
+		};
+
 		if (cb[e.button]) {
 			cb[e.button]();
 		};
@@ -111,6 +117,12 @@ const ListRow = forwardRef<I.RowRef, Props>((props, ref) => {
 
 		e.preventDefault();
 		e.stopPropagation();
+
+		// The row handler is bypassed by stopPropagation, so the host view has to be given
+		// the same chance to claim the click here.
+		if ((e.button == 0) && !keyboard.withCommand(e) && onRecordClick?.(e, record.id)) {
+			return;
+		};
 
 		onCellClick(e, relation.relationKey, record.id);
 	};

--- a/src/ts/component/block/dataview/view/split.stories.tsx
+++ b/src/ts/component/block/dataview/view/split.stories.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import ViewSplit from './split';
+import * as I from 'Interface';
+import * as M from 'Model';
+
+const noop = () => {};
+
+const meta: Meta<typeof ViewSplit> = {
+	title: 'Block/Dataview/View/Split',
+	component: ViewSplit,
+	tags: ['autodocs'],
+};
+
+export { meta as default };
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		rootId: 'root',
+		block: new M.Block({ id: 'split-block', type: I.BlockType.Dataview, childrenIds: [], content: {} }),
+		readonly: false,
+		isInline: false,
+		isCollection: true,
+		getView: () => new M.View({ id: 'view-1', type: I.ViewType.Split } as I.View),
+		getTarget: () => ({}),
+		getVisibleRelations: () => [],
+		getSources: () => [],
+		loadData: noop,
+		onRecordAdd: noop,
+		onContext: noop,
+	},
+};
+
+export const EmptyDetail: Story = {
+	args: {
+		...Default.args,
+		getRecords: () => [],
+	},
+};

--- a/src/ts/component/block/dataview/view/split.tsx
+++ b/src/ts/component/block/dataview/view/split.tsx
@@ -39,14 +39,17 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 	// className from the dataview root is already viewSplit — don't repeat it in the list.
 	const cn = [ 'viewContent', 'viewSplit' ].concat((className && (className != 'viewSplit')) ? [ className ] : []);
 
-	// A collection can contain itself. Opening the host in its own detail panel would mount an
-	// editor for the page already rendering it, so it is excluded from selection entirely.
-	const selectable = records.filter(it => it != rootId);
+	// A collection can contain itself — a page whose inline collection lists every page, or a
+	// collection added to its own records. The host is selectable: the detail panel renders it
+	// from the store data the host page already has open, and the dataview nested inside the
+	// panel is masked out (the isInsideSplit gate in Block). What neither side may do is open or
+	// close that object a second time — see open() below and EditorPage's own lifecycle guard.
+	const isHostRecord = (id: string): boolean => id == rootId;
 
 	// A record can vanish from the view while selected — filtered out, deleted, or the
 	// stored id predating a change of filters. Fall back to the first record instead of
 	// asking the middleware to open something that is no longer listed.
-	const activeId = selectable.includes(selectedId) ? selectedId : String(selectable[0] || '');
+	const activeId = records.includes(selectedId) ? selectedId : String(records[0] || '');
 	const object = activeId ? S.Detail.get(activeId, activeId, [ 'layout' ], true) : null;
 
 	const checkWidth = (v: number): number => {
@@ -56,8 +59,10 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 
 	const close = () => {
 		if (openedRef.current) {
-			// Guarded: the host collection may hold the same object open.
-			if (openedRef.current != rootId) {
+			// open() never records the host, so this only ever closes objects the panel itself
+			// opened. Kept as a belt-and-braces guard against closing the host out from under
+			// the page rendering it.
+			if (!isHostRecord(openedRef.current)) {
 				Action.pageClose(isPopup, openedRef.current, false);
 			};
 			openedRef.current = '';
@@ -70,6 +75,14 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 		};
 
 		close();
+
+		// The host page already has this object open; opening it again would hand its
+		// subscription a second owner, and the matching close would tear it down under the
+		// page still rendering it. Its blocks are already in the store, so the panel just renders.
+		if (isHostRecord(id)) {
+			return;
+		};
+
 		setIsLoading(true);
 
 		C.ObjectOpen(id, '', S.Common.space, (message: any) => {
@@ -121,17 +134,17 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 
 	const onKeyDown = (e: any) => {
 		// Never steal keys from the editor in the detail panel.
-		if (keyboard.isFocused || !selectable.length) {
+		if (keyboard.isFocused || !records.length) {
 			return;
 		};
 
-		const idx = selectable.indexOf(activeId);
+		const idx = records.indexOf(activeId);
 
 		keyboard.shortcut('arrowup, arrowdown', e, (pressed: string) => {
 			e.preventDefault();
 
 			const dir = pressed == 'arrowup' ? -1 : 1;
-			const next = selectable[Math.min(selectable.length - 1, Math.max(0, idx + dir))];
+			const next = records[Math.min(records.length - 1, Math.max(0, idx + dir))];
 
 			onSelect(next);
 		});
@@ -306,6 +319,7 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 							rootId={activeId}
 							isPopup={isPopup}
 							isInsideSplit={true}
+							isSecondaryView={isHostRecord(activeId)}
 						/>
 					)}
 				</div>

--- a/src/ts/component/block/dataview/view/split.tsx
+++ b/src/ts/component/block/dataview/view/split.tsx
@@ -83,7 +83,14 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 			// open() never records the host, so this only ever closes objects the panel itself
 			// opened. Kept as a belt-and-braces guard against closing the host out from under
 			// the page rendering it.
-			if (!isHostRecord(openedRef.current)) {
+			//
+			// The route check is what makes the expand control work from an inline collection:
+			// navigating unmounts the host page's whole block tree, so this runs *after* the
+			// route already points at the record the panel had open. PageMainEdit takes its
+			// rootId from the route and keys its EditorPage with a constant, so that editor is
+			// already rendering this object from the store — and pageClose would clear the
+			// blocks and destroy the subscription out from under it, leaving a blank page.
+			if (!isHostRecord(openedRef.current) && (keyboard.getRootId(isPopup) != openedRef.current)) {
 				Action.pageClose(isPopup, openedRef.current, false);
 			};
 			openedRef.current = '';

--- a/src/ts/component/block/dataview/view/split.tsx
+++ b/src/ts/component/block/dataview/view/split.tsx
@@ -1,0 +1,327 @@
+import React, { forwardRef, useRef, useState, useEffect, useImperativeHandle } from 'react';
+import raf from 'raf';
+import { EditorPage, Icon, IconObject, Loader } from 'Component';
+import ViewList from './list';
+import * as I from 'Interface';
+import Storage from 'Lib/storage';
+
+const PADDING = 46;
+const MIN_HEIGHT = 480;
+
+/**
+ * Split renders a master-detail layout: the record list on the left, the selected
+ * object's page on the right.
+ *
+ * The container sizes itself to the viewport (the technique ViewGraph uses) so each
+ * panel owns its own scroll. This matters because U.Dom.getScrollContainer resolves to a
+ * single global element per namespace — letting the detail panel scroll the page itself
+ * would fight the host collection for the same container.
+ *
+ * Panel width and the selected record are UI state only, persisted locally via
+ * Lib/storage; the middleware view schema has no fields for them.
+ */
+const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
+
+	const { rootId, block, className, isPopup, isInline, getView, getRecords, loadData } = props;
+	const nodeRef = useRef(null);
+	const masterRef = useRef(null);
+	const frame = useRef(0);
+	const startX = useRef(0);
+	const startWidth = useRef(0);
+	const openedRef = useRef('');
+	const openTimeout = useRef(0);
+	const view = getView();
+	const records = getRecords();
+	const storageKey = Storage.getSplitViewKey(rootId, block.id, view.id);
+	const [ selectedId, setSelectedId ] = useState(() => String(Storage.getSplitView(storageKey).selectedId || ''));
+	const [ width, setWidth ] = useState(() => Number(Storage.getSplitView(storageKey).width) || J.Size.dataview.split.master.default);
+	const [ isLoading, setIsLoading ] = useState(false);
+	// className from the dataview root is already viewSplit — don't repeat it in the list.
+	const cn = [ 'viewContent', 'viewSplit' ].concat((className && (className != 'viewSplit')) ? [ className ] : []);
+
+	// A record can vanish from the view while selected — filtered out, deleted, or the
+	// stored id predating a change of filters. Fall back to the first record instead of
+	// asking the middleware to open something that is no longer listed.
+	const activeId = records.includes(selectedId) ? selectedId : String(records[0] || '');
+	const object = activeId ? S.Detail.get(activeId, activeId, [ 'layout' ], true) : null;
+
+	const checkWidth = (v: number): number => {
+		const { min, max } = J.Size.dataview.split.master;
+		return Math.min(max, Math.max(min, Math.floor(v)));
+	};
+
+	const close = () => {
+		if (openedRef.current) {
+			// Guarded: the host collection may hold the same object open.
+			if (openedRef.current != rootId) {
+				Action.pageClose(isPopup, openedRef.current, false);
+			};
+			openedRef.current = '';
+		};
+	};
+
+	const open = (id: string) => {
+		if (!id || (openedRef.current == id)) {
+			return;
+		};
+
+		close();
+		setIsLoading(true);
+
+		C.ObjectOpen(id, '', S.Common.space, (message: any) => {
+			setIsLoading(false);
+
+			if (!U.Common.checkErrorOnOpen(id, message.error.code)) {
+				return;
+			};
+
+			openedRef.current = id;
+		});
+	};
+
+	// Arrow-key navigation can move selection faster than objects open, so debounce the
+	// open and drop any pending one on unmount.
+	const openDebounced = (id: string) => {
+		window.clearTimeout(openTimeout.current);
+		openTimeout.current = window.setTimeout(() => open(id), 100);
+	};
+
+	const onSelect = (id: string) => {
+		if (!id || (id == selectedId)) {
+			return;
+		};
+
+		setSelectedId(id);
+		Storage.setSplitView(storageKey, { selectedId: id });
+	};
+
+	const onExpand = (e: any) => {
+		if (!object) {
+			return;
+		};
+
+		if (keyboard.withCommand(e)) {
+			U.Object.openEvent(e, object);
+		} else {
+			U.Object.openRoute(object);
+		};
+	};
+
+	const onKeyDown = (e: any) => {
+		// Never steal keys from the editor in the detail panel.
+		if (keyboard.isFocused || !records.length) {
+			return;
+		};
+
+		const idx = records.indexOf(activeId);
+
+		keyboard.shortcut('arrowup, arrowdown', e, (pressed: string) => {
+			e.preventDefault();
+
+			const dir = pressed == 'arrowup' ? -1 : 1;
+			const next = records[Math.min(records.length - 1, Math.max(0, idx + dir))];
+
+			onSelect(next);
+		});
+
+		keyboard.shortcut('enter', e, () => {
+			e.preventDefault();
+			onExpand(e);
+		});
+	};
+
+	const mouseMoveHandler = useRef<(e: any) => void>(null);
+	const mouseUpHandler = useRef<(e: any) => void>(null);
+
+	const onResizeStart = (e: React.MouseEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+
+		const master = masterRef.current;
+		if (!master) {
+			return;
+		};
+
+		startX.current = e.pageX;
+		startWidth.current = master.offsetWidth;
+
+		keyboard.disableSelection(true);
+		keyboard.setResize(true);
+		U.Dom.addClass(document.body, 'colResize');
+
+		if (mouseMoveHandler.current) {
+			U.Dom.removeEvent(window, 'mousemove', mouseMoveHandler.current);
+		};
+		if (mouseUpHandler.current) {
+			U.Dom.removeEvent(window, 'mouseup', mouseUpHandler.current);
+		};
+
+		mouseMoveHandler.current = (e: any) => onResizeMove(e);
+		mouseUpHandler.current = (e: any) => onResizeEnd(e);
+
+		U.Dom.addEvents(window, [
+			['mousemove', mouseMoveHandler.current],
+			['mouseup', mouseUpHandler.current],
+		]);
+	};
+
+	const onResizeMove = (e: any) => {
+		if (frame.current) {
+			raf.cancel(frame.current);
+		};
+
+		frame.current = raf(() => {
+			const master = masterRef.current;
+			if (!master) {
+				return;
+			};
+
+			// Applied straight to the node during the drag; committing to state on every
+			// mousemove would re-render the embedded editor on each frame.
+			U.Dom.css(master, { width: `${checkWidth(startWidth.current + e.pageX - startX.current)}px` });
+		});
+	};
+
+	const onResizeEnd = (e: any) => {
+		raf.cancel(frame.current);
+
+		const w = checkWidth(startWidth.current + e.pageX - startX.current);
+
+		setWidth(w);
+		Storage.setSplitView(storageKey, { width: w });
+
+		keyboard.disableSelection(false);
+		keyboard.setResize(false);
+		U.Dom.removeClass(document.body, 'colResize');
+
+		if (mouseMoveHandler.current) {
+			U.Dom.removeEvent(window, 'mousemove', mouseMoveHandler.current);
+			mouseMoveHandler.current = null;
+		};
+		if (mouseUpHandler.current) {
+			U.Dom.removeEvent(window, 'mouseup', mouseUpHandler.current);
+			mouseUpHandler.current = null;
+		};
+	};
+
+	// Sizes the container to the viewport so each panel scrolls internally.
+	const resize = () => {
+		const node = nodeRef.current;
+		if (!node || isInline) {
+			return;
+		};
+
+		U.Dom.css(node, { width: '0px', height: '0px', marginLeft: '0px' });
+
+		const container = U.Dom.getPageContainer(isPopup);
+		const cw = container?.clientWidth ?? 0;
+		const ch = container?.clientHeight ?? 0;
+		const mw = cw - PADDING * 2;
+		const margin = (cw - mw) / 2;
+		const { top } = node.getBoundingClientRect();
+
+		U.Dom.css(node, {
+			width: `${cw}px`,
+			height: `${Math.max(MIN_HEIGHT, ch - top - 2)}px`,
+			marginLeft: `${-margin - 2}px`,
+		});
+	};
+
+	useEffect(() => {
+		U.Dom.addEvent(window, 'keydown', onKeyDown);
+
+		return () => {
+			U.Dom.removeEvent(window, 'keydown', onKeyDown);
+		};
+	});
+
+	useEffect(() => resize());
+
+	useEffect(() => {
+		if (activeId) {
+			openDebounced(activeId);
+		};
+	}, [ activeId ]);
+
+	useEffect(() => {
+		return () => {
+			window.clearTimeout(openTimeout.current);
+			raf.cancel(frame.current);
+			close();
+		};
+	}, []);
+
+	useImperativeHandle(ref, () => ({
+		resize,
+	}));
+
+	let detail = null;
+	if (!activeId) {
+		detail = (
+			<div className="splitDetailEmpty">
+				<div className="label">{translate('blockDataviewSplitEmptyDetail')}</div>
+			</div>
+		);
+	} else {
+		detail = (
+			<>
+				<div className="splitDetailHead">
+					<div className="side left">
+						<IconObject object={object} size={20} />
+						<div className="name">{U.Object.name(object)}</div>
+					</div>
+
+					<div className="side right">
+						<Icon
+							name="common/expand"
+							withBackground={true}
+							onClick={onExpand}
+							tooltipParam={{ text: translate('commonOpenObject'), typeY: I.MenuDirection.Bottom }}
+						/>
+					</div>
+				</div>
+
+				<div className="splitDetailBody">
+					{isLoading ? <Loader /> : (
+						/*
+						 * Only the PageComponent contract is passed — spreading the dataview props would
+						 * leak view-level props into the editor. Deliberately no S.Common.refSet('editor' + ns)
+						 * either: that ref is keyed only by isPopup and belongs to the host page's editor.
+						 */
+						<EditorPage
+							key={`splitDetail-${activeId}`}
+							rootId={activeId}
+							isPopup={isPopup}
+						/>
+					)}
+				</div>
+			</>
+		);
+	};
+
+	return (
+		<div ref={nodeRef} className="wrap">
+			<div className={cn.join(' ')}>
+				<div ref={masterRef} className="splitMaster" style={{ width }}>
+					<ViewList
+						{...props}
+						isInline={true}
+						className="viewList splitMasterList"
+						onCellClick={(e: any, key: string, id: string) => onSelect(id)}
+					/>
+				</div>
+
+				<div className="resize-h" onMouseDown={onResizeStart}>
+					<div className="resize-handle" />
+				</div>
+
+				<div className="splitDetail">
+					{detail}
+				</div>
+			</div>
+		</div>
+	);
+
+});
+
+export default ViewSplit;

--- a/src/ts/component/block/dataview/view/split.tsx
+++ b/src/ts/component/block/dataview/view/split.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useRef, useState, useEffect, useImperativeHandle } from 'react';
 import raf from 'raf';
-import { EditorPage, Icon, IconObject, Loader } from 'Component';
+import { EditorPage, Icon, Loader } from 'Component';
 import ViewList from './list';
 import * as I from 'Interface';
 import Storage from 'Lib/storage';
@@ -93,6 +93,14 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 
 		setSelectedId(id);
 		Storage.setSplitView(storageKey, { selectedId: id });
+	};
+
+	// Claims a row click for the detail panel. Returning true tells ListRow to skip its
+	// default U.Object.openConfig navigation — this is what makes clicking anywhere on the
+	// row, including the empty space right of the title, select rather than navigate.
+	const onRecordClick = (e: any, id: string): boolean => {
+		onSelect(id);
+		return true;
 	};
 
 	const onExpand = (e: any) => {
@@ -265,21 +273,19 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 	} else {
 		detail = (
 			<>
-				<div className="splitDetailHead">
-					<div className="side left">
-						<IconObject object={object} size={20} />
-						<div className="name">{U.Object.name(object)}</div>
-					</div>
-
-					<div className="side right">
-						<Icon
-							name="common/expand"
-							withBackground={true}
-							onClick={onExpand}
-							tooltipParam={{ text: translate('commonOpenObject'), typeY: I.MenuDirection.Bottom }}
-						/>
-					</div>
-				</div>
+				{/*
+				 * No name header: the embedded editor already renders the object's title, and a
+				 * second copy of it read as a stray "Untitled" row. The expand control instead
+				 * floats over the top-right of the pane, level with that title, and stays put
+				 * while the pane scrolls.
+				 */}
+				<Icon
+					className="splitDetailExpand"
+					name="common/expand"
+					withBackground={true}
+					onClick={onExpand}
+					tooltipParam={{ text: translate('commonOpenObject'), typeY: I.MenuDirection.Bottom }}
+				/>
 
 				<div className="splitDetailBody">
 					{isLoading ? <Loader /> : (
@@ -307,7 +313,7 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 						{...props}
 						isInline={true}
 						className="viewList splitMasterList"
-						onCellClick={(e: any, key: string, id: string) => onSelect(id)}
+						onRecordClick={onRecordClick}
 					/>
 				</div>
 

--- a/src/ts/component/block/dataview/view/split.tsx
+++ b/src/ts/component/block/dataview/view/split.tsx
@@ -434,8 +434,28 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 		);
 	};
 
+	/*
+	 * Keeps clicks inside this view from handing the app's focus state to the host block.
+	 *
+	 * An inline dataview's root carries tabIndex={0} and .focusable, and its onFocus runs
+	 * focus.set(block.id) — inline only, which is why this is an inline-only problem. Clicking
+	 * something that is not itself focusable (the detail controls, a master row) focuses the
+	 * nearest focusable ancestor, i.e. that root. The next focus.apply() then resolves .focusable
+	 * to it and, since it is not a text value, paints isKeyboardFocused on its selectionTarget —
+	 * the same full-size overlay as block selection, over the whole inline collection, and there
+	 * it stays until focus moves. Toggling the properties section re-renders the embedded editor,
+	 * whose mount/update effect calls focus.apply(), so the click that sets it also shows it.
+	 *
+	 * tabIndex makes this wrapper the nearer focusable ancestor, so the fallback stops here, and
+	 * stopping the focus event keeps it out of the host's handler. Elements that are focusable in
+	 * their own right — the detail editor's text blocks, property inputs — are unaffected.
+	 */
+	const onFocus = (e: React.FocusEvent) => {
+		e.stopPropagation();
+	};
+
 	return (
-		<div ref={nodeRef} className="wrap">
+		<div ref={nodeRef} className="wrap" tabIndex={-1} onFocus={onFocus}>
 			<div className={cn.join(' ')}>
 				<div ref={masterRef} className="splitMaster" style={{ width }}>
 					<ViewList

--- a/src/ts/component/block/dataview/view/split.tsx
+++ b/src/ts/component/block/dataview/view/split.tsx
@@ -39,10 +39,14 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 	// className from the dataview root is already viewSplit — don't repeat it in the list.
 	const cn = [ 'viewContent', 'viewSplit' ].concat((className && (className != 'viewSplit')) ? [ className ] : []);
 
+	// A collection can contain itself. Opening the host in its own detail panel would mount an
+	// editor for the page already rendering it, so it is excluded from selection entirely.
+	const selectable = records.filter(it => it != rootId);
+
 	// A record can vanish from the view while selected — filtered out, deleted, or the
 	// stored id predating a change of filters. Fall back to the first record instead of
 	// asking the middleware to open something that is no longer listed.
-	const activeId = records.includes(selectedId) ? selectedId : String(records[0] || '');
+	const activeId = selectable.includes(selectedId) ? selectedId : String(selectable[0] || '');
 	const object = activeId ? S.Detail.get(activeId, activeId, [ 'layout' ], true) : null;
 
 	const checkWidth = (v: number): number => {
@@ -117,17 +121,17 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 
 	const onKeyDown = (e: any) => {
 		// Never steal keys from the editor in the detail panel.
-		if (keyboard.isFocused || !records.length) {
+		if (keyboard.isFocused || !selectable.length) {
 			return;
 		};
 
-		const idx = records.indexOf(activeId);
+		const idx = selectable.indexOf(activeId);
 
 		keyboard.shortcut('arrowup, arrowdown', e, (pressed: string) => {
 			e.preventDefault();
 
 			const dir = pressed == 'arrowup' ? -1 : 1;
-			const next = records[Math.min(records.length - 1, Math.max(0, idx + dir))];
+			const next = selectable[Math.min(selectable.length - 1, Math.max(0, idx + dir))];
 
 			onSelect(next);
 		});
@@ -243,7 +247,10 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 		};
 	});
 
-	useEffect(() => resize());
+	// Deliberately not on every render: resize() writes layout, and every mounted EditorPage
+	// answers the global window resize that a re-render can trigger. Width is the only prop it
+	// reads that changes after mount; drag-time sizing is applied straight to the node instead.
+	useEffect(() => resize(), [ width ]);
 
 	useEffect(() => {
 		if (activeId) {
@@ -298,6 +305,7 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 							key={`splitDetail-${activeId}`}
 							rootId={activeId}
 							isPopup={isPopup}
+							isInsideSplit={true}
 						/>
 					)}
 				</div>

--- a/src/ts/component/block/dataview/view/split.tsx
+++ b/src/ts/component/block/dataview/view/split.tsx
@@ -22,7 +22,7 @@ const MIN_HEIGHT = 480;
  */
 const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 
-	const { rootId, block, className, isPopup, isInline, getView, getRecords, loadData } = props;
+	const { rootId, block, className, isPopup, isInline, getView, getRecord, getRecords, loadData } = props;
 	const nodeRef = useRef(null);
 	const masterRef = useRef(null);
 	const frame = useRef(0);
@@ -50,7 +50,22 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 	// stored id predating a change of filters. Fall back to the first record instead of
 	// asking the middleware to open something that is no longer listed.
 	const activeId = records.includes(selectedId) ? selectedId : String(records[0] || '');
-	const object = activeId ? S.Detail.get(activeId, activeId, [ 'layout' ], true) : null;
+
+	// Read the record from the dataview's own subscription rather than from the object's, which
+	// only holds details once the panel has opened it. The row is already rendered from this
+	// data, so layout is available before (and without) any open — which is what the chat
+	// branch below depends on.
+	const object = activeId ? getRecord(activeId) : null;
+	const hasObject = !!object && !object._empty_;
+
+	// Chat objects cannot render in the panel. They route to page/main/chat.tsx, never to
+	// EditorPage, and their content is a synthetic BlockType.Chat block that page constructs
+	// client-side — it exists in no store, so an embedded editor has nothing to draw. Beyond
+	// that, BlockChat drives U.Dom.getScrollContainer, which resolves to the single global
+	// page scroller and would fight the host collection for it. Show a placeholder and, more
+	// importantly, never call ObjectOpen: for a chat the change-tree IS the message history,
+	// which is why page/main/chat.tsx dropped that call in 8446cde734 (seconds of blocking).
+	const isChatRecord = (id: string): boolean => U.Object.isChatLayout(getRecord(id).layout);
 
 	const checkWidth = (v: number): number => {
 		const { min, max } = J.Size.dataview.split.master;
@@ -80,6 +95,12 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 		// subscription a second owner, and the matching close would tear it down under the
 		// page still rendering it. Its blocks are already in the store, so the panel just renders.
 		if (isHostRecord(id)) {
+			return;
+		};
+
+		// The panel renders a placeholder for chats, so there is nothing to open — and opening
+		// one would build its entire message CRDT tree just to throw the result away.
+		if (isChatRecord(id)) {
 			return;
 		};
 
@@ -121,7 +142,7 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 	};
 
 	const onExpand = (e: any) => {
-		if (!object) {
+		if (!hasObject) {
 			return;
 		};
 
@@ -291,6 +312,35 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 			</div>
 		);
 	} else {
+		let body = null;
+		if (isChatRecord(activeId)) {
+			// The expand control above stays available, so the chat is one click from opening
+			// as a full page — which is the only place its messages can render.
+			body = (
+				<div className="splitDetailUnsupported">
+					<div className="label">{translate('blockDataviewSplitChatDetail')}</div>
+				</div>
+			);
+		} else
+		if (isLoading) {
+			body = <Loader />;
+		} else {
+			body = (
+				/*
+				 * Only the PageComponent contract is passed — spreading the dataview props would
+				 * leak view-level props into the editor. Deliberately no S.Common.refSet('editor' + ns)
+				 * either: that ref is keyed only by isPopup and belongs to the host page's editor.
+				 */
+				<EditorPage
+					key={`splitDetail-${activeId}`}
+					rootId={activeId}
+					isPopup={isPopup}
+					isInsideSplit={true}
+					isSecondaryView={isHostRecord(activeId)}
+				/>
+			);
+		};
+
 		detail = (
 			<>
 				{/*
@@ -308,20 +358,7 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 				/>
 
 				<div className="splitDetailBody">
-					{isLoading ? <Loader /> : (
-						/*
-						 * Only the PageComponent contract is passed — spreading the dataview props would
-						 * leak view-level props into the editor. Deliberately no S.Common.refSet('editor' + ns)
-						 * either: that ref is keyed only by isPopup and belongs to the host page's editor.
-						 */
-						<EditorPage
-							key={`splitDetail-${activeId}`}
-							rootId={activeId}
-							isPopup={isPopup}
-							isInsideSplit={true}
-							isSecondaryView={isHostRecord(activeId)}
-						/>
-					)}
+					{body}
 				</div>
 			</>
 		);

--- a/src/ts/component/block/dataview/view/split.tsx
+++ b/src/ts/component/block/dataview/view/split.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, useRef, useState, useEffect, useImperativeHandle } from 'react';
 import raf from 'raf';
 import { EditorPage, Icon, Loader } from 'Component';
+import SidebarPageObjectRelation from 'Component/sidebar/page/object/relation';
 import ViewList from './list';
 import * as I from 'Interface';
 import Storage from 'Lib/storage';
@@ -36,8 +37,13 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 	const [ selectedId, setSelectedId ] = useState(() => String(Storage.getSplitView(storageKey).selectedId || ''));
 	const [ width, setWidth ] = useState(() => Number(Storage.getSplitView(storageKey).width) || J.Size.dataview.split.master.default);
 	const [ isLoading, setIsLoading ] = useState(false);
+	const [ isPropertiesOpen, setIsPropertiesOpen ] = useState(() => !!Storage.getSplitView(storageKey).isPropertiesOpen);
 	// className from the dataview root is already viewSplit — don't repeat it in the list.
 	const cn = [ 'viewContent', 'viewSplit' ].concat((className && (className != 'viewSplit')) ? [ className ] : []);
+	// Id of the properties wrapper, handed to the panel as getId so its DOM lookups stay
+	// inside this pane. Scoped by block and namespace, since the same block can be mounted
+	// in the page and in a popup at once.
+	const propertiesId = U.String.toCamelCase(`splitProperties-${block.id}${isPopup ? '-popup' : ''}`);
 
 	// A collection can contain itself — a page whose inline collection lists every page, or a
 	// collection added to its own records. The host is selectable: the detail panel renders it
@@ -151,6 +157,15 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 		} else {
 			U.Object.openRoute(object);
 		};
+	};
+
+	const onPropertiesToggle = (e: any) => {
+		e.stopPropagation();
+
+		const v = !isPropertiesOpen;
+
+		setIsPropertiesOpen(v);
+		Storage.setSplitView(storageKey, { isPropertiesOpen: v });
 	};
 
 	const onKeyDown = (e: any) => {
@@ -312,6 +327,41 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 			</div>
 		);
 	} else {
+		// Chats render a placeholder, so there is no object in the store to read properties from.
+		// The toggle survives loading — hiding it would make it flicker on every selection —
+		// but the section itself waits, since it reads the object's own subscription.
+		const withProperties = !isChatRecord(activeId);
+		const isOpen = withProperties && isPropertiesOpen && !isLoading;
+		const cni = [ 'splitDetailPropertiesToggle' ].concat(isPropertiesOpen ? [ 'active' ] : []);
+
+		let properties = null;
+		if (isOpen) {
+			properties = (
+				/*
+				 * The right sidebar's own properties page, rendered in place. Only its content is
+				 * reusable: the sidebar chrome around it is driven by S.Common.getRightSidebarState,
+				 * a singleton keyed only by isPopup, so opening the real panel here would retarget
+				 * the host page's sidebar at the panel's object. This component takes rootId as a
+				 * prop, so it needs none of that. What it does need is the .sidebarPage classes —
+				 * all of its styling is scoped under them, which is why the outer wrapper is a
+				 * shared parent of that stylesheet — and getId, so its section toggles resolve
+				 * against this instance instead of #sidebarRight.
+				 */
+				<div className="splitDetailProperties">
+					<div id={propertiesId} className="sidebarPage pageObjectRelation">
+						<SidebarPageObjectRelation
+							key={`splitProperties-${activeId}`}
+							rootId={activeId}
+							isPopup={isPopup}
+							page="object/relation"
+							sidebarDirection={I.SidebarDirection.Right}
+							getId={() => propertiesId}
+						/>
+					</div>
+				</div>
+			);
+		};
+
 		let body = null;
 		if (isChatRecord(activeId)) {
 			// The expand control above stays available, so the chat is one click from opening
@@ -337,6 +387,7 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 					isPopup={isPopup}
 					isInsideSplit={true}
 					isSecondaryView={isHostRecord(activeId)}
+					afterHead={properties}
 				/>
 			);
 		};
@@ -345,17 +396,29 @@ const ViewSplit = forwardRef<I.ViewRef, I.ViewComponent>((props, ref) => {
 			<>
 				{/*
 				 * No name header: the embedded editor already renders the object's title, and a
-				 * second copy of it read as a stray "Untitled" row. The expand control instead
-				 * floats over the top-right of the pane, level with that title, and stays put
-				 * while the pane scrolls.
+				 * second copy of it read as a stray "Untitled" row. The controls instead float
+				 * over the top-right of the pane, level with that title, and stay put while the
+				 * pane scrolls.
 				 */}
-				<Icon
-					className="splitDetailExpand"
-					name="common/expand"
-					withBackground={true}
-					onClick={onExpand}
-					tooltipParam={{ text: translate('commonOpenObject'), typeY: I.MenuDirection.Bottom }}
-				/>
+				<div className="splitDetailControls">
+					{withProperties ? (
+						<Icon
+							className={cni.join(' ')}
+							name="header/relation"
+							withBackground={true}
+							onClick={onPropertiesToggle}
+							tooltipParam={{ text: translate('commonRelations'), typeY: I.MenuDirection.Bottom }}
+						/>
+					) : ''}
+
+					<Icon
+						className="splitDetailExpand"
+						name="common/expand"
+						withBackground={true}
+						onClick={onExpand}
+						tooltipParam={{ text: translate('commonOpenObject'), typeY: I.MenuDirection.Bottom }}
+					/>
+				</div>
 
 				<div className="splitDetailBody">
 					{body}

--- a/src/ts/component/block/index.tsx
+++ b/src/ts/component/block/index.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useRef, useEffect, useImperativeHandle } from 'react';
 import { createRoot, Root } from 'react-dom/client';
-import { DropTarget, ListChildren, Icon, SelectionTarget, IconObject, Loader } from 'Component';
+import { DropTarget, ListChildren, Icon, SelectionTarget, IconObject, Label, Loader } from 'Component';
 
 import BlockDataview from './dataview';
 import BlockText from './text';
@@ -43,7 +43,7 @@ const SNAP = 0.01;
 const Block = forwardRef<Ref, Props>((props, ref) => {
 
 	const { 
-		rootId, css, className, block, index, readonly, isInsideTable, isSelectionDisabled, contextParam, onMouseEnter, onMouseLeave,
+		rootId, css, className, block, index, readonly, isInsideTable, isInsideSplit, isSelectionDisabled, contextParam, onMouseEnter, onMouseLeave,
 		isContextMenuDisabled, blockRemove, getWrapperWidth,
 	} = props;
 	const nodeRef = useRef(null);
@@ -1104,6 +1104,20 @@ const Block = forwardRef<Ref, Props>((props, ref) => {
 
 			if (isInline) {
 				cn.push('isInline');
+			};
+
+			// Inside a Split detail panel the dataview is not mounted at all. Mounting it would
+			// open a second record subscription and broadcast global editor resizes from within
+			// a panel that ViewSplit is concurrently sizing, which exhausted the heap. Guarding
+			// here rather than in the render keeps BlockDataview's mount effect from running.
+			// isInsideSplit is inherited by every block below the panel, so this holds at any depth.
+			if (isInsideSplit) {
+				blockComponent = (
+					<div className="dataviewNested">
+						<Label text={translate('blockDataviewNestedInSplit')} />
+					</div>
+				);
+				break;
 			};
 
 			blockComponent = <BlockDataview key={key} ref={childRef} isInline={isInline} {...props} />;

--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -18,6 +18,10 @@ interface Props extends I.PageComponent {
 	// Set when this editor is embedded in a Split view's detail panel. Inherited by every
 	// block below, so a dataview at any depth can refuse to mount another live view.
 	isInsideSplit?: boolean;
+	// Set when the embedding page is already rendering this same object — a collection that
+	// contains itself, selected in its own Split panel. The object's lifecycle (ObjectOpen /
+	// ObjectClose, focus, the virtual last block) then belongs to that page, not to this editor.
+	isSecondaryView?: boolean;
 };
 
 const THROTTLE = 40;
@@ -25,7 +29,7 @@ const BUTTON_OFFSET = 10;
 
 const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 	
-	const { rootId, isPopup, onOpen, isInsideSplit } = props;
+	const { rootId, isPopup, onOpen, isInsideSplit, isSecondaryView } = props;
 	const root = S.Block.getLeaf(rootId, rootId);
 	const nodeRef = useRef(null);
 	const tocRef = useRef(null);
@@ -245,6 +249,14 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 		setIsDeleted(false);
 		idRef.current = rootId;
 
+		// A secondary view does not own the object — the page it is embedded in is already
+		// rendering the same one, so its blocks are in the store and an ObjectOpen here would
+		// give the subscription a second owner. Focus is skipped too: the carriage is per
+		// object, and claiming it would pull it away from the primary view.
+		if (isSecondaryView) {
+			return;
+		};
+
 		C.ObjectOpen(rootId, '', S.Common.space, (message: any) => {
 			if (!U.Common.checkErrorOnOpen(rootId, message.error.code)) {
 				return;
@@ -261,6 +273,15 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 	};
 
 	const close = () => {
+		// Symmetric with open(): a secondary view opened nothing, so it must close nothing.
+		// pageClose would run S.Block.clear + ObjectClose on an object the embedding page is
+		// still rendering (U.Data.checkPageClose only guards the popup case), blanking it.
+		// virtualBlock and the stored focus are per object and belong to the primary view.
+		if (isSecondaryView) {
+			idRef.current = '';
+			return;
+		};
+
 		virtualBlock.deactivate();
 		Action.pageClose(isPopup, idRef.current, true);
 		Storage.setFocus(idRef.current, focus.state);
@@ -3356,7 +3377,12 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 						getWrapperWidth={getWrapperWidth}
 					/>
 
-					{virtualBlock.isRendered(rootId, isPopup) && !readonly ? (
+					{/*
+					 * virtualBlock is a process-wide singleton keyed by (rootId, isPopup), so a
+					 * secondary view of the same object would render a second placeholder under
+					 * the same block id and both would answer the same focus.
+					 */}
+					{virtualBlock.isRendered(rootId, isPopup) && !readonly && !isSecondaryView ? (
 						<Block
 							key="block-virtualLast"
 							{...props}

--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -22,6 +22,10 @@ interface Props extends I.PageComponent {
 	// contains itself, selected in its own Split panel. The object's lifecycle (ObjectOpen /
 	// ObjectClose, focus, the virtual last block) then belongs to that page, not to this editor.
 	isSecondaryView?: boolean;
+	// Rendered between the object's head (icon, cover, title) and its content blocks. The Split
+	// detail panel puts its properties section here, which is the only place a host can sit
+	// something below the title without owning the head's own markup.
+	afterHead?: React.ReactNode;
 };
 
 const THROTTLE = 40;
@@ -29,7 +33,7 @@ const BUTTON_OFFSET = 10;
 
 const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 	
-	const { rootId, isPopup, onOpen, isInsideSplit, isSecondaryView } = props;
+	const { rootId, isPopup, onOpen, isInsideSplit, isSecondaryView, afterHead } = props;
 	const root = S.Block.getLeaf(rootId, rootId);
 	const nodeRef = useRef(null);
 	const tocRef = useRef(null);
@@ -3364,6 +3368,8 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 						readonly={readonly}
 						getWrapperWidth={getWrapperWidth}
 					/>
+
+					{afterHead}
 
 					<Children
 						{...props}

--- a/src/ts/component/editor/page.tsx
+++ b/src/ts/component/editor/page.tsx
@@ -15,6 +15,9 @@ import { getTopLevelIds, getIndentTargetId } from 'Lib/util/blockSelection';
 
 interface Props extends I.PageComponent {
 	onOpen?(): void;
+	// Set when this editor is embedded in a Split view's detail panel. Inherited by every
+	// block below, so a dataview at any depth can refuse to mount another live view.
+	isInsideSplit?: boolean;
 };
 
 const THROTTLE = 40;
@@ -22,7 +25,7 @@ const BUTTON_OFFSET = 10;
 
 const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 	
-	const { rootId, isPopup, onOpen } = props;
+	const { rootId, isPopup, onOpen, isInsideSplit } = props;
 	const root = S.Block.getLeaf(rootId, rootId);
 	const nodeRef = useRef(null);
 	const tocRef = useRef(null);
@@ -3380,7 +3383,12 @@ const EditorPage = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 				<TableOfContents ref={tocRef} {...props} />
 
-				{!isTemplate ? (
+				{/*
+				 * Suppressed inside a Split detail panel: the host page already renders its own
+				 * discussion, so a second "start discussion" affordance appeared alongside it.
+				 * The object's discussion is still reachable via the expand control.
+				 */}
+				{(!isTemplate && !isInsideSplit) ? (
 					<CommentSection
 						rootId={rootId}
 						targetId={rootId}

--- a/src/ts/component/menu/dataview/view/layout.tsx
+++ b/src/ts/component/menu/dataview/view/layout.tsx
@@ -459,6 +459,7 @@ const MenuViewLayout = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 		[I.ViewType.Board]: 'dataview/view/kanban',
 		[I.ViewType.Calendar]: 'dataview/view/calendar',
 		[I.ViewType.Graph]: 'dataview/view/graph',
+		[I.ViewType.Split]: 'dataview/view/split',
 	};
 
 	const layouts = U.Menu.getViews().map((it: any) => {

--- a/src/ts/component/sidebar/page/object/relation.tsx
+++ b/src/ts/component/sidebar/page/object/relation.tsx
@@ -7,7 +7,7 @@ import Storage from 'Lib/storage';
 const SidebarPageObjectRelation = forwardRef<{}, I.SidebarPageComponent>((props, ref) => {
 
 	const [ dummy, setDummy ] = useState(0);
-	const { rootId, readonly, page, isPopup } = props;
+	const { rootId, readonly, page, isPopup, getId } = props;
 	const object = S.Detail.get(rootId, rootId);
 	const isReadonly = readonly || !S.Block.isAllowed(object.restrictions, [ I.RestrictionObject.Details ]);
 	const type = S.Record.getTypeById(object.type);
@@ -126,8 +126,19 @@ const SidebarPageObjectRelation = forwardRef<{}, I.SidebarPageComponent>((props,
 		});
 	};
 
+	// Scope group lookups to this instance's own container. getId() is the id the host puts on
+	// the element wrapping this page, so the same component can render outside the right sidebar
+	// (the Split detail panel does) without its toggles reaching into another copy — or, when
+	// #sidebarRight is closed, finding nothing and silently doing nothing.
+	const getGroupNode = (id: string): HTMLElement | null => {
+		const containerId = getId?.();
+		const container = containerId ? U.Dom.get(containerId) : null;
+
+		return container ? U.Dom.select(`#relationGroup-${id}`, container) : null;
+	};
+
 	const initToggle = (id: string, isOpen: boolean) => {
-		const obj = U.Dom.select(`#sidebarRight #relationGroup-${id}`);
+		const obj = getGroupNode(id);
 		if (!obj) return;
 
 		const title = U.Dom.select('.titleWrap', obj);
@@ -139,7 +150,7 @@ const SidebarPageObjectRelation = forwardRef<{}, I.SidebarPageComponent>((props,
 	};
 
 	const onToggle = (id: string) => {
-		const obj = U.Dom.select(`#sidebarRight #relationGroup-${id}`);
+		const obj = getGroupNode(id);
 		if (!obj) return;
 
 		const title = U.Dom.select('.titleWrap', obj);

--- a/src/ts/component/util/icons/dataview/view/index.ts
+++ b/src/ts/component/util/icons/dataview/view/index.ts
@@ -5,6 +5,7 @@ import Gallery from './gallery';
 import Kanban from './kanban';
 import Calendar from './calendar';
 import Graph from './graph';
+import Split from './split';
 
 registerIcon('dataview/view/grid', Grid);
 registerIcon('dataview/view/list', List);
@@ -12,3 +13,4 @@ registerIcon('dataview/view/gallery', Gallery);
 registerIcon('dataview/view/kanban', Kanban);
 registerIcon('dataview/view/calendar', Calendar);
 registerIcon('dataview/view/graph', Graph);
+registerIcon('dataview/view/split', Split);

--- a/src/ts/component/util/icons/dataview/view/split.tsx
+++ b/src/ts/component/util/icons/dataview/view/split.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const Split = (props: React.SVGProps<SVGSVGElement>) => (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 56 56" fill="none" {...props}>
+		<rect x="11" y="13" width="34" height="30" rx="3" fill="url(#paint0_linear_split)" />
+		<rect x="11.5" y="13.5" width="33" height="29" rx="2.5" stroke="currentColor" />
+		<rect x="24" y="13" width="1" height="30" fill="currentColor" />
+		<rect x="14" y="19" width="7" height="1" rx="0.5" fill="currentColor" />
+		<rect x="14" y="24" width="7" height="1" rx="0.5" fill="currentColor" />
+		<rect x="14" y="29" width="7" height="1" rx="0.5" fill="currentColor" />
+		<rect x="14" y="34" width="7" height="1" rx="0.5" fill="currentColor" />
+		<rect x="28" y="18" width="13" height="2" rx="1" fill="currentColor" />
+		<rect x="28" y="24" width="13" height="1" rx="0.5" fill="currentColor" />
+		<rect x="28" y="29" width="13" height="1" rx="0.5" fill="currentColor" />
+		<rect x="28" y="34" width="8" height="1" rx="0.5" fill="currentColor" />
+		<defs>
+			<linearGradient id="paint0_linear_split" x1="11" y1="14.5" x2="45.6446" y2="31.9283" gradientUnits="userSpaceOnUse">
+				<stop stopColor="#E9E9E9" />
+				<stop offset="1" stopColor="#F2F2F2" stopOpacity="0" />
+			</linearGradient>
+		</defs>
+	</svg>
+);
+
+export default Split;

--- a/src/ts/interface/block/dataview.ts
+++ b/src/ts/interface/block/dataview.ts
@@ -205,6 +205,9 @@ export interface ViewComponent {
 	closeFilters?: () => void;
 	onTemplateMenu?: (e: any, dur: number) => void;
 	onCellClick?(e: any, key: string, id?: string, record?: any): void;
+	// A host view (Split) claims a row click to select the record in place. Returning true
+	// suppresses the row's default navigation.
+	onRecordClick?(e: any, id: string): boolean;
 	onContext?(e: any, id: string, subId?: string): void;
 	onCellChange?: (id: string, key: string, value: any, callBack?: (message: any) => void) => void;
 	onDragRecordStart?: (e: any, id?: string) => void;

--- a/src/ts/interface/block/dataview.ts
+++ b/src/ts/interface/block/dataview.ts
@@ -37,6 +37,7 @@ export enum ViewType {
 	Calendar		 = 4,
 	Graph			 = 5,
 	Timeline		 = 6,
+	Split			 = 7,
 };
 
 export enum SortType { 
@@ -261,6 +262,7 @@ export interface View {
 	isList?(): boolean;
 	isGallery?(): boolean;
 	isBoard?(): boolean;
+	isSplit?(): boolean;
 };
 
 export interface Cell {

--- a/src/ts/interface/block/index.ts
+++ b/src/ts/interface/block/index.ts
@@ -73,6 +73,7 @@ export interface BlockComponent {
 	isPopup?: boolean;
 	isInsideTable?: boolean;
 	isInsidePreview?: boolean;
+	isInsideSplit?: boolean;
 	isSelectionDisabled?: boolean;
 	isContextMenuDisabled?: boolean;
 	index?: any;

--- a/src/ts/lib/storage.ts
+++ b/src/ts/lib/storage.ts
@@ -26,6 +26,7 @@ const SPACE_KEYS = new Set([
 	'binViewMode',
 	'pendingMembers',
 	'inviteSecurityDismissed',
+	'splitView',
 ]);
 
 const LOCAL_KEYS = new Set([
@@ -37,6 +38,7 @@ const LOCAL_KEYS = new Set([
 	'updateBanner',
 	'lastOpenedSimple',
 	'inviteSecurityDismissed',
+	'splitView',
 ]);
 
 const cache: Map<string, any> = new Map();
@@ -711,6 +713,45 @@ class Storage {
 	getChat (id: string) {
 		const map = this.get('chat', this.isLocal('chat')) || {};
 		return map[id] || {};
+	};
+
+	/**
+	 * Sets local UI state for a Split view (panel width, last selected object).
+	 * Stored locally because the middleware view schema has no fields for it.
+	 * @param {string} key - The view key, from Storage.getSplitViewKey.
+	 * @param {any} obj - The partial state to merge in.
+	 */
+	setSplitView (key: string, obj: any) {
+		if (!key) {
+			return;
+		};
+
+		const map = this.get('splitView', this.isLocal('splitView')) || {};
+
+		map[key] = Object.assign(map[key] || {}, obj);
+		this.set('splitView', map, this.isLocal('splitView'));
+	};
+
+	/**
+	 * Gets local UI state for a Split view.
+	 * @param {string} key - The view key, from Storage.getSplitViewKey.
+	 * @returns {any} The stored state, or an empty object.
+	 */
+	getSplitView (key: string) {
+		const map = this.get('splitView', this.isLocal('splitView')) || {};
+		return map[key] || {};
+	};
+
+	/**
+	 * Builds the storage key for a Split view. State is per dataview block per view, so
+	 * two views of the same collection keep independent widths and selections.
+	 * @param {string} rootId - The root object ID.
+	 * @param {string} blockId - The dataview block ID.
+	 * @param {string} viewId - The view ID.
+	 * @returns {string} The storage key.
+	 */
+	getSplitViewKey (rootId: string, blockId: string, viewId: string): string {
+		return [ rootId, blockId, viewId ].join('-');
 	};
 
 	/**

--- a/src/ts/lib/util/menu.ts
+++ b/src/ts/lib/util/menu.ts
@@ -445,6 +445,7 @@ class UtilMenu {
 			{ id: I.ViewType.Calendar },
 			{ id: I.ViewType.Graph },
 			config.experimental ? { id: I.ViewType.Timeline } : null,
+			config.experimental ? { id: I.ViewType.Split } : null,
 		].filter(it => it).map(it => ({ ...it, name: translate(`viewName${it.id}`) }));
 	};
 

--- a/src/ts/model/view.test.ts
+++ b/src/ts/model/view.test.ts
@@ -89,6 +89,20 @@ describe('View', () => {
 
 			expect(view.isBoard()).toBe(false);
 		});
+
+		it('isSplit should return true for Split type', () => {
+			const view = makeView({ type: I.ViewType.Split });
+
+			expect(view.isSplit()).toBe(true);
+			expect(view.isList()).toBe(false);
+			expect(view.isGrid()).toBe(false);
+		});
+
+		it('isSplit should return false for non-Split type', () => {
+			const view = makeView({ type: I.ViewType.List });
+
+			expect(view.isSplit()).toBe(false);
+		});
 	});
 
 	describe('getRelation', () => {

--- a/src/ts/model/view.ts
+++ b/src/ts/model/view.ts
@@ -13,6 +13,7 @@ import * as M from 'Model';
  * - List: Simple list view
  * - Gallery: Card-based gallery view
  * - Board: Kanban-style board view
+ * - Split: Master-detail — record list on the left, selected object's page on the right
  *
  * Configuration:
  * - filters: Which objects to show
@@ -109,6 +110,10 @@ class View implements I.View {
 
 	isBoard () {
 		return this.type == I.ViewType.Board;
+	};
+
+	isSplit () {
+		return this.type == I.ViewType.Split;
 	};
 
 	getRelations () {


### PR DESCRIPTION
## What

Adds **Split**, a seventh dataview layout for sets and collections: the record list stays
in a resizable left pane while the selected record's full page renders on the right.
Selecting another record swaps the right pane without navigating, so reviewing many
objects no longer means a repeated open → read → back loop that loses list position.

An expand control in the detail pane opens the current record as a normal full page, so
the split is an entry point to the standard editor rather than a dead end.

Gated behind `config.experimental`, matching the Timeline precedent (`4dca3ca073`).

## Why

Opening a record from a collection always navigates away — via route, popup, or new tab.
For triage-style work across a collection, that context loss is the dominant cost.

## How it works

```
.viewContent.viewSplit          // sized to viewport, own scroll per pane
  .splitMaster                  // renders <ViewList isInline>
  .resize-h > .resize-handle    // drag to resize, width persisted locally
  .splitDetail
    .icon.splitDetailExpand     // floats top-right, over the editor's own title
    .splitDetailBody            // <EditorPage> for the selected object
```

Three constraints shaped the implementation:

**`U.Dom.getScrollContainer` is global.** It resolves to a single element per namespace
(`#page.isFull` / `#page.isPopup`, `lib/util/dom.ts:167`). A detail pane that scrolled the
document would fight the host collection for the same container. So the split container
measures the page container and sizes itself to the viewport, giving each pane its own
internal scroll — the technique `ViewGraph` already uses.

**The master pane reuses `ViewList` unchanged.** It is passed `isInline: true` so it takes
the non-`WindowScroller` branch (`view/list.tsx:59`) and scrolls inside the pane. `isInline`
is threaded only into the master child, never the dataview root, so none of the root's
~20 `isInline` branches change behaviour.

**`EditorPage` had never been embedded** outside `page/main/edit.tsx`. Only the
`I.PageComponent` contract is passed; `S.Common.refSet('editor' + ns)` is deliberately
skipped, since that ref is keyed only by `isPopup` and belongs to the host page's editor.

Split-specific UI state (pane width, last selected record) persists **locally** via
`Lib/storage`, keyed by `rootId` + `blockId` + `viewId`. Nothing new is sent to
middleware beyond the view `type`.

### Middleware compatibility

`Mapper.To.View` sends `type` as a raw number. The checked-in schema at
`dist/lib/protos/models.proto` defines `View.Type` as `Table=0 … Graph=5` — it stops at 5,
so shipped `Timeline=6` *already* exceeds it and round-trips fine, because proto3 open
enums carry unknown numeric values through unchanged. `Split=7` sits in exactly that
position and needs no fallback. Confirmed at runtime: reopening a collection preserves the
Split view.

## Behaviour notes

- **Row click** selects into the detail pane, including the empty space right of the title.
  Cmd-, Shift-, Alt- and middle-click keep their existing open-in-tab/window behaviour;
  right-click passes through to the existing context menu untouched.
- **Keyboard**: ArrowUp/ArrowDown move selection, Enter expands to a full page. Guarded by
  `keyboard.isFocused` so keys are never stolen from the editor in the right pane.
- **Selection is reconciled** against `getRecords()` each render, so a filtered-out or
  deleted record falls back to the first record rather than dangling.
- **Object opening is debounced** (100ms) so fast arrow-key navigation doesn't open and
  close a dozen subscriptions; the pending open is cancelled on unmount. Closing is guarded
  so the detail pane can never close the host collection itself.
- **The add-cover / show-description toolbar is hidden** in the pane (the object is reachable
  as a full page via expand), following the `editorWrapper.isBookmark` precedent.
- **The embedded editor fills the pane.** `EditorPage.getWidth` caps its inline width at
  `J.Size.editor` (704px), which left a dead column beside the text in a wider pane. One
  consequence: the object's own layout-width slider is inert inside the pane — it is
  unreachable there anyway (`#editorSize` is hidden until the block-layout menu opens), and
  pane width is governed by the split resizer instead.

## Scope note for reviewers

**This touches one existing shared component.** `list/row.tsx` hardcoded
`U.Object.openConfig` on row click with no seam to override it, so clicking a row in the
split view navigated away instead of selecting. Fixed by adding an optional

```ts
onRecordClick?(e: any, id: string): boolean;
```

to `I.ViewComponent`, which `ListRow` honours for unmodified left clicks. It is additive
and opt-in — every existing view passes nothing and behaves exactly as before. It has to be
checked in *both* the row handler and the per-cell handler, because the latter calls
`stopPropagation()` and would otherwise bypass the row.

The rest of the change is new files plus additive registration (enum value, dispatch case,
icon map, experimental gate, storage helpers, one translation key).

## Test plan

Automated:
- `bun run typecheck` — clean, both tsconfigs
- `bun run lint` — 0 errors (pre-existing warnings only, in untouched files)
- `bunx vitest run src/ts/model/view.test.ts` — 15/15, extended for `isSplit()`
- Full `bunx vitest run` matches the pre-change baseline exactly (601 passed; the 90
  failures are a pre-existing `ReferenceError: U is not defined` in `lib/util/router.ts:94`,
  unrelated to this branch)
- Dark mode audited: no hardcoded colours, only `--color-shape-*` / `--color-text-*`
  variables that the dark theme already redefines, so no new overrides are needed

Manual, with the experimental flag on:
- Switch a collection to Split; master + detail render
- Navigate away and reopen — view is still Split (middleware round-trip)
- Rapid selection changes; detail pane tracks, editing in the right pane saves, no
  subscription leak or console errors
- Expand → lands on the normal full page for that object
- Drag the resizer, reload, width persisted
- Empty collection, deleted selected record, narrow window, dark mode

**Not covered: E2E.** The Playwright suite lives in a separate repo that was not available
in this working copy, so no automated E2E was added, and the checks that run on PRs here are
CLA and Socket Security rather than a test suite. Flagging rather than omitting silently —
happy to add coverage if you point me at the expected specs and how they are run.

## Follow-up (not in this PR)

Grid as the master pane. `ViewGrid.resize()` measures the page container and applies
negative breakout margins in both branches, and its inline branch looks for `#editorWrapper`,
which doesn't exist inside a pane. Doing it properly needs a `getContainerNode` seam on
`I.ViewComponent`, a `splitMasterType` field with explicit clamping (`Grid === 0` is
swallowed by the `Number(x) || default` idiom), a List/Grid sub-setting in the layout menu,
and local persistence for it. Kept separate to keep this PR reviewable; List is the safer
default regardless.
