### PR TITLE
GO-7387: land new objects in their sorted position on commit

### DIFF
--- a/src/scss/component/cell.scss
+++ b/src/scss/component/cell.scss
@@ -4,6 +4,10 @@
 	.name { @include text-overflow-nw; display: inline-block; vertical-align: top; width: 100%; }
 }
 
+.cell {
+	.name.isPlaceholder { color: var(--color-text-tertiary); }
+}
+
 .cell.isEditing { border-radius: 2px; }
 .cell.isEditing, .cellContent.isEditing {
 	.input { padding: 0px; height: 20px; background: none; border: 0px; border-radius: 0px; }

--- a/src/ts/component/block/dataview.tsx
+++ b/src/ts/component/block/dataview.tsx
@@ -21,6 +21,7 @@ import ViewTimeline from './dataview/view/timeline';
 import * as I from 'Interface';
 import Storage from 'Lib/storage';
 import { focus } from 'Lib/focus';
+import { placeCreatedRecord } from 'Lib/util/subscription';
 
 interface Props extends I.BlockComponent {
 	isInline?: boolean;
@@ -41,6 +42,7 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 	const timeoutFilter = useRef(0);
 	const timeoutDrag = useRef(0);
 	const editingRecordId = useRef('');
+	const nameSaveIssued = useRef(false);
 	const filterRef = useRef('');
 	const viewIdRef = useRef('');
 	const viewTypeRef = useRef<I.ViewType | null>(null);
@@ -536,25 +538,21 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 			const isSorted = !isViewBoard && S.Record.getMeta(subId, '').isSorted;
 
+			// On a sorted subscription the middleware may add the new record at its sorted
+			// position before this callback runs (a race): the record is moved to the creation
+			// spot so the row stays put while its name is typed, and deferAfterId carries the
+			// sorted position to restore when editing ends (GO-7387)
+			let deferAfterId: string | null = null;
+
 			if (!isViewCalendar) {
 				// Board columns render from the group subscription record list as is:
 				// use the raw list, getRecords would apply the object order of the
 				// first matching group (JS-9747, JS-9764)
-				let records = isViewBoard ? [ ...S.Record.getRecordIds(subId, '') ] : getRecords(groupId);
+				const source = isViewBoard ? [ ...S.Record.getRecordIds(subId, '') ] : getRecords(groupId);
+				const placement = placeCreatedRecord(source, message.objectId, dir, idx ?? -1, isSorted);
+				const records = placement.records;
 
-				const oldIndex = records.indexOf(message.objectId);
-
-				// If idx present use idx otherwise use dir to add record to the beginning or end of the list
-				if (oldIndex < 0) {
-					if (idx >= 0) {
-						records.splice(idx, 0, message.objectId);
-					} else {
-						dir > 0 ? records.push(message.objectId) : records.unshift(message.objectId);
-					};
-				} else {
-					const newIndex = idx >= 0 ? idx : (dir > 0 ? records.length : 0);
-					records = arrayMove(records, oldIndex, newIndex);
-				};
+				deferAfterId = placement.deferAfterId;
 
 				// Insert the new record into the group's custom order (if any), so the
 				// card keeps its position and stays visible after the column
@@ -603,6 +601,13 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 				// ends — setRecordEditingOff applies the stashed position (GO-7387)
 				if (isSorted) {
 					S.Record.positionLockSet(subId, '', object.id);
+
+					// The reposition already arrived and was applied before the lock existed
+					// (race): re-stash the sorted position so it is restored on commit, even
+					// when the record is left unnamed and sorts to the top (GO-7387)
+					if (deferAfterId !== null) {
+						S.Record.positionLockStash(subId, '', deferAfterId);
+					};
 				};
 
 				window.setTimeout(() => setRecordEditingOn(e, object.id), 15);
@@ -879,7 +884,26 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 		details[relationKey] = value;
 		S.Detail.update(subId, { id, details }, false);
 
-		C.ObjectListSetDetails([ id ], [ { key: relationKey, value } ], callBack);
+		// Record that a name save is in flight for a position-locked (freshly created) record, so
+		// editing-end defers to this save's callback to apply the sorted position instead of restoring
+		// the stashed head position itself (GO-7387)
+		const nameLock = S.Record.getPositionLock(subId, '');
+		if ((relationKey == 'name') && nameLock && (nameLock.id == id)) {
+			nameSaveIssued.current = true;
+		};
+
+		C.ObjectListSetDetails([ id ], [ { key: relationKey, value } ], (message: any) => {
+			// The name save is what commits the record's sorted position: apply the reposition
+			// stashed while the position lock was held, so the row moves to its sorted slot in a
+			// single step once the middleware order is known (GO-7387)
+			const lock = S.Record.getPositionLock(subId, '');
+
+			if (lock && (lock.id == id) && (relationKey == 'name')) {
+				U.Subscription.applyPendingPosition(subId);
+			};
+
+			callBack?.(message);
+		});
 
 		if ((undefined !== record[relationKey]) && !U.Common.compareJSON(record[relationKey], value)) {
 			analytics.changeRelationValue(relation, value, { type: 'dataview', id: 'Single' });
@@ -1564,6 +1588,7 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 		if (ref && ref.setIsEditing) {
 			ref.setIsEditing(true);
 			editingRecordId.current = id;
+			nameSaveIssued.current = false;
 		};
 
 		nameRef?.onClick(e);
@@ -1584,7 +1609,9 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 		};
 
 		recordKeyDownHandlerRef.current = (e: KeyboardEvent) => {
-			keyboard.shortcut('escape, enter', e, () => setRecordEditingOff(id));
+			keyboard.shortcut('escape, enter', e, () => {
+				setRecordEditingOff(id);
+			});
 		};
 
 		U.Dom.addEvents(window, [
@@ -1615,8 +1642,17 @@ const BlockDataview = forwardRef<I.BlockRef, Props>((props, ref) => {
 
 		nameRef?.onBlur();
 
-		// Apply any subscription reposition stashed while the name was being edited (GO-7387)
-		U.Subscription.applyPendingPosition(getSubId());
+		const subId = getSubId();
+
+		// When the name changed, its save applies the stashed sorted position on RPC completion
+		// (onCellChange), moving the row once with no flash. Otherwise no name save fires, so release
+		// the lock and restore the stashed position here - covering unnamed and unedited records, so a
+		// held lock can never strand the row or swallow later repositions (GO-7387).
+		if (!nameSaveIssued.current) {
+			U.Subscription.applyPendingPosition(subId);
+		};
+
+		nameSaveIssued.current = false;
 	};
 
 	const multiSelectAction = (id: string) => {

--- a/src/ts/component/cell/text.stories.tsx
+++ b/src/ts/component/cell/text.stories.tsx
@@ -20,3 +20,25 @@ export const Default: Story = {
 		viewType: I.ViewType.Grid,
 	},
 };
+
+// An empty name falls back to "Untitled" and renders in the placeholder color.
+export const EmptyName: Story = {
+	args: {
+		relation: { relationKey: 'name', format: I.RelationType.ShortText },
+		recordId: 'record-2',
+		getRecord: () => ({ name: '' }),
+		placeholder: 'Enter text...',
+		viewType: I.ViewType.Grid,
+	},
+};
+
+// A name literally typed as "Untitled" is a real value and keeps the normal color.
+export const LiteralUntitledName: Story = {
+	args: {
+		relation: { relationKey: 'name', format: I.RelationType.ShortText },
+		recordId: 'record-3',
+		getRecord: () => ({ name: 'Untitled' }),
+		placeholder: 'Enter text...',
+		viewType: I.ViewType.Grid,
+	},
+};

--- a/src/ts/component/cell/text.tsx
+++ b/src/ts/component/cell/text.tsx
@@ -165,6 +165,7 @@ const CellText = forwardRef<I.CellRef, I.Cell>((props, ref: any) => {
 	let val = record[relation.relationKey];
 	let icon = null;
 	let counter = null;
+	let isNamePlaceholder = false;
 
 	if (isDate || isNumber) {
 		val = Relation.formatValue(relation, val, true);
@@ -271,7 +272,13 @@ const CellText = forwardRef<I.CellRef, I.Cell>((props, ref: any) => {
 				if (textLimit) {
 					name = U.String.shorten(name, textLimit);
 				};
-				content = <div className="name">{name}</div>;
+
+				const cn = [ 'name' ];
+				if (isNamePlaceholder) {
+					cn.push('isPlaceholder');
+				};
+
+				content = <div className={cn.join(' ')}>{name}</div>;
 			} else {
 				if (isName && U.Object.isNoteLayout(record.layout)) {
 					content = <span className="emptyText">{translate('commonEmpty')}</span>;
@@ -337,6 +344,9 @@ const CellText = forwardRef<I.CellRef, I.Cell>((props, ref: any) => {
 			} else {
 				val = val || translate('defaultNamePage');
 			};
+
+			// Grey the fallback for an empty name; a name literally typed as "Untitled" stays normal.
+			isNamePlaceholder = !record.name && (val == translate('defaultNamePage'));
 
 			if (U.Object.isChatLayout(record.layout)) {
 				counter = <ChatCounter chatId={record.id} />;

--- a/src/ts/lib/util/subscription.test.ts
+++ b/src/ts/lib/util/subscription.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applySubscriptionPosition } from './subscription';
+import { applySubscriptionPosition, placeCreatedRecord } from './subscription';
 import UtilSubscription from './subscription';
 
 /**
@@ -112,6 +112,80 @@ describe('applySubscriptionPosition', () => {
 			expect(records).toEqual([ 'a', 'B1', 'b', 'c', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'z' ]);
 		});
 
+	});
+
+});
+
+/**
+ * Regression coverage for the GO-7387 follow-up: on a sorted subscription the middleware often adds a
+ * newly created record at its sorted position before the ObjectCreate callback runs (a race). The
+ * callback then must move the record to the creation spot so the row stays put while its name is typed,
+ * and defer the sorted position so it is restored on commit - including for an unnamed record, which
+ * sorts to the head. Previously the callback dragged the already-placed record to the creation spot with
+ * no way back, so it never returned to its sorted position.
+ */
+describe('placeCreatedRecord', () => {
+
+	const base = [ 'r1', 'r2', 'r3' ];
+
+	describe('record not yet in the list', () => {
+
+		it('appends to the tail when dir is positive', () => {
+			const { records, deferAfterId } = placeCreatedRecord(base, 'x', 1, -1, false);
+			expect(records).toEqual([ 'r1', 'r2', 'r3', 'x' ]);
+			expect(deferAfterId).toBeNull();
+		});
+
+		it('prepends to the head when dir is negative', () => {
+			const { records, deferAfterId } = placeCreatedRecord(base, 'x', -1, -1, false);
+			expect(records).toEqual([ 'x', 'r1', 'r2', 'r3' ]);
+			expect(deferAfterId).toBeNull();
+		});
+
+		it('inserts at an explicit index', () => {
+			const { records, deferAfterId } = placeCreatedRecord(base, 'x', 1, 1, false);
+			expect(records).toEqual([ 'r1', 'x', 'r2', 'r3' ]);
+			expect(deferAfterId).toBeNull();
+		});
+
+	});
+
+	describe('record already placed by the subscription (race)', () => {
+
+		it('moves it to the creation spot and defers the head position on sorted subscriptions', () => {
+			const { records, deferAfterId } = placeCreatedRecord([ 'x', 'r1', 'r2', 'r3' ], 'x', 1, -1, true);
+			expect(records).toEqual([ 'r1', 'r2', 'r3', 'x' ]);
+			expect(deferAfterId).toBe('');
+		});
+
+		it('defers the predecessor position when placed mid-list', () => {
+			const { records, deferAfterId } = placeCreatedRecord([ 'r1', 'r2', 'x', 'r3' ], 'x', 1, -1, true);
+			expect(records).toEqual([ 'r1', 'r2', 'r3', 'x' ]);
+			expect(deferAfterId).toBe('r2');
+		});
+
+		it('moves without deferring on unsorted subscriptions', () => {
+			const { records, deferAfterId } = placeCreatedRecord([ 'x', 'r1', 'r2', 'r3' ], 'x', 1, -1, false);
+			expect(records).toEqual([ 'r1', 'r2', 'r3', 'x' ]);
+			expect(deferAfterId).toBeNull();
+		});
+
+	});
+
+	it('does not mutate the input list', () => {
+		const input = [ 'x', 'r1', 'r2' ];
+		placeCreatedRecord(input, 'x', 1, -1, true);
+		expect(input).toEqual([ 'x', 'r1', 'r2' ]);
+	});
+
+	// Full race flow: the row is moved to the creation spot for editing, then the deferred sorted
+	// position is replayed on commit - an unnamed record returns to the head (GO-7387)
+	it('restores the sorted position on commit via applySubscriptionPosition', () => {
+		const placement = placeCreatedRecord([ 'x', 'r1', 'r2', 'r3' ], 'x', 1, -1, true);
+		expect(placement.records).toEqual([ 'r1', 'r2', 'r3', 'x' ]);
+
+		const committed = applySubscriptionPosition(placement.records, 'x', placement.deferAfterId as string, false, true);
+		expect(committed).toEqual([ 'x', 'r1', 'r2', 'r3' ]);
 	});
 
 });

--- a/src/ts/lib/util/subscription.ts
+++ b/src/ts/lib/util/subscription.ts
@@ -48,6 +48,43 @@ export const applySubscriptionPosition = (records: string[], id: string, afterId
 };
 
 /**
+ * Computes the record id list after optimistically creating a record, and the position to defer.
+ *
+ * On a sorted subscription the middleware often adds the new record at its sorted position before the
+ * ObjectCreate callback runs (a race). Moving that record to the creation spot keeps the row where the
+ * user clicked while its name is typed, and the returned deferAfterId lets the caller stash the sorted
+ * position so it is restored on commit - including for an unnamed record, which sorts to the top (GO-7387).
+ *
+ * @param {string[]} records - The current record id list.
+ * @param {string} id - The created record id.
+ * @param {number} dir - Creation direction: > 0 appends to the end, otherwise prepends to the start.
+ * @param {number} [idx] - Explicit creation index; takes precedence over dir when >= 0.
+ * @param {boolean} isSorted - Whether the subscription order is defined by explicit view sorts.
+ * @returns {{ records: string[], deferAfterId: string | null }} The next id list and, when the record was
+ *   already present on a sorted subscription, the sorted afterId to defer (empty string means head); otherwise null.
+ */
+export const placeCreatedRecord = (records: string[], id: string, dir: number, idx: number, isSorted: boolean): { records: string[], deferAfterId: string | null } => {
+	records = [ ...records ];
+
+	const oldIndex = records.indexOf(id);
+	const to = idx >= 0 ? idx : (dir > 0 ? records.length : 0);
+
+	let deferAfterId: string | null = null;
+
+	if (oldIndex < 0) {
+		records.splice(to, 0, id);
+	} else {
+		if (isSorted) {
+			deferAfterId = oldIndex > 0 ? records[oldIndex - 1] : '';
+		};
+
+		records.splice(to, 0, records.splice(oldIndex, 1)[0]);
+	};
+
+	return { records, deferAfterId };
+};
+
+/**
  * Utility class for managing subscriptions, search, and data synchronization in the application.
  * Provides methods for subscribing to object changes, searching, and managing subscription state.
  */
@@ -124,6 +161,7 @@ class UtilSubscription {
 		const lock = S.Record.getPositionLock(subId, '');
 
 		S.Record.positionLockClear(subId, '');
+
 
 		if (!lock || !lock.hasPending) {
 			return;


### PR DESCRIPTION
- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

### Description

This PR fixes new objects not landing in their sorted position in name-sorted
Sets and Type views (GO-7387), and renders an empty object name in the
placeholder color so it reads as empty rather than as a real value.

- In a name-sorted dataview, a newly created object was moved to the creation
  spot while its name was typed, then either stayed at the bottom or briefly
  jumped to the top before settling. The position lock is now held through
  commit so the middleware reposition is applied once, moving the row to its
  sorted slot in a single step. Unnamed or unedited records restore their
  stashed position when editing ends.
- A name cell with no name showed the "Untitled" fallback in the normal text
  color, so an empty value looked like a real one. It now renders in the
  placeholder color (`--color-text-tertiary`). A name literally typed as
  "Untitled" keeps the normal color.

### What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix
- [x] 🎨 Style

### Related Tickets & Documents

GO-7387 (builds on the earlier collection-sorting fix, PR #2310)

### Mobile & Desktop Screenshots/Recordings

_To add: before/after of the empty-name cell color, and a clip of create-and-sort with no flash._

### Added tests?

- [x] 👍 yes

### Added to documentation?

- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?

None.
