### PR TITLE
JS-9868: fix Space key silently breaking the global search shortcut

### DIFF
--- a/electron/ts/menu.ts
+++ b/electron/ts/menu.ts
@@ -78,6 +78,11 @@ class MenuManager {
 			} else
 			if (arrowKeys[keyLower]) {
 				ret.push(arrowKeys[keyLower]);
+			} else
+			// ' ' is what pre-fix builds persisted for Space - Electron cannot parse it and
+			// register() throws, so heal it here as well as at the recorder
+			if ((keyLower == 'space') || (keyLower == ' ')) {
+				ret.push('Space');
 			} else {
 				ret.push(key.toUpperCase());
 			};
@@ -538,7 +543,10 @@ class MenuManager {
 			// does not say by whom. On Wayland without the portal it fails the same way.
 			try {
 				this.globalShortcutRegistered = globalShortcut.register(accelerator, () => this.onGlobalSearch());
-			} catch (e) {
+			} catch (e: any) {
+				// Invalid accelerator - never silently: a swallowed throw here is
+				// indistinguishable from a shortcut that simply never fires
+				Util.log('error', `[MenuManager].initGlobalShortcuts: failed to register "${accelerator}": ${e.message}`);
 				this.globalShortcutRegistered = false;
 			};
 		};

--- a/electron/ts/menu.ts
+++ b/electron/ts/menu.ts
@@ -61,6 +61,10 @@ class MenuManager {
 		keys = keys || [];
 
 		const arrowKeys: { [key: string]: string } = { arrowup: 'Up', arrowdown: 'Down', arrowleft: 'Left', arrowright: 'Right', up: 'Up', down: 'Down', left: 'Left', right: 'Right' };
+		// Canonical names the recorder persists that Electron cannot parse on its own:
+		// uppercasing them yields COMMA / SPACE, and ' ' is what pre-fix builds stored
+		// for Space. Both make register() throw
+		const namedKeys: { [key: string]: string } = { space: 'Space', ' ': 'Space', comma: ',' };
 		const ret: string[] = [];
 		for (const key of keys) {
 			const keyLower = key.toLowerCase();
@@ -79,10 +83,8 @@ class MenuManager {
 			if (arrowKeys[keyLower]) {
 				ret.push(arrowKeys[keyLower]);
 			} else
-			// ' ' is what pre-fix builds persisted for Space - Electron cannot parse it and
-			// register() throws, so heal it here as well as at the recorder
-			if ((keyLower == 'space') || (keyLower == ' ')) {
-				ret.push('Space');
+			if (namedKeys[keyLower]) {
+				ret.push(namedKeys[keyLower]);
 			} else {
 				ret.push(key.toUpperCase());
 			};

--- a/src/ts/component/popup/shortcut.tsx
+++ b/src/ts/component/popup/shortcut.tsx
@@ -419,7 +419,9 @@ const PopupShortcut = forwardRef<{}, I.Popup>((props, ref) => {
 			const key = keyboard.eventKey(e);
 			const which = e.which;
 			const code = String(e.code || '').toLowerCase();
-			const special = [ 'comma' ];
+			// Keys whose e.key is not the canonical name used by J.Shortcut: Space reports a
+			// literal ' ', which would persist an unregisterable accelerator
+			const special = [ 'comma', 'space' ];
 
 			if (key == Key.escape) {
 				clear();

--- a/src/ts/component/popup/shortcut.tsx
+++ b/src/ts/component/popup/shortcut.tsx
@@ -435,8 +435,12 @@ const PopupShortcut = forwardRef<{}, I.Popup>((props, ref) => {
 			if (!skip.includes(key)) {
 				let parsedCode = false;
 
+				// At most one non-modifier per chord - `codes` records that one was already
+				// captured. Without this a stray second tap (A then Space inside the 200ms
+				// save window) appends a key the OS happily binds but no in-app matcher can
+				// ever produce, since matching builds its chord from a single keydown
 				codeChecks.forEach(c => {
-					if (codes.has(c)) {
+					if (codes.size) {
 						parsedCode = true;
 						return;
 					};
@@ -449,14 +453,21 @@ const PopupShortcut = forwardRef<{}, I.Popup>((props, ref) => {
 				});
 
 				for (const s of special) {
+					if (codes.size) {
+						parsedCode = true;
+						break;
+					};
+
 					if (which == J.Key[s]) {
 						pressed.push(s);
+						codes.add(s);
 						parsedCode = true;
 					};
 				};
 
 				if (!parsedCode && key) {
 					pressed.push(key);
+					codes.add(key);
 				};
 			};
 

--- a/src/ts/lib/storage.test.ts
+++ b/src/ts/lib/storage.test.ts
@@ -68,3 +68,84 @@ describe('Storage last-opened (per-space isolation)', () => {
 	});
 
 });
+
+/**
+ * Regression coverage for JS-9868.
+ *
+ * The shortcut recorder derived the stored key name from `keyboard.eventKey()`
+ * (= `e.key.toLowerCase()`). For Space `e.key` is a literal ' ', not the canonical
+ * 'space' the J.Shortcut defaults use, so recording any Space combo persisted ' '.
+ * `MenuManager.getAccelerator()` then emitted "CmdOrCtrl+Shift+ ",
+ * `globalShortcut.register()` threw, and a try/catch swallowed it - the settings
+ * panel showed a blank chip for a shortcut never registered with the OS.
+ *
+ * The recorder now stores 'space'; this covers the read-side heal that recovers
+ * configs already written by 0.56.8-beta.
+ */
+describe('Storage shortcuts (Space key normalization)', () => {
+
+	let store: Record<string, string>;
+
+	beforeEach(() => {
+		store = {};
+
+		vi.stubGlobal('localStorage', {
+			getItem: (k: string) => (k in store ? store[k] : null),
+			setItem: (k: string, v: string) => { store[k] = v; },
+			removeItem: (k: string) => { delete store[k]; },
+		});
+
+		vi.stubGlobal('U', { Common: { getElectron: () => ({}) } });
+		vi.stubGlobal('S', { Common: { space: '' }, Auth: { account: null } });
+
+		Storage.set('shortcuts', {}, false);
+	});
+
+	it('heals a legacy literal space into the canonical name', () => {
+		Storage.set('shortcuts', { globalSearch: [ 'cmd', 'shift', ' ' ] }, false);
+
+		expect(Storage.getShortcuts().globalSearch).toEqual([ 'cmd', 'shift', 'space' ]);
+	});
+
+	it('leaves every other key untouched', () => {
+		Storage.set('shortcuts', {
+			globalSearch: [ 'cmd', 'shift', 'k' ],
+			settings: [ 'cmd', 'comma' ],
+			newTab: [ 'cmd', 'arrowup' ],
+		}, false);
+
+		const list = Storage.getShortcuts();
+
+		expect(list.globalSearch).toEqual([ 'cmd', 'shift', 'k' ]);
+		expect(list.settings).toEqual([ 'cmd', 'comma' ]);
+		expect(list.newTab).toEqual([ 'cmd', 'arrowup' ]);
+	});
+
+	it('heals every entry, not just the first', () => {
+		Storage.set('shortcuts', {
+			globalSearch: [ 'cmd', 'shift', ' ' ],
+			shortcut: [ 'ctrl', ' ' ],
+		}, false);
+
+		const list = Storage.getShortcuts();
+
+		expect(list.globalSearch).toEqual([ 'cmd', 'shift', 'space' ]);
+		expect(list.shortcut).toEqual([ 'ctrl', 'space' ]);
+	});
+
+	it('does not throw on a non-array value from an unvalidated import', () => {
+		Storage.set('shortcuts', { newTab: 'cmd+t' } as any, false);
+
+		expect(() => Storage.getShortcuts()).not.toThrow();
+		expect(Storage.getShortcuts().newTab).toEqual([]);
+	});
+
+	it('returns a fresh copy so in-place sorts cannot leak into the cache', () => {
+		Storage.set('shortcuts', { globalSearch: [ 'cmd', 'shift', 'k' ] }, false);
+
+		Storage.getShortcuts().globalSearch.sort();
+
+		expect(Storage.getShortcuts().globalSearch).toEqual([ 'cmd', 'shift', 'k' ]);
+	});
+
+});

--- a/src/ts/lib/storage.ts
+++ b/src/ts/lib/storage.ts
@@ -765,7 +765,7 @@ class Storage {
 		const ret: Record<string, string[]> = {};
 
 		for (const id in list) {
-			ret[id] = (list[id] || []).map((key: string) => (key == ' ') ? 'space' : key);
+			ret[id] = Array.isArray(list[id]) ? list[id].map((key: string) => (key == ' ') ? 'space' : key) : [];
 		};
 
 		return ret;

--- a/src/ts/lib/storage.ts
+++ b/src/ts/lib/storage.ts
@@ -755,11 +755,20 @@ class Storage {
 	};
 
 	/**
-	 * Gets the list of keyboard shortcuts from storage.
+	 * Gets the list of keyboard shortcuts from storage. Values recorded by builds that
+	 * stored the raw e.key for Space carry a literal ' ' where J.Shortcut uses 'space' -
+	 * heal them on read so display, matching and the next write all agree.
 	 * @returns {any} The shortcuts data.
 	 */
 	getShortcuts () {
-		return this.get('shortcuts', this.isLocal('shortcuts')) || {};
+		const list = this.get('shortcuts', this.isLocal('shortcuts')) || {};
+		const ret: Record<string, string[]> = {};
+
+		for (const id in list) {
+			ret[id] = (list[id] || []).map((key: string) => (key == ' ') ? 'space' : key);
+		};
+
+		return ret;
 	};
 
 	/**


### PR DESCRIPTION
Closes JS-9868.

## Problem

Recording any Space-containing combo in **Settings → Shortcuts** silently kills the OS-level global search shortcut. The panel shows what looks like a valid binding; nothing is registered with the OS, and no error surfaces anywhere.

## Root cause

`keyboard.eventKey()` returns `e.key.toLowerCase()`, and for the Space key `e.key` is a literal `" "` — not the canonical `"space"` the `J.Shortcut` defaults use (`[ cmdKey, 'shift', 'space' ]`). The recorder in `popup/shortcut.tsx` only strips `key`/`digit` prefixes off `e.code`, so Space fell through to `pressed.push(key)` and persisted `" "`.

Everything downstream then broke, quietly:

- `MenuManager.getAccelerator()` emitted `CmdOrCtrl+Shift+ `
- `globalShortcut.register()` threw `Error processing argument at index 0, conversion failure`
- the `try/catch` in `initGlobalShortcuts()` swallowed the throw and left `globalShortcutRegistered = false`
- `getSymbolsFromKeys()` rendered `" "` as a blank chip, so the UI showed a shortcut that had never been registered

## Changes

1. **Recorder** — resolve Space through the existing `special`/`J.Key` path (`J.Key.space == 32`), so it stores the canonical `'space'`. Root cause.
2. **`getAccelerator()`** — a `namedKeys` map (alongside the existing `arrowKeys`) covering `space`, a legacy `' '`, and `comma`. Configs already written by `0.56.8-beta` heal themselves instead of staying dead.
3. **`Storage.getShortcuts()`** — normalize a legacy `' '` on read, guarded with `Array.isArray`. This matters beyond global search: stored keys feed `J.Shortcut.getItems()`, so any in-app shortcut recorded with Space was affected too.
4. **`initGlobalShortcuts()`** — log the `register()` failure instead of discarding it. A swallowed throw here is indistinguishable from a shortcut that just never fires, which is what made this hard to see.

### From code review

5. **`comma` had the identical defect** and is fixed by the same map. It was already in the recorder's `special` array before this branch, so it has always persisted the literal string `'comma'`, which `getAccelerator()` uppercased to `COMMA` — unparseable, throws exactly like `" "`. Reachable today by binding anything to `⌘,`; `newTab`/`close`/`selectAll` and seven other menu accelerators have no in-app fallback, so such a binding is simply dead.
6. **Capped a chord at one non-modifier.** Adding `'space'` to `special` made a bad state reachable: that loop had no equivalent of the `codeChecks` `codes` guard, so tapping `A` then Space inside the 200 ms save window stored `['cmd','shift','a','space']` where Space was previously discarded. The OS accepts `CmdOrCtrl+Shift+A+Space` (verified REGISTERED) but in-app matching builds its chord from a single keydown and can never produce two non-modifiers — so the binding silently diverges from what the panel displays. `codes` now means "a non-modifier was captured" and gates all three push sites.
7. **`Array.isArray` guard.** `shortcutImport` `JSON.parse`s an arbitrary user file with no validation; `.map()` on a non-array value would throw at boot via `keyboard.initShortcuts`.

## Verification

Driving the **real** `MenuManager.getAccelerator()` from a bundled `menu.ts` inside an Electron 41.9.0 process on macOS 26.5.2:

| stored keys | before | after |
|---|---|---|
| `["cmd","shift"," "]` | `CmdOrCtrl+Shift+ ` → **THREW** | `CmdOrCtrl+Shift+Space` → **REGISTERED** |
| `["cmd","shift","comma"]` | `CmdOrCtrl+Shift+COMMA` → **THREW** | `CmdOrCtrl+Shift+,` → **REGISTERED** |
| `["cmd","shift","space"]` | REGISTERED | REGISTERED |
| letter / digit / arrow / `+` / no override | REGISTERED | unchanged |

`src/ts/lib/storage.test.ts` gains 5 cases; 4 of them fail against `origin/develop` and the fifth is a deliberate no-change guard. Suite passes 8/8. `bunx tsc -p tsconfig.electron.json` exits 0; the renderer typecheck reports only 3 pre-existing `Cannot find module` errors for gitignored codegen artifacts, byte-identical on a stashed `origin/develop` baseline. ESLint and the biome/eslint pre-commit hooks pass.

## Known adjacent issues, deliberately NOT in this PR

Review surfaced more of the same root cause. All pre-existing, none introduced here, each wants its own change:

- **Non-Latin layouts.** `codeChecks` recovers letters/digits positionally, but every other `e.code` falls through to the layout-localized `e.key`. `Ж Х Б Ю Э Ё ä ö ü ß` all produce throwing accelerators — verified against the parser.
- **Modifier-only chords are saveable.** With only modifiers held the recorder saves after 1500 ms, and the `globalSearch` guard requires ≥1 modifier but never a non-modifier. `['cmd','shift']` → `CmdOrCtrl+Shift` → throws.
- **The red-alert misdiagnoses.** `registered == false` renders "used by another application", but a malformed accelerator (throw) and an OS-taken one (`false`) are indistinguishable at that boundary. `globalShortcutUnavailable` is Linux+Wayland only, so macOS/Windows get no correct explanation — and the alert is `isGlobal`-gated, so the other 18 menu accelerators get nothing at all.
- **`getAccelerator` collapses Ctrl into Cmd on macOS** (`(keyLower == 'ctrl') || (keyLower == 'cmd')` → `CmdOrCtrl`). The shipped default `shortcut: ['ctrl','space']` displays and matches as `⌃Space` in-app but registers as `⌘Space` in the Help menu.
- **Dead keys / IME.** `e.key` is `'Dead'` for accent keys and `'Process'` while a CJK IME composes; both throw.
- **Numpad** records the main-row digit (NumLock on) or `'End'` (off).

The structural fix for most of these is to extract `getAccelerator` into a pure module with no imports — every one of them flows through it, and it is currently unreachable from vitest because `menu.ts` imports `electron` plus five managers at module scope.

## Scope note

Found while investigating a separate report that global search does not work on **macOS 27 beta**. This is not that bug — macOS 27 also assigns `Cmd+Shift+Space` to Visual Intelligence system-wide, and the reporter says rebinding does not help either. That investigation continues in the original issue; this fix stands on its own and affects every platform.

Affects `v0.56.8-beta` only (feature landed in f7527e3490, 2026-08-26). Not in any stable release.