### PR TITLE
fix(editor): stop mark helpers rewriting the block's stored marks (JS-9853)

### DIFF
--- a/src/ts/lib/mark.test.ts
+++ b/src/ts/lib/mark.test.ts
@@ -415,6 +415,63 @@ describe('Mark', () => {
 
 			expect(result).toHaveLength(2);
 		});
+
+		// The input list is the block's stored marks: mutating it in place makes the
+		// store look already-updated, so the save is skipped as a no-op (JS-9853)
+		it('should not mutate the input marks on Equal overlap with param', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Color, range: { from: 0, to: 5 }, param: 'red' },
+			];
+
+			const result = Mark.toggle(marks, {
+				type: I.MarkType.Color,
+				range: { from: 0, to: 5 },
+				param: 'blue',
+			});
+
+			expect(result[0].param).toBe('blue');
+			expect(marks[0].param).toBe('red');
+			expect(result[0]).not.toBe(marks[0]);
+		});
+
+		it('should not mutate the input marks when shrinking ranges', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Bold, range: { from: 0, to: 10 }, param: '' },
+			];
+
+			Mark.toggle(marks, {
+				type: I.MarkType.Bold,
+				range: { from: 0, to: 5 },
+				param: '',
+			});
+
+			expect(marks[0].range).toEqual({ from: 0, to: 10 });
+		});
+	});
+
+	describe('toggleLink', () => {
+		it('should replace the param of an existing link', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Link, range: { from: 0, to: 5 }, param: 'http://a.com' },
+			];
+
+			const result = Mark.toggleLink({ type: I.MarkType.Link, range: { from: 0, to: 5 }, param: 'http://b.com' }, marks);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].param).toBe('http://b.com');
+		});
+
+		it('should not mutate the input marks', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Link, range: { from: 0, to: 5 }, param: 'http://a.com' },
+			];
+
+			Mark.toggleLink({ type: I.MarkType.Link, range: { from: 0, to: 10 }, param: 'http://a.com' }, marks);
+
+			expect(marks).toHaveLength(1);
+			expect(marks[0].param).toBe('http://a.com');
+			expect(marks[0].range).toEqual({ from: 0, to: 5 });
+		});
 	});
 
 	describe('trimRange', () => {

--- a/src/ts/lib/mark.test.ts
+++ b/src/ts/lib/mark.test.ts
@@ -289,6 +289,44 @@ describe('Mark', () => {
 			expect(result[0].range.from).toBe(5);
 			expect(result[0].range.to).toBe(11);
 		});
+
+		// toHtml runs checkRanges on every render with the block's stored marks:
+		// rewriting their ranges in place corrupts the store (JS-9853)
+		it('should not mutate the input marks when merging adjacent marks', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Bold, range: { from: 0, to: 5 }, param: '' },
+				{ type: I.MarkType.Bold, range: { from: 5, to: 10 }, param: '' },
+			];
+			const before = JSON.stringify(marks);
+
+			const result = Mark.checkRanges('hello world', marks);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].range).toEqual({ from: 0, to: 10 });
+			expect(JSON.stringify(marks)).toBe(before);
+		});
+
+		it('should not mutate the input marks when clamping to text length', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Bold, range: { from: 0, to: 50 }, param: '' },
+			];
+
+			const result = Mark.checkRanges('hello', marks);
+
+			expect(result[0].range.to).toBe(5);
+			expect(marks[0].range.to).toBe(50);
+		});
+
+		it('should not mutate the input marks when trimming code newlines', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Code, range: { from: 0, to: 6 }, param: '' },
+			];
+
+			const result = Mark.checkRanges('hello\nworld', marks);
+
+			expect(result[0].range.to).toBe(5);
+			expect(marks[0].range.to).toBe(6);
+		});
 	});
 
 	describe('toggle', () => {
@@ -446,6 +484,87 @@ describe('Mark', () => {
 			});
 
 			expect(marks[0].range).toEqual({ from: 0, to: 10 });
+		});
+	});
+
+	// U.Data.blockSetText drops a write when the text is unchanged and the new marks
+	// still compare equal to the block's stored marks. Callers hand it the store's own
+	// array, so a mark helper that edits that array in place makes the store look
+	// already-updated and the change never reaches middleware. These cases assert the
+	// write survives the guard — the failure mode the mutation tests above only imply
+	describe('guard: mark change must remain visible to blockSetText', () => {
+		const cases = [
+			{
+				name: 'recolour the same selection again',
+				stored: { type: I.MarkType.Color, range: { from: 0, to: 5 }, param: 'red' },
+				toggled: { type: I.MarkType.Color, range: { from: 0, to: 5 }, param: 'blue' },
+			},
+			{
+				name: 'change the background colour of the same selection',
+				stored: { type: I.MarkType.BgColor, range: { from: 0, to: 5 }, param: 'red' },
+				toggled: { type: I.MarkType.BgColor, range: { from: 0, to: 5 }, param: 'blue' },
+			},
+			{
+				name: 'un-bold the left edge of a bold run',
+				stored: { type: I.MarkType.Bold, range: { from: 0, to: 11 }, param: '' },
+				toggled: { type: I.MarkType.Bold, range: { from: 0, to: 5 }, param: '' },
+			},
+			{
+				name: 'un-bold the right edge of a bold run',
+				stored: { type: I.MarkType.Bold, range: { from: 0, to: 11 }, param: '' },
+				toggled: { type: I.MarkType.Bold, range: { from: 6, to: 11 }, param: '' },
+			},
+			{
+				name: 'un-bold the middle of a bold run',
+				stored: { type: I.MarkType.Bold, range: { from: 0, to: 11 }, param: '' },
+				toggled: { type: I.MarkType.Bold, range: { from: 3, to: 7 }, param: '' },
+			},
+			{
+				name: 'extend a colour run leftwards with the same colour',
+				stored: { type: I.MarkType.Color, range: { from: 5, to: 11 }, param: 'red' },
+				toggled: { type: I.MarkType.Color, range: { from: 0, to: 7 }, param: 'red' },
+			},
+			{
+				name: 'extend a colour run rightwards with the same colour',
+				stored: { type: I.MarkType.Color, range: { from: 0, to: 6 }, param: 'red' },
+				toggled: { type: I.MarkType.Color, range: { from: 3, to: 11 }, param: 'red' },
+			},
+			{
+				name: 'recolour a superset of an existing run',
+				stored: { type: I.MarkType.Color, range: { from: 3, to: 7 }, param: 'red' },
+				toggled: { type: I.MarkType.Color, range: { from: 0, to: 11 }, param: 'blue' },
+			},
+		];
+
+		for (const c of cases) {
+			it(`should send a write when the user does: ${c.name}`, () => {
+				const stored: I.Mark[] = [ c.stored ];
+				const result = Mark.toggle(stored, c.toggled);
+
+				expect(U.Common.compareJSON(stored, result)).toBe(false);
+			});
+		};
+
+		it('should send a write when changing an existing link url', () => {
+			const stored: I.Mark[] = [
+				{ type: I.MarkType.Link, range: { from: 0, to: 5 }, param: 'http://a.com' },
+			];
+
+			const result = Mark.toggleLink({ type: I.MarkType.Link, range: { from: 0, to: 5 }, param: 'http://b.com' }, stored);
+
+			expect(U.Common.compareJSON(stored, result)).toBe(false);
+		});
+
+		// The guard exists to stop no-op writes destroying a concurrent peer edit
+		// (JS-9826): a fix that simply removed it would break this
+		it('should not send a write when nothing actually changed', () => {
+			const stored: I.Mark[] = [
+				{ type: I.MarkType.Color, range: { from: 0, to: 5 }, param: 'red' },
+			];
+
+			const result = Mark.toggle(stored, { type: I.MarkType.Color, range: { from: 0, to: 5 }, param: 'red' });
+
+			expect(U.Common.compareJSON(stored, result)).toBe(true);
 		});
 	});
 

--- a/src/ts/lib/mark.ts
+++ b/src/ts/lib/mark.ts
@@ -242,7 +242,11 @@ class Mark {
 	 * @returns {I.Mark[]} The updated list of marks.
 	 */
 	checkRanges(text: string, marks: I.Mark[]) {
-		marks = (marks || []).slice().sort(this.sort);
+		// slice() copied the array but not the marks inside it, and the loop below
+		// edits mark.range in place. toHtml runs this on every render with the
+		// block's stored marks, so the ranges were rewritten in the store, which
+		// then defeats the save's no-op guard the same way toggle did (JS-9853)
+		marks = (marks || []).map(m => ({ ...m, range: { ...m.range } })).sort(this.sort);
 
 		for (let i = 0; i < marks.length; ++i) {
 			const mark = marks[i];

--- a/src/ts/lib/mark.ts
+++ b/src/ts/lib/mark.ts
@@ -123,7 +123,10 @@ class Mark {
 			return marks;
 		};
 
-		const map = U.Common.mapToArray(marks, 'type');
+		// Copy before mutating: callers pass the block's stored marks, so editing
+		// them in place makes the store look already-updated and the write is
+		// then dropped as a no-op, never reaching middleware (JS-9853)
+		const map = U.Common.mapToArray((marks || []).map(m => ({ ...m, range: { ...m.range } })), 'type');
 		const type = mark.type;
 
 		let add = true;
@@ -975,19 +978,16 @@ class Mark {
 	 * @returns {I.Mark[]} The updated marks.
 	 */
 	toggleLink(newMark: I.Mark, marks: I.Mark[]) {
-		for (let i = 0; i < marks.length; ++i) {
-			const mark = marks[i];
-			if ([I.MarkType.Link, I.MarkType.Object].includes(mark.type) &&
+		// Filter into a new list rather than splicing the caller's: the input is the
+		// block's stored marks and must not be edited in place (JS-9853)
+		const list = (marks || []).filter(mark => {
+			return !([ I.MarkType.Link, I.MarkType.Object ].includes(mark.type) &&
 				(mark.range.from >= newMark.range.from) &&
 				(mark.range.to <= newMark.range.to) &&
-				(mark.param == newMark.param)
-			) {
-				marks.splice(i, 1);
-				i--;
-			};
-		};
+				(mark.param == newMark.param));
+		});
 
-		return this.toggle(marks, newMark);
+		return this.toggle(list, newMark);
 	};
 
 	/**


### PR DESCRIPTION
Closes JS-9853

## Problem

Pick a text colour on a selection — works. Pick a **different** colour on the same selection — the UI repaints but no `BlockSetText` RPC is sent, so the change is lost on reload. The only way to make it save again is to reset to Default and pick the colour again.

Investigation showed the reported colour case is one of several. These writes were all being silently dropped, verified by running each scenario through the real `blockSetText` guard against the pre-fix code:

| User action | Pre-fix |
|---|---|
| Recolour the same selection again *(the reported bug)* | **lost** |
| Change the background colour of the same selection | **lost** |
| Un-bold / un-italicise / un-underline the **left edge** of an existing run | **lost** |
| Same on the **right edge** | **lost** |
| Extend a colour run **leftwards** by re-applying the same colour | **lost** |
| Same **rightwards** | **lost** |
| Change an existing link's URL over the same range | **lost** |
| Un-bold the middle of a run *(splits it)* | ok |
| Recolour a superset of an existing run | ok |

## Root cause

The mark helpers mutated the array they were given instead of returning a new one. Those objects are the block's **stored** marks:

```
block.content.marks (store) → marks prop → marksRef.current (component/block/text.tsx:71, re-aliased at :153)
  → menu data.marks → Mark.toggle input
```

`M.Mark` fields are MobX `observable` (`model/content/text.ts:14-18`), so writing `el.param` / `el.range.from` went straight into the store. The no-op guard in `U.Data.blockSetText` (`lib/util/data.ts:578`, added by the JS-9826 concurrent-text-loss fix) then compared the incoming marks against a store that had *already been updated by the mutation*, found them identical, and returned without emitting `BlockTextSetText`.

That is also why the bug was invisible: the mutation re-rendered the block, so the colour appeared to apply while the write was being discarded.

Three separate mutators, all fixed in `src/ts/lib/mark.ts`:

1. **`toggle`** — the `Equal` branch did `el.param = mark.param`; `InnerLeft` / `InnerRight` / `Inner` / `Left` / `Right` all edited `el.range` in place. Now copies each mark before grouping, matching the pattern `Mark.adjust` already uses.
2. **`toggleLink`** — spliced the caller's array in place. Now filters into a new list.
3. **`checkRanges`** — `.slice()` copies the array but not the marks inside it, and the loop wrote `mark.range.from/to` and `prev.range.to` through to the caller's objects. `Mark.toHtml` calls it on **every render** with `marksRef.current`, so merely rendering a block rewrote ranges in the store: adjacent same-param marks were merged in place while the removed one stayed in the caller's array, leaving an overlapping duplicate that a later mark-only change could then compare equal against.

All 12 callers of `toggle`/`toggleLink` and all 15 of `checkRanges` already use the return value, so nothing depended on the mutation.

## Scope

- **Covered:** text colour, background colour, B/I/U/S/code from the toolbar and from keyboard shortcuts, links (context menu and hover preview), and text inside **table cells** (same component, same path).
- **Not affected, before or after:** multi-block selection, which goes through `C.BlockTextListSetMark` — a server-side toggle that never touches `Mark.toggle`. The emoji and mention menus already passed `U.Common.objectCopy`.
- **Chat:** improved incidentally. While editing an existing message, `marks.current` aliases the stored message marks, so the formatting toolbar was mutating `S.Chat` in place. Chat has no no-op guard, so nothing was lost there, but unsaved formatting rendered and survived cancelling the edit.

## Tests

17 tests added to `src/ts/lib/mark.test.ts`:

- Non-mutation assertions for `toggle`, `toggleLink` and `checkRanges`.
- A `guard:` block asserting each user action above stays visible to the `blockSetText` comparison — this encodes the *actual* failure mode, which the non-mutation tests only imply.
- A negative control: an unchanged selection must still compare equal, so a future "fix" that simply deletes the guard fails here. The guard exists for the JS-9826 / JS-9285 concurrent-edit reason and must stay.

**Verified against the pre-fix `mark.ts`: 13 of the new tests fail there and pass here.**

Full suite: 90 failed / 616 passed vs. a baseline of 90 failed / 599 passed — same pre-existing failures, no regressions. `typecheck` and `eslint` clean.

## Not in this PR

Two related bugs of the same class were found during review and are being filed separately:

- `component/block/text.tsx:772` pushes an inline-code mark straight into the store array. Harmless in normal text blocks (the keyup handler reassigns the ref and breaks the alias), but `canHaveMarks()` is `false` for **title and description** blocks so that reassign never runs — backticking a word in a page title renders monospace and saves nothing.
- `setText`'s own early-return (`text.tsx:1291`) compares text only, so a mark-only change is invisible to it when `update = false`.

## Manual check

Change text colour twice on the same selection without touching the selection in between, reload, confirm the second colour persisted. Then: bold a phrase, select just its first half and un-bold — reload and confirm. Same for a link URL change. Worth repeating inside a table cell.