### PR TITLE
JS-9861: fix block order for cross-block text selection

### DIFF
--- a/docs/src/ts/component/selection/README.md
+++ b/docs/src/ts/component/selection/README.md
@@ -19,6 +19,7 @@ Imperative ref API (`SelectionRefProps`):
 - `rebind()` - Re-attach mouse/keyboard event listeners
 - `setContextMenuHandler(handler)` - Register context menu callback
 - `getTextSelection()` - Cross-block text selection state (`{ from, to }` endpoints with per-block `I.TextRange`), or `null`
+- `getTextSelectionIds()` - Ordered block ids covered by the cross-block text selection (slice of `S.Block.getTreeList(rootId)`, the depth-first document order, so nested children between the endpoints are included)
 - `clearTextSelection()` - Dissolve the cross-block text selection and restore the blocks wrapper
 - `isCrossSelecting()` - Whether a cross-block text drag is in progress
 

--- a/src/ts/component/selection/provider.tsx
+++ b/src/ts/component/selection/provider.tsx
@@ -337,8 +337,7 @@ const SelectionProvider = forwardRef<SelectionRefProps, Props>((props, ref) => {
 					const first = (currentIds.length && currentIds[0]) ? currentIds[0] : focusedId.current;
 
 					if (first && id && (first !== id)) {
-						const tree = S.Block.getTree(rootId, S.Block.getBlocks(rootId));
-						const list = S.Block.unwrapTree(tree);
+						const list = S.Block.getTreeList(rootId);
 						const idxStart = list.findIndex(it => it.id == first);
 						const idxEnd = list.findIndex(it => it.id == id);
 
@@ -908,8 +907,7 @@ const SelectionProvider = forwardRef<SelectionRefProps, Props>((props, ref) => {
 		};
 
 		const { from, to } = crossState.current;
-		const rootId = keyboard.getRootId();
-		const list = S.Block.unwrapTree(S.Block.getTree(rootId, S.Block.getBlocks(rootId)));
+		const list = S.Block.getTreeList(keyboard.getRootId());
 		const idxStart = list.findIndex(it => it.id == from.id);
 		const idxEnd = list.findIndex(it => it.id == to.id);
 
@@ -960,9 +958,7 @@ const SelectionProvider = forwardRef<SelectionRefProps, Props>((props, ref) => {
 		};
 
 		// Sort blocks by their document tree order
-		const rootId = keyboard.getRootId();
-		const tree = S.Block.getTree(rootId, S.Block.getChildren(rootId, rootId));
-		const treeOrder = S.Block.unwrapTree(tree).map(it => it.id);
+		const treeOrder = S.Block.getTreeList(keyboard.getRootId()).map(it => it.id);
 		const orderMap = new Map(treeOrder.map((id, idx) => [ id, idx ]));
 
 		list.sort((a, b) => {

--- a/src/ts/store/block.test.ts
+++ b/src/ts/store/block.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { Block as BlockStore } from 'Store/block';
+import Block from 'Model/block';
+import * as I from 'Interface';
+
+const ROOT = 'root';
+
+// Mirrors a real document: the middleware wraps top-level blocks into layout Div blocks and sends
+// blocks in breadth-first order, so nested list items arrive long after their parents.
+const STRUCTURE: [ string, string[] ][] = [
+	[ ROOT, [ 'header', 'divA', 'divB', 'divC' ] ],
+	[ 'header', [ 'title', 'featuredRelations' ] ],
+	[ 'divA', [ 'a1', 'a2' ] ],
+	[ 'divB', [ 'collections', 'views', 'queries', 'general', 'search' ] ],
+	[ 'divC', [ 'c1' ] ],
+	[ 'title', [] ],
+	[ 'featuredRelations', [] ],
+	[ 'a1', [] ],
+	[ 'a2', [] ],
+	[ 'collections', [] ],
+	[ 'views', [ 'sorts', 'filters', 'layouts' ] ],
+	[ 'queries', [ 'autocollect' ] ],
+	[ 'general', [] ],
+	[ 'search', [] ],
+	[ 'c1', [] ],
+	[ 'sorts', [] ],
+	[ 'filters', [] ],
+	[ 'layouts', [ 'grid', 'board' ] ],
+	[ 'autocollect', [] ],
+	[ 'grid', [] ],
+	[ 'board', [] ],
+];
+
+const DOCUMENT_ORDER = [
+	'header', 'title', 'featuredRelations',
+	'divA', 'a1', 'a2',
+	'divB', 'collections', 'views', 'sorts', 'filters', 'layouts', 'grid', 'board', 'queries', 'autocollect', 'general', 'search',
+	'divC', 'c1',
+];
+
+const makeBlock = (id: string, childrenIds: string[]): Block => {
+	const isLayout = (id == 'header') || id.startsWith('div');
+
+	return new Block({
+		id,
+		parentId: '',
+		type: (id == ROOT) ? I.BlockType.Page : (isLayout ? I.BlockType.Layout : I.BlockType.Text),
+		childrenIds,
+		hAlign: I.BlockHAlign.Left,
+		vAlign: I.BlockVAlign.Top,
+		bgColor: '',
+		fields: {},
+		content: isLayout ? { style: I.LayoutStyle.Div } : { style: I.TextStyle.Paragraph, text: id },
+	});
+};
+
+describe('BlockStore tree helpers', () => {
+
+	beforeAll(() => {
+		// U is an auto-import global in the app bundle; the store only needs objectCopy here
+		(globalThis as any).U = {
+			Common: {
+				objectCopy: (o: any) => JSON.parse(JSON.stringify(typeof o === 'undefined' ? {} : o)),
+			},
+		};
+	});
+
+	beforeEach(() => {
+		BlockStore.clear(ROOT);
+		BlockStore.set(ROOT, STRUCTURE.map(([ id, childrenIds ]) => makeBlock(id, childrenIds)));
+		BlockStore.setStructure(ROOT, STRUCTURE.map(([ id, childrenIds ]) => ({ id, childrenIds })));
+		BlockStore.updateStructureParents(ROOT);
+	});
+
+	describe('getTree', () => {
+		it('builds the full depth of nested children', () => {
+			const tree = BlockStore.getTree(ROOT, BlockStore.getChildren(ROOT, ROOT));
+			const divB = tree.find(it => it.id == 'divB');
+			const views = divB.childBlocks.find(it => it.id == 'views');
+			const layouts = views.childBlocks.find(it => it.id == 'layouts');
+
+			expect(views.childBlocks.map(it => it.id)).toEqual([ 'sorts', 'filters', 'layouts' ]);
+			expect(layouts.childBlocks.map(it => it.id)).toEqual([ 'grid', 'board' ]);
+		});
+
+		it('does not mutate the store blocks', () => {
+			BlockStore.getTree(ROOT, BlockStore.getChildren(ROOT, ROOT));
+
+			expect((BlockStore.getLeaf(ROOT, 'views') as any).childBlocks).toBeUndefined();
+		});
+	});
+
+	describe('getTreeList', () => {
+		it('returns every block once, in document order, without the root', () => {
+			const ids = BlockStore.getTreeList(ROOT).map(it => it.id);
+
+			expect(ids).toEqual(DOCUMENT_ORDER);
+		});
+
+		it('slices a range of top-level blocks together with their nested children', () => {
+			const ids = BlockStore.getTreeList(ROOT).map(it => it.id);
+			const slice = ids.slice(ids.indexOf('collections'), ids.indexOf('search') + 1);
+
+			expect(slice).toEqual([ 'collections', 'views', 'sorts', 'filters', 'layouts', 'grid', 'board', 'queries', 'autocollect', 'general', 'search' ]);
+		});
+
+		it('slices from a top-level block to a nested block without leaking unrelated blocks', () => {
+			const ids = BlockStore.getTreeList(ROOT).map(it => it.id);
+			const slice = ids.slice(ids.indexOf('collections'), ids.indexOf('autocollect') + 1);
+
+			expect(slice).toEqual([ 'collections', 'views', 'sorts', 'filters', 'layouts', 'grid', 'board', 'queries', 'autocollect' ]);
+			expect(slice).not.toContain('header');
+			expect(slice).not.toContain('featuredRelations');
+			expect(slice).not.toContain('divA');
+		});
+	});
+
+});

--- a/src/ts/store/block.ts
+++ b/src/ts/store/block.ts
@@ -801,6 +801,7 @@ class BlockStore {
 
 	/**
 	 * Gets the tree structure for a root ID and list of blocks.
+	 * Each item is a copy of the block with a recursive `childBlocks` array; the live store objects are not touched.
 	 * @param {string} rootId - The root ID.
 	 * @param {any[]} list - The list of blocks.
 	 * @returns {any[]} The tree structure.
@@ -808,9 +809,19 @@ class BlockStore {
 	getTree (rootId: string, list: any[]): any[] {
 		list = U.Common.objectCopy(list || []);
 		for (const item of list) {
-			item.childBlocks = this.getTree(item.id, this.getChildren(rootId, item.id));
+			// The structure map is keyed by rootId at every depth, so the recursion must keep the real rootId
+			item.childBlocks = this.getTree(rootId, this.getChildren(rootId, item.id));
 		};
 		return list;
+	};
+
+	/**
+	 * Gets all blocks of a root in document (depth-first) order.
+	 * @param {string} rootId - The root ID.
+	 * @returns {any[]} Flat list of block copies in document order, excluding the root block itself.
+	 */
+	getTreeList (rootId: string): any[] {
+		return this.unwrapTree(this.getTree(rootId, this.getChildren(rootId, rootId)));
 	};
 
 	/**


### PR DESCRIPTION
## Summary
- Cross-block text selection (copy/cut/delete/Tab/quote) computed the covered block ids by slicing a "document order" list built from `S.Block.getTree(rootId, S.Block.getBlocks(rootId))`. That list was wrong in two ways: `getBlocks` is the flat store map in middleware (breadth-first) order, and `getTree` only expanded one level because the recursion passed `item.id` instead of the real `rootId`. Every block appeared several times out of order, so the slice between the endpoints either dropped nested children (`Collections → Search` sent 5 blocks instead of 11 — indented bullets lost) or swept in unrelated blocks (`Collections → Auto-collect` sent 94 blocks incl. title/featured relations — "whole note copied/cut/deleted").
- `getTree` now keeps the real `rootId` through the recursion; new `S.Block.getTreeList(rootId)` returns the depth-first document order.
- Selection provider uses `getTreeList` for `getTextSelectionIds`, shift+click block ranges, and selection ordering (all three had the same latent bug).
- Regression test `src/ts/store/block.test.ts` modeled on the reported document structure (middleware BFS order + layout `div` wrappers + nested lists); fails 4/5 on the old code.

Linear: https://linear.app/anytype/issue/JS-9861/big-regression-on-copy-paste

## Test plan
- [x] `bunx vitest run src/ts/store/block.test.ts` — 5/5 pass (4 fail on old `getTree`)
- [x] Re-ran both reported cases against the attached export through the fixed path: 94 → 9 blocks, 5 → 11 blocks
- [x] `bun run typecheck`, eslint clean
- [x] Manual: in a page with nested bullet lists, drag-select text from a heading across nested items and Cmd+C / Cmd+X / Delete / Tab — only the visibly selected blocks (incl. indented children) are affected
- [x] Manual: shift+click a block range across nested lists selects exactly the in-between blocks