### PR TITLE
fix(cell): open editor for ShortText properties in object header (JS-9855)

### DIFF
--- a/src/ts/component/cell/index.tsx
+++ b/src/ts/component/cell/index.tsx
@@ -280,6 +280,9 @@ const Cell = forwardRef<I.CellRef, Props>((props, ref) => {
 				break;
 			};
 
+			// Without inplace editing the text menu is the only editor available (JS-9855),
+			// with inplace editing the input in component/cell/text.tsx handles both formats
+			case I.RelationType.ShortText:
 			case I.RelationType.Number: {
 				if (!noInplace) {
 					break;


### PR DESCRIPTION
Featured relations in the object header render their cells with `noInplace`, so the format switch in `Cell.onClickHandler` is what decides which editor menu opens. Every text format had a branch there except `ShortText`, which fell through to `setOn()` — and `setOn()` returns immediately when `noInplace` is set, so clicking a plain text property in the header did nothing and the relations panel was the only way to edit it. The branch was lost when the `noInplace` refactor (`f7667a9`) removed `onInplaceEdit()`, whose switch did cover ShortText. ShortText now opens the same `dataviewText` menu the Number branch uses; grid cells keep inplace editing untouched. Kanban cards, gallery cards and list rows pass `noInplace` for non-name cells too, so they get the same fix.

Closes #2278 · JS-9855

## How to test

1. Create a new object (any type).
2. Open the properties panel (the "i" icon) and add a new property of type **Text** (plain text), e.g. "Location".
3. Make sure the property is shown in the object header (featured properties). If it is not, use "Show in header" / add it to the type's header properties.
4. Click the property value in the header, right under the object title.
5. **Expected:** a small editor opens with the property name as its title, and you can type a value. Before the fix nothing happened at all.
6. Type some text, then click outside the editor — the value is saved and shown in the header.
7. Repeat the click on the saved value — the editor reopens with the existing text.