### PR TITLE
fix(dataview): anchor empty Query parameter menu to the clicked element (JS-9856)

### DIFF
--- a/src/ts/component/block/dataview.tsx
+++ b/src/ts/component/block/dataview.tsx
@@ -613,12 +613,13 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 	};
 
 	const onEmpty = (e: any) => {
-		let element = '';
 		if (isInline) {
-			element = `#block-${U.Common.esc(block.id)} #head-source-select`;
-			onSourceSelect(element, { horizontal: I.MenuDirection.Center });
+			onSourceSelect(`#block-${U.Common.esc(block.id)} #head-source-select`, { horizontal: I.MenuDirection.Center });
 		} else {
-			element = `#${U.Common.esc(Relation.cellId('blockFeatured', 'setOf', rootId))}`;
+			// The featured setOf cell is not rendered on an empty Query page, so the menu is anchored
+			// to the clicked placeholder and only falls back to the cell when there is no event (JS-9856)
+			const element = e?.currentTarget || U.Dom.select(`#${U.Common.esc(Relation.cellId('blockFeatured', 'setOf', rootId))}`);
+
 			onSourceTypeSelect(element);
 		};
 	};

--- a/src/ts/component/menu/index.tsx
+++ b/src/ts/component/menu/index.tsx
@@ -479,17 +479,32 @@ const Menu = forwardRef<RefProps, I.Menu>((props, ref) => {
 				oy = Number(rect.y) || 0;
 			} else {
 				const el = getElement();
-				if (!el) {
-					console.log('[Menu].position', id, 'element not found', element);
-					return;
+				const elRect = el ? el.getBoundingClientRect() : null;
+
+				// An absent or zero-area anchor - a node which is missing, detached, or hidden with
+				// display: none - carries no geometry, so the menu falls back to the centre of the
+				// window instead of painting at the window origin (JS-9856)
+				const anchor = U.Dom.getAnchorRect(el ? {
+					x: elRect.left,
+					y: elRect.top,
+					width: el.offsetWidth,
+					height: el.offsetHeight,
+				} : null, winSize);
+
+				if (anchor.isFallback) {
+					console.log('[Menu].position', id, 'element not found or not visible', element);
+
+					// A menu which was already placed against a live anchor keeps its position
+					// instead of jumping, only the initial placement uses the fallback
+					if (menuEl.style.left) {
+						return;
+					};
 				};
 
-				const elRect = el.getBoundingClientRect();
-
-				ew = el.offsetWidth;
-				eh = el.offsetHeight;
-				ox = elRect.left + window.scrollX;
-				oy = elRect.top + window.scrollY;
+				ew = anchor.width;
+				eh = anchor.height;
+				ox = anchor.x + window.scrollX;
+				oy = anchor.y + window.scrollY;
 			};
 
 			let x = ox;

--- a/src/ts/lib/util/dom.test.ts
+++ b/src/ts/lib/util/dom.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import UtilDom from './dom';
+
+describe('UtilDom', () => {
+
+	describe('getAnchorRect', () => {
+
+		const winSize = { ww: 1000, wh: 800 };
+
+		it('should keep a rect which has area', () => {
+			const rect = UtilDom.getAnchorRect({ x: 120, y: 240, width: 80, height: 24 }, winSize);
+
+			expect(rect).toEqual({ x: 120, y: 240, width: 80, height: 24, isFallback: false });
+		});
+
+		it('should keep a zero size rect which has a position', () => {
+			const rect = UtilDom.getAnchorRect({ x: 120, y: 240, width: 0, height: 0 }, winSize);
+
+			expect(rect).toEqual({ x: 120, y: 240, width: 0, height: 0, isFallback: false });
+		});
+
+		it('should keep a rect which is positioned at the origin but has area', () => {
+			const rect = UtilDom.getAnchorRect({ x: 0, y: 0, width: 40, height: 12 }, winSize);
+
+			expect(rect).toEqual({ x: 0, y: 0, width: 40, height: 12, isFallback: false });
+		});
+
+		it('should fall back to the window centre when there is no rect', () => {
+			const rect = UtilDom.getAnchorRect(null, winSize);
+
+			expect(rect).toEqual({ x: 500, y: 400, width: 0, height: 0, isFallback: true });
+		});
+
+		it('should fall back to the window centre for a hidden element, which has an all zero rect', () => {
+			const rect = UtilDom.getAnchorRect({ x: 0, y: 0, width: 0, height: 0 }, winSize);
+
+			expect(rect).toEqual({ x: 500, y: 400, width: 0, height: 0, isFallback: true });
+		});
+
+		it('should handle missing window dimensions', () => {
+			const rect = UtilDom.getAnchorRect(null, null);
+
+			expect(rect).toEqual({ x: 0, y: 0, width: 0, height: 0, isFallback: true });
+		});
+
+	});
+
+});

--- a/src/ts/lib/util/dom.ts
+++ b/src/ts/lib/util/dom.ts
@@ -145,6 +145,30 @@ class UtilDom {
 	};
 
 	/**
+	 * Returns the rectangle to anchor floating UI to. A missing rectangle, or one which is entirely
+	 * zero - a node hidden with display: none, or detached from the document - carries no usable
+	 * geometry, so it falls back to the centre of the window instead of the window origin.
+	 * @param {object|null} rect - The anchor rectangle.
+	 * @param {object} winSize - The window dimensions.
+	 * @returns {object} The rectangle to position against, isFallback is set when it was replaced.
+	 */
+	getAnchorRect (rect: any, winSize: { ww: number; wh: number }): I.MenuPosition & { isFallback: boolean } {
+		const x = Number(rect?.x) || 0;
+		const y = Number(rect?.y) || 0;
+		const width = Number(rect?.width) || 0;
+		const height = Number(rect?.height) || 0;
+
+		if (!rect || (!x && !y && !width && !height)) {
+			const ww = Number(winSize?.ww) || 0;
+			const wh = Number(winSize?.wh) || 0;
+
+			return { x: ww / 2, y: wh / 2, width: 0, height: 0, isFallback: true };
+		};
+
+		return { x, y, width, height, isFallback: false };
+	};
+
+	/**
 	 * Clears the current selection in the document.
 	 */
 	clearSelection () {


### PR DESCRIPTION
### Cause

On a full page Query the source menu was anchored to `#blockFeatured-setOf-<rootId>`, the featured `setOf` cell — but that cell is not rendered on an empty Query (the set page only renders `HeadSimple` + the dataview, and `setOf` is not among the featured relations there). `Menu.position()` found no anchor element, logged `element not found` and returned before writing `left`/`top`, so the menu stayed at its unpositioned static origin in the top-left corner of the window. `onEmpty` now anchors the menu to the placeholder that was actually clicked (this is what it did before JS-7550), and `Menu.position()` got a defensive guard: `U.Dom.getAnchorRect()` turns a missing or zero-area anchor (a node that is absent, detached, or hidden with `display: none`) into a centred fallback rect on first placement, instead of painting at the window origin. An already-placed menu keeps its position rather than jumping.

Closes #2277 · JS-9856

The reporter also asked for a visible labelled "+ Define Query Source" button in place of the bare placeholders. That is intentionally **out of scope** here — bare placeholders are a deliberate design decision (DSGN-1418 via JS-7550) and no styling was touched.

### How to test

1. Create a new object of type **Query** (`+ New Object` → Query).
2. Open it as a full page.
3. Click one of the grey placeholder rows.
4. The "Select a parameter to collect objects by it" menu opens next to the clicked placeholder, not in the top-left corner.
5. Repeat with the window narrow / the object scrolled so the placeholders sit near the window edges — the menu stays on screen.
6. Check in both light and dark theme.
7. Regression pass: inline sets/collections in a page (click the empty state), and other anchored menus (relation cells, header menus) still open next to their element.

### Tests

`src/ts/lib/util/dom.test.ts` covers `getAnchorRect`: rects with area and zero-size-but-positioned rects (caret anchors) pass through untouched; a missing rect and an all-zero rect (hidden element) fall back to the window centre.
