### PR TITLE
fix(chat): drop link marks whose text was replaced by a paste (JS-9869)

### DIFF
--- a/src/ts/component/block/chat/form.tsx
+++ b/src/ts/component/block/chat/form.tsx
@@ -321,7 +321,7 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 
 				const res = U.String.insert(current, newText, from, to);
 
-				marks.current = Mark.adjust(marks.current, from, newText.length - (to - from));
+				marks.current = Mark.adjustForReplace(marks.current, from, to, newText.length);
 				marks.current = Mark.checkRanges(res, marks.current);
 				setMarks(marks.current);
 
@@ -587,7 +587,7 @@ const ChatForm = forwardRef<RefProps, Props>((props, ref) => {
 
 			newMarks = Mark.adjust(newMarks, 0, from);
 
-			marks.current = Mark.adjust(marks.current, from, newText.length - (to - from));
+			marks.current = Mark.adjustForReplace(marks.current, from, to, newText.length);
 			marks.current = marks.current.concat(newMarks);
 			marks.current = marks.current.filter(it => !skipMarks.includes(it.type));
 			marks.current = Mark.checkRanges(res, marks.current);

--- a/src/ts/lib/mark.test.ts
+++ b/src/ts/lib/mark.test.ts
@@ -178,6 +178,74 @@ describe('Mark', () => {
 		});
 	});
 
+	describe('adjustForReplace', () => {
+		it('should drop a link whose text was entirely replaced (JS-9869)', () => {
+			// Pasting over a selection deletes the selected text, so a link that
+			// lived inside it has no anchor left. A plain adjust() only shifts it,
+			// stranding it on unrelated words further down the message.
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Link, range: { from: 20, to: 38 }, param: 'https://example.com' },
+			];
+
+			const adjusted = Mark.adjustForReplace(marks, 10, 50, 12);
+
+			expect(adjusted).toHaveLength(0);
+		});
+
+		it('should drop every link inside the replaced range, not just the first', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Link, range: { from: 20, to: 38 }, param: 'https://example.com' },
+				{ type: I.MarkType.Link, range: { from: 40, to: 50 }, param: 'https://example.org' },
+			];
+
+			const adjusted = Mark.adjustForReplace(marks, 10, 60, 12);
+
+			expect(adjusted).toHaveLength(0);
+		});
+
+		it('should keep and shift marks that sit after the replaced range', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Link, range: { from: 100, to: 118 }, param: 'https://example.com' },
+			];
+
+			const adjusted = Mark.adjustForReplace(marks, 10, 50, 12);
+
+			expect(adjusted).toHaveLength(1);
+			expect(adjusted[0].range).toEqual({ from: 72, to: 90 });
+		});
+
+		it('should leave marks before the replaced range untouched', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Link, range: { from: 0, to: 5 }, param: 'https://example.org' },
+			];
+
+			const adjusted = Mark.adjustForReplace(marks, 10, 50, 12);
+
+			expect(adjusted[0].range).toEqual({ from: 0, to: 5 });
+		});
+
+		it('should keep formatting marks, which are not anchored to a param', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Bold, range: { from: 20, to: 38 }, param: '' },
+			];
+
+			const adjusted = Mark.adjustForReplace(marks, 10, 50, 12);
+
+			expect(adjusted).toHaveLength(1);
+		});
+
+		it('should behave like adjust when nothing is selected', () => {
+			const marks: I.Mark[] = [
+				{ type: I.MarkType.Link, range: { from: 20, to: 38 }, param: 'https://example.org' },
+			];
+
+			const replaced = Mark.adjustForReplace(marks, 10, 10, 12);
+			const shifted = Mark.adjust(marks, 10, 12);
+
+			expect(replaced).toEqual(shifted);
+		});
+	});
+
 	describe('checkRanges', () => {
 		it('should remove marks with from >= text length', () => {
 			const marks: I.Mark[] = [

--- a/src/ts/lib/mark.ts
+++ b/src/ts/lib/mark.ts
@@ -370,6 +370,32 @@ class Mark {
 	};
 
 	/**
+	 * Adjusts mark ranges for a replacement of text[from, to) with `length` new characters.
+	 * A mark whose whole range sat inside the replaced text is dropped rather than shifted:
+	 * its anchor text is gone, and adjust() alone would slide it down onto unrelated words
+	 * (a pasted-over link keeps pointing at its old URL from the middle of the new text,
+	 * and checkUrls then adds a second mark for the real one — JS-9869). Only param-carrying
+	 * marks are dropped, mirroring the guard onKeyUpInput applies when a character is typed
+	 * over a selection.
+	 * @param {I.Mark[]} marks - The list of marks.
+	 * @param {number} from - The start of the replaced range.
+	 * @param {number} to - The end of the replaced range.
+	 * @param {number} length - The length of the inserted text.
+	 * @returns {I.Mark[]} The updated list of marks.
+	 */
+	adjustForReplace(marks: I.Mark[], from: number, to: number, length: number): I.Mark[] {
+		const kept = (marks || []).filter(mark => {
+			if ((to <= from) || !this.needsBreak(mark.type)) {
+				return true;
+			};
+
+			return !((mark.range.from >= from) && (mark.range.to <= to));
+		});
+
+		return this.adjust(kept, from, length - (to - from));
+	};
+
+	/**
 	 * Extracts marks for a text slice, clamped to the slice and rebased to zero.
 	 * @param {I.Mark[]} marks - The list of marks.
 	 * @param {number} from - The start of the slice.


### PR DESCRIPTION
## Problem

Pasting over selected text in the chat composer leaves behind the Link marks that belonged to the replaced text. The sent message ends up with grey `markuplink` runs sitting on ordinary words, each still pointing at a URL from the earlier paste.

## Cause

`parseText` adjusted marks with:

```js
marks.current = Mark.adjust(marks.current, from, newText.length - (to - from));
```

`Mark.adjust` only knows an insertion point and a net delta — it has no idea a range was *deleted*. A mark that sat entirely inside the replaced selection matches `mark.range.from >= from`, so it is shifted by the delta instead of dropped, and lands on whatever text now occupies that offset. `Mark.checkRanges` keeps it (in-bounds, non-empty), and `checkUrls` then adds a correct mark for the real URL because its dedupe only checks the newly-found range — so the message carries one correct link plus one stranded link per URL that was in the replaced text.

## Fix

`Mark.adjustForReplace(marks, from, to, length)` drops param-carrying marks whose whole range sat inside the replaced text, then adjusts the rest. It uses the same `needsBreak` predicate `onKeyUpInput` already applies when a character is typed over a selection (`form.tsx:362-369`) — that guard existed for typing but not for pasting. Wired into both chat paste paths (⌘V and ⌘⇧V).

## Verification

Replaying the reported sequence through the real `getUrlsFromText` / `Mark.adjust` / `checkRanges` / `checkUrls`:

**Before** — 3 Link marks, 2 of them stranded:
```
264-282  https://example.com  covers "schemas.anytype.io"   ← correct
362-380  https://example.com  covers "ed, that's likely "   ← stranded
424-434  https://example.org  covers "hboard cli"           ← stranded
```

**After** — 1 mark:
```
264-282  https://example.com  covers "schemas.anytype.io"
```

- 6 new unit tests in `mark.test.ts`, written failing first; 107 pass in that file
- `bun run typecheck` exit 0, eslint clean

## Repro

1. Paste text containing two or more auto-linkable URLs into the chat composer
2. Select that text and paste replacement text over it
3. Send — the message renders links over non-URL words

## Notes

Not a regression of JS-9819 (bare-domain over-detection). That fix is intact: the detector finds exactly one URL in the affected message; the extra links come from stale marks, not from detection.

The editor's paste path (`component/block/text.tsx:518-520`) already does this as an explicit delete-then-insert pair and is unaffected.

Closes JS-9869
