### PR TITLE
fix(sidebar): restore toggles on the empty object state (JS-9859)

### DIFF
--- a/src/scss/common.scss
+++ b/src/scss/common.scss
@@ -197,6 +197,7 @@ html {
 			}
 
 			#header:not(.withSidebarTotalLeft) > .side.left { padding-left: 84px; }
+			.pageFlex:not(.withSidebarTotalLeft) .pageMainVoid .wrapper > .side.left { left: 84px; }
 			#sidebar {
 				#subPageWrapper {
 					.sidebarPage > .head { padding-left: 84px; }

--- a/src/scss/page/common.scss
+++ b/src/scss/page/common.scss
@@ -18,10 +18,22 @@
 		#page { border-top-left-radius: 0px; border-bottom-left-radius: 0px; }
 	}
 
-	&.withSidebarLeft {
+	&.withSidebarTotalLeft {
 		.pageMainVoid {
 			.wrapper {
-				> .icon.vaultToggle { display: none; }
+				> .side.left {
+					.icon.vaultToggle { display: none; }
+				}
+			}
+		}
+	}
+
+	&.withSidebarSubLeft {
+		.pageMainVoid {
+			.wrapper {
+				> .side.left {
+					.icon.headerWidget { display: none; }
+				}
 			}
 		}
 	}

--- a/src/scss/page/main/void.scss
+++ b/src/scss/page/main/void.scss
@@ -9,7 +9,7 @@
 .pageMainVoid {
 	.wrapper { width: var(--editor-width); margin: 0px auto; padding: 48px 0px; display: flex; flex-direction: row; align-items: center; justify-content: center; }
 	.wrapper {
-		.icon.vaultToggle { position: absolute; left: 12px; top: 12px; }
+		> .side.left { position: absolute; left: 12px; top: 12px; display: flex; flex-direction: row; align-items: center; gap: 0px 8px; }
 
 		.frame { text-align: center; position: absolute; }
 		.iconWrapper { display: flex; align-items: center; justify-content: space-around; }

--- a/src/scss/page/main/void.scss
+++ b/src/scss/page/main/void.scss
@@ -9,7 +9,10 @@
 .pageMainVoid {
 	.wrapper { width: var(--editor-width); margin: 0px auto; padding: 48px 0px; display: flex; flex-direction: row; align-items: center; justify-content: center; }
 	.wrapper {
-		> .side.left { position: absolute; left: 12px; top: 12px; display: flex; flex-direction: row; align-items: center; gap: 0px 8px; }
+		> .side.left {
+			position: absolute; left: 12px; top: 12px; display: flex; flex-direction: row; align-items: center;
+			gap: 0px 8px; -webkit-app-region: no-drag;
+		}
 
 		.frame { text-align: center; position: absolute; }
 		.iconWrapper { display: flex; align-items: center; justify-content: space-around; }

--- a/src/ts/component/page/main/void.tsx
+++ b/src/ts/component/page/main/void.tsx
@@ -80,7 +80,7 @@ const PageMainVoid = forwardRef<I.PageRef, I.PageComponent>((props, ref) => {
 				animate={{ opacity: 1, transition: { duration: 0.12 } }}
 				exit={{ opacity: 0, transition: { duration: 0.08 } }}
 			>
-				{id != 'empty' ? (
+				<div className="side left">
 					<Icon
 						name="widget/vaultToggle" className="vaultToggle" withBackground={true}
 						onClick={() => sidebar.leftPanelToggle(true, true)}
@@ -89,7 +89,19 @@ const PageMainVoid = forwardRef<I.PageRef, I.PageComponent>((props, ref) => {
 							typeY: I.MenuDirection.Bottom,
 						}}
 					/>
-				) : ''}
+
+					{id == 'empty' ? (
+						<Icon
+							name="header/widget" withBackground={true}
+							onClick={() => sidebar.leftPanelSubPageToggle('widget', true, true)}
+							tooltipParam={{
+								text: translate('commonWidgets'),
+								caption: keyboard.getCaption('widget'),
+								typeY: I.MenuDirection.Bottom,
+							}}
+						/>
+					) : ''}
+				</div>
 
 				<Frame>
 					{icon ? (


### PR DESCRIPTION
Closes JS-9859 — https://linear.app/anytype/issue/JS-9859

## Problem

On the `Select an object from the sidebar or create a new one` screen (`/main/void/empty`), closing both left panels left no clickable way to reopen them — the panels could only be recovered with a keyboard shortcut.

`/main/void/empty` is the only in-space page that renders no `Header`, so it never gets the header's vault + widget toggle cluster. Every remaining copy of those toggles lives inside the vault panel (`sidebar/page/vault.tsx`) or the widget panel (`sidebar/page/widget.tsx`, `widgetManage.tsx`) — all invisible once both panels are closed. On top of that, `page/main/void.tsx` explicitly suppressed its own vault toggle for the `empty` state (`id != 'empty'`), added in e91b2d0e17, which intentionally dropped the icon and header chrome for this state on the assumption that the sidebar would still be there.

## Fix

`void.tsx` now renders the standard top-left icon cluster instead of a lone conditional icon:

- vault toggle for all void states
- widget toggle for `empty` only — the one void state that lives inside a space (`select` clears the widget subpage, `error` hides the sidebar entirely)

Hiding follows the header's existing convention rather than a new one: vault toggle hides on `withSidebarTotalLeft`, widget toggle hides on `withSidebarSubLeft`, so an open panel's own toggle takes over instead of duplicating. The previous void rule keyed off `withSidebarLeft`, which would have shown a duplicate vault toggle now that the widget panel can be open on this page.

## Testing

- `bun run typecheck` clean, `bun run lint` 0 errors, production build compiles and emits the expected CSS.
- No design values changed — the cluster keeps the existing `left: 12px / top: 12px` position and uses the header's `8px` icon gap. Both icons are inline SVGs on `currentColor`, so dark mode needs no variants.
- E2E added in `anytype-desktop-suite`: `tests/sidebar/void-empty-toggles.spec.ts` (3/3 passing). Confirmed to be a real regression test — it fails on the pre-fix code at exactly the reported symptom.