### PR TITLE
fix(auth): restore session token after renderer reload

### DIFF
--- a/electron/ts/api.ts
+++ b/electron/ts/api.ts
@@ -14,7 +14,7 @@ import UpdateManager from './update';
 import Server from './server';
 import Util from './util';
 import { getSafeStorage } from './safeStorage';
-import { AppWindow, TabView, TabData, CreateTabOptions, AppConfig, Bounds } from './types';
+import { AppWindow, TabView, TabData, TabUpdateData, CreateTabOptions, AppConfig, Bounds } from './types';
 
 const KEYTAR_SERVICE = 'Anytype';
 
@@ -714,12 +714,12 @@ class Api {
 		WindowManager.setActiveTab(win, id);
 	};
 
-	getTab (win: AppWindow, id: string): { id: string; data: TabData } | null {
+	getTab (win: AppWindow, id: string): { id: string; data: TabData; token?: string } | null {
 		const view = (win.views || []).find((it: TabView) => it.id == id);
-		return view ? { id: view.id, data: view.data } : null;
+		return view ? { id: view.id, data: view.data, token: view.token } : null;
 	};
 
-	updateTab (win: AppWindow, id: string, data: Partial<TabData>): void {
+	updateTab (win: AppWindow, id: string, data: TabUpdateData): void {
 		WindowManager.updateTab(win, id, data);
 	};
 

--- a/electron/ts/types.ts
+++ b/electron/ts/types.ts
@@ -16,6 +16,7 @@ export interface AppWindow extends BrowserWindow {
 export interface TabView extends WebContentsView {
 	id: string;
 	data: TabData;
+	token?: string;
 	isLoaded: boolean;
 };
 
@@ -26,6 +27,9 @@ export interface TabData {
 	spaceType?: number;
 	isPinned?: boolean;
 };
+
+/** Runtime update for a tab. Authentication tokens are not persisted with tab data. */
+export type TabUpdateData = Partial<TabData> & { token?: string };
 
 /** Options for creating a new main window */
 export interface CreateMainOptions {

--- a/electron/ts/window.ts
+++ b/electron/ts/window.ts
@@ -11,7 +11,7 @@ import UpdateManager from './update';
 import MenuManager from './menu';
 import Util from './util';
 import { getSafeStorage } from './safeStorage';
-import { AppWindow, TabView, TabData, CreateMainOptions, CreateTabOptions, SavedTabState, SavedWindowsState, Bounds } from './types';
+import { AppWindow, TabView, TabData, TabUpdateData, CreateMainOptions, CreateTabOptions, SavedTabState, SavedWindowsState, Bounds } from './types';
 
 const port: string = Util.getPort();
 
@@ -474,7 +474,7 @@ class WindowManager {
 		Util.sendToAllTabs(win, 'set-active-tab', id);
 	};
 
-	updateTab (win: AppWindow, id: string, data: Partial<TabData>): void {
+	updateTab (win: AppWindow, id: string, update: TabUpdateData): void {
 		id = String(id || '');
 
 		if (!id || !win.views) {
@@ -486,7 +486,12 @@ class WindowManager {
 			return;
 		};
 
+		const { token, ...data } = update || {};
+
 		view.data = Object.assign(view.data || {}, data);
+		if (token !== undefined) {
+			view.token = token;
+		};
 		Util.send(win, 'update-tab', { id: view.id, data: view.data });
 	};
 

--- a/src/ts/lib/web/electronMock.test.ts
+++ b/src/ts/lib/web/electronMock.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('ElectronMock tab session', () => {
+
+	let storage: Map<string, string>;
+
+	beforeEach(() => {
+		storage = new Map();
+		vi.resetModules();
+		vi.stubGlobal('localStorage', {
+			getItem: (key: string) => storage.get(key) || null,
+			setItem: (key: string, value: string) => storage.set(key, value),
+			removeItem: (key: string) => storage.delete(key),
+		});
+		vi.stubGlobal('navigator', {
+			languages: [ 'en-US' ],
+			platform: 'Linux',
+			userAgent: 'Vitest',
+		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('keeps the session token separate from persisted tab data', async () => {
+		const { electronMock } = await import('./electronMock');
+		const tabId = electronMock.tabId();
+
+		await electronMock.Api(1, 'updateTab', [ tabId, { route: '/main/object/test', token: 'session-token' } ]);
+
+		const tab = await electronMock.Api(1, 'getTab', [ tabId ]);
+		const tabs = await electronMock.Api(1, 'getTabs');
+
+		expect(tab).toEqual({
+			id: tabId,
+			data: { route: '/main/object/test' },
+			token: 'session-token',
+		});
+		expect(tabs.tabs[0].data).not.toHaveProperty('token');
+	});
+
+});

--- a/src/ts/lib/web/electronMock.ts
+++ b/src/ts/lib/web/electronMock.ts
@@ -208,9 +208,11 @@ class ElectronMock {
 		handlers.set('updateTab', (args) => {
 			const tabToUpdate = this.tabs.find(t => t.id === args[0]);
 			if (tabToUpdate) {
-				tabToUpdate.data = { ...tabToUpdate.data, ...args[1] };
-				if (args[1].token) {
-					tabToUpdate.token = args[1].token;
+				const { token, ...data } = args[1] || {};
+
+				tabToUpdate.data = { ...tabToUpdate.data, ...data };
+				if (token !== undefined) {
+					tabToUpdate.token = token;
 				}
 			}
 			return true;


### PR DESCRIPTION
## Summary

- keep each tab's live session token in runtime tab state
- return that token from `getTab` so a renderer reload can resume the existing session
- keep authentication tokens out of serializable tab metadata
- align the web Electron mock and add regression coverage for the tab contract

## Root cause

`AuthStore.tokenSet()` sends the session token through `updateTab`. The main process merged that update into `view.data`, while `getTab` returned only `{ id, data }`. The renderer expects `tab.token`, so after `Ctrl+R` it could not find the live token and unnecessarily fell back to the OS keychain/recovery flow.

This was reproduced on CachyOS with Anytype 0.56.1. Windows was not tested.

## Validation

- `bun run test -- src/ts/lib/web/electronMock.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build:electron`

The full local test command still reports unrelated existing test-harness failures where auto-imported globals such as `U` and `Relation` are unavailable; the new regression test passes independently.
