### PR TITLE
JS-9852: fix calendar widget month/year dropdown rendering behind the sidebar

### DIFF
--- a/src/ts/component/widget/view/calendar/index.tsx
+++ b/src/ts/component/widget/view/calendar/index.tsx
@@ -199,26 +199,29 @@ const WidgetViewCalendar = forwardRef<WidgetViewCalendarRefProps, I.WidgetViewCo
 	const months = U.Date.getMonths();
 	const years = U.Date.getYears(0, 3000);
 	const dotMap = getDotMap();
+	const menuParam = { className: 'fixed', classNameWrap: 'fromSidebar' };
 
 	return (
 		<div className="body">
 			<div id="dateSelect" className="dateSelect">
 				<div className="side left">
-					<Select 
+					<Select
 						ref={monthRef}
-						id={`widget-${block.id}-calendar-month`} 
-						value={m} 
-						options={months} 
-						className="month" 
-						onChange={m => setValue(U.Date.timestamp(y, m, 1))} 
+						id={`widget-${block.id}-calendar-month`}
+						value={m}
+						options={months}
+						className="month"
+						menuParam={menuParam}
+						onChange={m => setValue(U.Date.timestamp(y, m, 1))}
 					/>
-					<Select 
+					<Select
 						ref={yearRef}
-						id={`widget-${block.id}-calendar-year`} 
-						value={y} 
-						options={years} 
-						className="year" 
-						onChange={y => setValue(U.Date.timestamp(y, m, 1))} 
+						id={`widget-${block.id}-calendar-year`}
+						value={y}
+						options={years}
+						className="year"
+						menuParam={menuParam}
+						onChange={y => setValue(U.Date.timestamp(y, m, 1))}
 					/>
 				</div>
 


### PR DESCRIPTION
## Problem

Clicking the month or the year in the sidebar calendar widget appeared to do nothing — the dropdown opened *behind* the sidebar (reported on 0.56.1).

## Cause

The month/year `Select` in `src/ts/component/widget/view/calendar/index.tsx` opened the `select` menu with default menu params, so the menu wrapper kept the default z-index:

- `.menus .menuWrap` → `z-index: 23` (`src/scss/menu/common.scss`)
- `.sidebar` → `z-index: 24` (`src/scss/component/sidebar/common.scss`)

`SidebarLeft` and `ListMenu` are siblings in the same stacking context (`src/ts/app.tsx`), so the dropdown was painted underneath the sidebar, whose `.pageWrapper` has an opaque background.

Every other menu opened from the sidebar passes `classNameWrap: 'fromSidebar'` (z-index 50) — including the `calendarDay` menu a few lines above in the same file.

## Fix

Pass the same params the rest of the sidebar uses to both selects:

```ts
const menuParam = { className: 'fixed', classNameWrap: 'fromSidebar' };
```

## Testing

- Manually verified in the app: month and year dropdowns now open on top of the sidebar and selecting a value updates the calendar.
- `bun run typecheck` and `bun run lint` pass.

Closes JS-9852