### PR TITLE
fix(editor): drop pasted zero-width spaces from code block render (JS-9857)

### DIFF
--- a/src/ts/component/block/text.tsx
+++ b/src/ts/component/block/text.tsx
@@ -216,6 +216,12 @@ const BlockText = forwardRef<I.BlockRef, Props>((props, ref) => {
 			const lang = U.Prism.aliasMap[fields.lang] || 'plain';
 			const grammar = Prism.languages[lang];
 
+			// Zero-width spaces ride along with pasted text (AI answers are full of them).
+			// The model never keeps them — getTextValue strips them on read — so leaving
+			// them in the DOM creates characters the user cannot see but the browser can:
+			// Backspace silently eats one instead of deleting a visible character (JS-9857)
+			html = Mark.stripZws(html);
+
 			html = grammar ? Prism.highlight(html, grammar, lang) : Prism.util.encode(html) as string;
 			langRef.current?.setValue(lang);
 		} else {

--- a/src/ts/lib/mark.test.ts
+++ b/src/ts/lib/mark.test.ts
@@ -922,4 +922,52 @@ describe('Mark', () => {
 		});
 	});
 
+	describe('stripZws', () => {
+
+		// Minimal element-like node: a single text node, the way a code block renders
+		const element = (text: string): any => {
+			return {
+				textContent: text,
+				childNodes: [ { nodeType: 3, textContent: text, childNodes: [] } ],
+			};
+		};
+
+		beforeAll(() => {
+			const g = globalThis as any;
+
+			if (typeof g.Node === 'undefined') {
+				g.Node = { TEXT_NODE: 3, ELEMENT_NODE: 1 };
+			};
+		});
+
+		it('should remove zero-width spaces that came in with pasted text', () => {
+			expect(Mark.stripZws('const a\u200B = 1;')).toBe('const a = 1;');
+		});
+
+		it('should remove a run of zero-width spaces', () => {
+			expect(Mark.stripZws('\u200Bconst\u200B\u200B a = 1;\u200B')).toBe('const a = 1;');
+		});
+
+		it('should leave text without zero-width spaces untouched', () => {
+			expect(Mark.stripZws('const a = 1;')).toBe('const a = 1;');
+		});
+
+		it('should keep DOM and model offsets aligned for the rendered text', () => {
+			const el = element(Mark.stripZws('const a\u200B = 1;'));
+
+			expect(Mark.hasZws(el)).toBe(false);
+			expect(Mark.domToModel(8, el)).toBe(8);
+			expect(Mark.modelToDom(8, el)).toBe(8);
+		});
+
+		it('should document the drift when a stray zero-width space reaches the DOM', () => {
+			const el = element('const a\u200B = 1;');
+
+			// The character is in the DOM but not in the model: every offset past it
+			// shifts, and Backspace on it deletes nothing the user can see
+			expect(Mark.hasZws(el)).toBe(true);
+			expect(Mark.domToModel(8, el)).toBe(7);
+		});
+	});
+
 });

--- a/src/ts/lib/mark.ts
+++ b/src/ts/lib/mark.ts
@@ -92,6 +92,7 @@ const Order = [
  */
 const ZWS = '\u200B';
 const ZWS_TYPES = [ ...Order ];
+const RE_ZWS = new RegExp(ZWS, 'g');
 
 class Mark {
 
@@ -1218,6 +1219,20 @@ class Mark {
 	hasZws (el: HTMLElement): boolean {
 		const text = el.textContent || '';
 		return text.includes(ZWS);
+	};
+
+	/**
+	 * Remove ZWS characters from plain text before it is rendered into the DOM.
+	 * ZWS is the editor's own cursor anchor around inline markup, never content:
+	 * the model drops it on read (Editable.getTextValue). A ZWS that arrives with
+	 * pasted text is not an anchor, so rendering it leaves a character the model
+	 * does not have — the caret can sit behind it and Backspace deletes it without
+	 * changing a single visible character (JS-9857).
+	 * @param {string} text - The plain text to render.
+	 * @returns {string} The text without ZWS characters.
+	 */
+	stripZws (text: string): string {
+		return String(text || '').replace(RE_ZWS, '');
 	};
 
 	/**


### PR DESCRIPTION
### Cause

A code block renders its text verbatim into the contenteditable, so zero-width spaces that ride along with pasted text (AI answers are full of them) end up in the DOM. The model never keeps them — `Editable.getTextValue()` strips ZWS on read, because ZWS is the editor's own cursor anchor around inline markup, not content. That leaves characters which exist for the browser but not for the editor: the caret can sit behind one and Backspace deletes it without changing a single visible character, so deletion reads as "does nothing" / "frozen" while typing still works. The fix strips ZWS from the text a code block renders, so the DOM and the model agree on which characters exist. Anchors are added by `Mark.toHtml` afterwards and are untouched, so mentions, emoji, links and IME input are unaffected.

Supersedes the approach in #2199, which bundles four changes and replaces native contenteditable deletion with programmatic UTF-16 deletion across the shared `focus.ts` / `editable.tsx` paths.

Closes #2196 · JS-9857

Unit test: `Mark.stripZws` in `src/ts/lib/mark.test.ts`, including the DOM↔model offset alignment of the rendered text and a case documenting the drift a stray ZWS causes.

### How to test

1. Put text with a zero-width space on the clipboard, e.g. in a browser console: ``navigator.clipboard.writeText('const a​ = 1;')`` — or copy an answer with an AI "Copy response" button.
2. In the editor, create a code block and paste the text into it.
3. Put the caret in the middle of the pasted text and press Backspace repeatedly — each press must delete the character immediately before the caret. Before the fix, some presses appeared to do nothing.
4. Select part of the text and press Backspace — the selection is removed.
5. Press Backspace at the very start of the code block — it still merges with the previous block as before.
6. In a normal paragraph, type `@` and insert a mention, then put the caret right after the mention and press Backspace — the whole mention is removed, and arrow keys still step over it atomically.
7. In a paragraph, insert an emoji with `:` and press Backspace right after it — the emoji is removed as one unit. Bold/italic/link marks keep working when typing at their boundaries.