### PR TITLE
JS-9864: show Create Channel inline under the last channel when short

### DIFF
--- a/src/scss/component/sidebar/page/vault.scss
+++ b/src/scss/component/sidebar/page/vault.scss
@@ -160,6 +160,12 @@
 			.side.right { flex-direction: column; gap: 12px; }
 
 			&:hover, &.hover { height: 178px; }
+
+			// Create Channel lives inline under the last channel instead of in this
+			// stack - one fewer icon, so the expanded height shrinks by its slot (icon + gap)
+			&.compact {
+				&:hover, &.hover { height: 134px; }
+			}
 		}
 	}
 }

--- a/src/ts/component/sidebar/page/vault.tsx
+++ b/src/ts/component/sidebar/page/vault.tsx
@@ -220,6 +220,7 @@ const SidebarPageVault = forwardRef<{}, I.SidebarPageComponent>((props, ref) => 
 		};
 
 		if (vaultIsMinimal && !skipUi) {
+			const spaceCount = items.length;
 			const pinned = items.filter(it => it.isPinned);
 			const notPinned = items.filter(it => !it.isPinned);
 
@@ -230,6 +231,12 @@ const SidebarPageVault = forwardRef<{}, I.SidebarPageComponent>((props, ref) => 
 			// Search leads the rail - the thing you reach for most. Creating a Channel is
 			// rare by comparison and lives in the bottom bar with the other chrome
 			items.unshift({ id: 'search' });
+
+			// A short list has room to spare - put Create Channel right under the last one
+			// instead of leaving it as hover-only chrome at the bottom
+			if (!filter && (spaceCount <= 5)) {
+				items.push({ id: 'createSpaceMinimal' });
+			};
 		} else
 		if (!skipUi && !filter && (items.length == 1)) {
 			items.push({ id: 'createSpaceInline' });
@@ -259,6 +266,7 @@ const SidebarPageVault = forwardRef<{}, I.SidebarPageComponent>((props, ref) => 
 	};
 
 	const items = getItems();
+	const hasInlineCreate = items.some(it => it.id == 'createSpaceMinimal');
 	const listRef = useRef<List>(null);
 	const filterRef = useRef(null);
 	const timeout = useRef(0);
@@ -403,6 +411,14 @@ const SidebarPageVault = forwardRef<{}, I.SidebarPageComponent>((props, ref) => 
 			return (
 				<div ref={forwardedRef} className="item add" style={item.style}>
 					{iconSearch()}
+				</div>
+			);
+		};
+
+		if (item.id == 'createSpaceMinimal') {
+			return (
+				<div ref={forwardedRef} className="item add" style={item.style}>
+					{iconCreate()}
 				</div>
 			);
 		};
@@ -643,6 +659,13 @@ const SidebarPageVault = forwardRef<{}, I.SidebarPageComponent>((props, ref) => 
 		};
 	}, [ itemIds ]);
 
+	// When Create Channel moves inline under the last channel, the hover-out footer
+	// has one fewer icon - shrink its expanded height to match, or the remaining
+	// icons drift up and leave a gap above the profile icon
+	if (hasInlineCreate) {
+		cnf.push('compact');
+	};
+
 	return (
 		<>
 			<div 
@@ -776,7 +799,7 @@ const SidebarPageVault = forwardRef<{}, I.SidebarPageComponent>((props, ref) => 
 					</div>
 
 					<div className="side right">
-						{vaultIsMinimal ? iconCreate() : ''}
+						{vaultIsMinimal && !hasInlineCreate ? iconCreate() : ''}
 						<Icon
 							name="vault/gallery"
 							className="gallery"


### PR DESCRIPTION
## What
Collapsed (minimal) vault: when a space has ≤5 channels, the Create Channel (+) button now appears inline as the last row in the rail, right under the last channel — instead of living only in the hover-revealed bottom toolbar.

## Why
JS-9863 moved (+) out of the top of the collapsed rail into the bottom toolbar, which requires a hover to discover. For a short list there's room to show it directly, matching where users expect it.

## Changes
- `vault.tsx`: inline `(+)` row added under the last channel when channel count ≤5; suppressed the duplicate `(+)` in the bottom toolbar in that case (avoids two elements sharing the `#button-create-space` anchor)
- `vault.scss`: shrink the toolbar's hover-expanded height by one icon slot when `(+)` has moved inline, so the remaining icons don't drift up and leave a gap above the profile icon

## Testing
- `bun run typecheck` and `bun run lint` pass
- Not yet visually verified in a running build — worth a quick eyeball on the footer spacing

JS-9864