### PR TITLE
fix(widget): correct visibility icon polarity in section menu (JS-9858)

### DIFF
--- a/src/ts/component/menu/widget/section.tsx
+++ b/src/ts/component/menu/widget/section.tsx
@@ -166,7 +166,7 @@ const MenuWidgetSection = forwardRef<I.MenuRef, I.Menu>((props, ref) => {
 						<div className="name">{item.name}</div>
 					</span>
 					<Icon
-						name={item.isHidden ? 'common/eye1' : 'common/eye0'}
+						name={item.isHidden ? 'common/eye0' : 'common/eye1'}
 						className="eye"
 						onClick={e => onSwitch(item)}
 					/>


### PR DESCRIPTION
The widget section menu (`src/ts/component/menu/widget/section.tsx`) was the wrong one: it rendered `item.isHidden ? 'common/eye1' : 'common/eye0'`, i.e. a slashed eye on hidden rows and an open eye on visible ones, the exact opposite of the Manage Sections sidebar panel. Everywhere else in the app the eye icon depicts the **action the click performs**, not the current state — `common/eye0` is the plain open eye ("show"), `common/eye1` the slashed eye ("hide"). That is pinned by the two call sites where the icon sits next to an explicit label: `menu/dataview/group/edit.tsx` pairs *Show column* with `eye0` and *Hide column* with `eye1`, and `menu/dataview/relation/edit.tsx` pairs *Hide Property* with `eye1`. `sidebar/page/widgetManage.tsx` follows the same rule and its tooltip proves it (`isHidden → eye0` + "Show section"), as does the passphrase reveal toggle in `form/phrase.tsx`. The menu was the only outlier; it also already conveys state independently through the `.isHidden` dimming class (`src/scss/menu/widget.scss`), so the icon is free to carry the action. One-token fix, no styling touched.

Closes #2244 · JS-9858

The reporter's literal complaint — hidden sections continuing to render in the sidebar — is a false alarm: `sidebar/page/widget.tsx` gates on `if (ws.isHidden) return null;` and `S.Common.widgetSectionsSet` persists immediately (no "Done" needed). What they hit was the inverted icon, which made them read "slashed eye" as "already hidden". Worth saying so in the reply to them.

### How to test

1. Open the left sidebar and its section context menu (`...` on a section) → **Manage sections**, and note the eye icon on a visible row: it is the **slashed** eye, tooltip "Hide section".
2. Click it. The section disappears from the sidebar, the icon becomes the **open** eye and the tooltip becomes "Show section".
3. Click it again to restore the section — the icon returns to the slashed eye.
4. Open the widget section menu (the older `widgetSection` menu with the same list) and check the same rows: visible rows now show the slashed eye and hidden rows the open eye, matching the sidebar panel. Hidden rows also stay dimmed.
