### PR TITLE
Tie the anytypeHelper process lifetime to the Electron main process

### DIFF
--- a/electron/ts/server.test.ts
+++ b/electron/ts/server.test.ts
@@ -1,16 +1,27 @@
 import { EventEmitter } from 'events';
 import { PassThrough } from 'stream';
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
 	spawn: vi.fn(),
 	appExit: vi.fn(),
+	showErrorBox: vi.fn(),
+	showItemInFolder: vi.fn(),
+	writeFileSync: vi.fn(),
 }));
 
 vi.mock('child_process', () => ({
 	default: {
 		spawn: mocks.spawn,
 	},
+	spawn: mocks.spawn,
+}));
+
+vi.mock('fs', () => ({
+	default: {
+		writeFileSync: mocks.writeFileSync,
+	},
+	writeFileSync: mocks.writeFileSync,
 }));
 
 vi.mock('electron', () => ({
@@ -19,10 +30,10 @@ vi.mock('electron', () => ({
 		getPath: () => '/tmp',
 	},
 	dialog: {
-		showErrorBox: vi.fn(),
+		showErrorBox: mocks.showErrorBox,
 	},
 	shell: {
-		showItemInFolder: vi.fn(),
+		showItemInFolder: mocks.showItemInFolder,
 	},
 }));
 
@@ -34,6 +45,14 @@ vi.mock('./util', () => ({
 }));
 
 import { Server } from './server';
+
+const binPath = '/tmp/anytypeHelper';
+const workingDir = '/tmp';
+const readyLine = (port: number) => `gRPC Web proxy started at: 127.0.0.1:${port}\n`;
+
+// Matches the constants in server.ts
+const gracefulShutdownTimeoutMs = 12000;
+const forceShutdownTimeoutMs = 5000;
 
 class FakeChildProcess extends EventEmitter {
 	stdin = new PassThrough();
@@ -50,97 +69,388 @@ class FakeChildProcess extends EventEmitter {
 	};
 };
 
-function setPlatform (platform: NodeJS.Platform): () => void {
-	const descriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+let platformDescriptor: PropertyDescriptor | undefined = undefined;
 
-	Object.defineProperty(process, 'platform', { value: platform });
-	return () => Object.defineProperty(process, 'platform', descriptor!);
+function setPlatform (platform: NodeJS.Platform): void {
+	platformDescriptor = platformDescriptor || Object.getOwnPropertyDescriptor(process, 'platform');
+	Object.defineProperty(process, 'platform', { value: platform, configurable: true });
 };
+
+/**
+ * Spawns a helper through the real start() path and drives it to ready.
+ */
+async function startReady (server: Server, cp: FakeChildProcess, port: number = 1234): Promise<boolean> {
+	mocks.spawn.mockReturnValueOnce(cp);
+
+	const spawnCount = mocks.spawn.mock.calls.length;
+	const started = server.start(binPath, workingDir);
+
+	await vi.waitFor(() => expect(mocks.spawn.mock.calls.length).toBe(spawnCount + 1));
+	cp.stdout.write(readyLine(port));
+
+	return started;
+};
+
+beforeEach(() => {
+	setPlatform('darwin');
+});
 
 afterEach(() => {
 	vi.useRealTimers();
-	vi.clearAllMocks();
+	vi.resetAllMocks();
+
+	if (platformDescriptor) {
+		Object.defineProperty(process, 'platform', platformDescriptor);
+		platformDescriptor = undefined;
+	};
 });
 
-describe('Server helper lifecycle', () => {
-	test('opts the helper into the stdin parent lifeline', async () => {
+describe('Server.start', () => {
+	test('opts the helper into the stdin parent lifeline and publishes its address', async () => {
 		const cp = new FakeChildProcess();
-		mocks.spawn.mockReturnValue(cp);
 		const server = new Server();
-		const started = server.start('/tmp/anytypeHelper', '/tmp');
 
-		await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledOnce());
+		await expect(startReady(server, cp)).resolves.toBe(true);
+
 		const spawnOptions = mocks.spawn.mock.calls[0][2];
 
 		expect(spawnOptions.stdio).toEqual([ 'pipe', 'pipe', 'pipe' ]);
 		expect(spawnOptions.env.ANYTYPE_PARENT_LIFELINE).toBe('stdin');
 
-		cp.stdout.write('gRPC Web proxy started at: 127.0.0.1:1234\n');
-		await expect(started).resolves.toBe(true);
+		// The lifeline depends on stdin staying open for the helper's whole life
+		expect(cp.stdin.writableEnded).toBe(false);
+		expect(cp.stdin.destroyed).toBe(false);
+
+		expect(server.isRunning).toBe(true);
+		expect(server.getAddress()).toBe('http://127.0.0.1:1234');
+		await expect(server.whenReady()).resolves.toBe('http://127.0.0.1:1234');
+	});
+
+	test('does not leak GOLOG_FILE into the main process environment', async () => {
+		const cp = new FakeChildProcess();
+		const server = new Server();
+
+		delete process.env.GOLOG_FILE;
+		await startReady(server, cp);
+
+		const spawnOptions = mocks.spawn.mock.calls[0][2];
+
+		if (!process.stdout.isTTY) {
+			expect(spawnOptions.env.GOLOG_FILE).toBeTruthy();
+		};
+		expect(process.env.GOLOG_FILE).toBeUndefined();
+	});
+
+	test('resolves false when the helper is stopped before it reports ready', async () => {
+		const cp = new FakeChildProcess();
+		const server = new Server();
+
+		mocks.spawn.mockReturnValueOnce(cp);
+
+		const started = server.start(binPath, workingDir);
+
+		await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledOnce());
 
 		const stopped = server.stop();
+
 		cp.exit();
+
+		await expect(stopped).resolves.toBe(true);
+		await expect(started).resolves.toBe(false);
+		expect(mocks.showErrorBox).not.toHaveBeenCalled();
+		expect(mocks.appExit).not.toHaveBeenCalled();
+	});
+
+	test('rejects when the helper dies before it reports ready', async () => {
+		const cp = new FakeChildProcess();
+		const server = new Server();
+
+		mocks.spawn.mockReturnValueOnce(cp);
+
+		const started = server.start(binPath, workingDir);
+
+		await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledOnce());
+
+		cp.exit(1);
+
+		await expect(started).rejects.toThrow('Anytype helper exited before it was ready');
+		await expect(server.whenReady()).rejects.toThrow('Anytype helper exited before it was ready');
+	});
+
+	test('aborts instead of spawning a second helper when the previous one cannot be stopped', async () => {
+		vi.useFakeTimers();
+
+		const stuck = new FakeChildProcess();
+		const server = new Server();
+
+		server.cp = stuck as any;
+
+		const started = server.start(binPath, workingDir);
+
+		await vi.advanceTimersByTimeAsync(gracefulShutdownTimeoutMs + forceShutdownTimeoutMs);
+
+		await expect(started).rejects.toThrow('Failed to stop the previous Anytype helper process');
+		await expect(server.whenReady()).rejects.toThrow('Failed to stop the previous Anytype helper process');
+		expect(mocks.spawn).not.toHaveBeenCalled();
+		expect(server.cp).toBe(stuck);
+	});
+
+	test('deduplicates concurrent start requests', async () => {
+		const cp = new FakeChildProcess();
+		const server = new Server();
+
+		mocks.spawn.mockReturnValue(cp);
+
+		const first = server.start(binPath, workingDir);
+		const second = server.start(binPath, workingDir);
+
+		expect(second).toBe(first);
+
+		await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledOnce());
+		cp.stdout.write(readyLine(1234));
+
+		await expect(first).resolves.toBe(true);
+		expect(mocks.spawn).toHaveBeenCalledOnce();
+	});
+
+	test('ignores a dead helper late stdout so it cannot publish a stale address', async () => {
+		const dead = new FakeChildProcess();
+		const live = new FakeChildProcess();
+		const server = new Server();
+
+		mocks.spawn.mockReturnValueOnce(dead);
+
+		const first = server.start(binPath, workingDir);
+
+		await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledOnce());
+
+		const stopped = server.stop();
+
+		dead.exit();
+
+		await expect(stopped).resolves.toBe(true);
+		await expect(first).resolves.toBe(false);
+
+		mocks.spawn.mockReturnValueOnce(live);
+
+		const second = server.start(binPath, workingDir);
+
+		await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledTimes(2));
+
+		// Node flushes buffered output after exit: the corpse must not win the race
+		dead.stdout.write(readyLine(1111));
+		dead.stderr.write('late noise from the dead helper');
+
+		expect(server.isRunning).toBe(false);
+		expect(server.getAddress()).toBe('');
+
+		live.stdout.write(readyLine(2222));
+
+		await expect(second).resolves.toBe(true);
+		expect(server.getAddress()).toBe('http://127.0.0.1:2222');
+	});
+
+	test('ignores a dead helper late exit so it cannot disown the live one', async () => {
+		const dead = new FakeChildProcess();
+		const live = new FakeChildProcess();
+		const server = new Server();
+
+		await startReady(server, dead);
+
+		// The helper is gone but its exit event has not been delivered yet, so
+		// stop() takes the already-exited path and start() spawns a replacement
+		dead.exitCode = 0;
+
+		await expect(startReady(server, live, 2222)).resolves.toBe(true);
+
+		dead.emit('exit', 0, null);
+
+		expect(server.cp).toBe(live);
+		expect(server.isRunning).toBe(true);
+		expect(server.getAddress()).toBe('http://127.0.0.1:2222');
+		expect(mocks.showErrorBox).not.toHaveBeenCalled();
+		expect(mocks.appExit).not.toHaveBeenCalled();
+	});
+});
+
+describe('Server crash reporting', () => {
+	test('writes a crash log and exits the app when a running helper dies', async () => {
+		const cp = new FakeChildProcess();
+		const server = new Server();
+
+		await startReady(server, cp);
+
+		cp.stderr.write('panic: something went wrong');
+		await vi.waitFor(() => expect(server.lastErrors.length).toBe(1));
+
+		cp.exit(1);
+
+		expect(mocks.writeFileSync).toHaveBeenCalledOnce();
+		expect(mocks.writeFileSync.mock.calls[0][1]).toContain('panic: something went wrong');
+		expect(mocks.showErrorBox).toHaveBeenCalledOnce();
+		expect(mocks.showItemInFolder).toHaveBeenCalledOnce();
+		expect(mocks.appExit).toHaveBeenCalledWith(0);
+		expect(server.isRunning).toBe(false);
+	});
+
+	test('stays silent when the helper exits because it was asked to', async () => {
+		const cp = new FakeChildProcess();
+		const server = new Server();
+
+		await startReady(server, cp);
+
+		const stopped = server.stop();
+
+		cp.exit();
+
+		await expect(stopped).resolves.toBe(true);
+		expect(mocks.writeFileSync).not.toHaveBeenCalled();
+		expect(mocks.showErrorBox).not.toHaveBeenCalled();
+		expect(mocks.appExit).not.toHaveBeenCalled();
+	});
+
+	test('still reports a crash after a stop/start cycle', async () => {
+		const first = new FakeChildProcess();
+		const second = new FakeChildProcess();
+		const server = new Server();
+
+		await startReady(server, first);
+
+		const stopped = server.stop();
+
+		first.exit();
+		await expect(stopped).resolves.toBe(true);
+
+		// stopTriggered must be cleared by start(), or this crash is swallowed
+		await startReady(server, second, 2222);
+
+		second.exit(1);
+
+		expect(mocks.showErrorBox).toHaveBeenCalledOnce();
+		expect(mocks.appExit).toHaveBeenCalledWith(0);
+	});
+});
+
+describe('Server.stop', () => {
+	test('terminates the helper with a signal on posix', async () => {
+		const cp = new FakeChildProcess();
+		const server = new Server();
+
+		server.cp = cp as any;
+
+		const stopped = server.stop();
+
+		expect(cp.kill).toHaveBeenCalledWith('SIGTERM');
+
+		cp.exit();
+
+		await expect(stopped).resolves.toBe(true);
+		expect(server.cp).toBeNull();
+		expect(server.isRunning).toBe(false);
+	});
+
+	test('force stops when the signal cannot be delivered', async () => {
+		const cp = new FakeChildProcess();
+		const server = new Server();
+
+		cp.kill.mockReturnValueOnce(false);
+		server.cp = cp as any;
+
+		const stopped = server.stop();
+
+		expect(cp.kill).toHaveBeenNthCalledWith(1, 'SIGTERM');
+		expect(cp.kill).toHaveBeenNthCalledWith(2, 'SIGKILL');
+
+		cp.exit();
+
 		await expect(stopped).resolves.toBe(true);
 	});
 
-	test('stops a spawned helper before it reports ready', async () => {
-		const restorePlatform = setPlatform('darwin');
+	test('resolves immediately for a helper that already exited', async () => {
 		const cp = new FakeChildProcess();
 		const server = new Server();
 
-		try {
-			server.cp = cp as any;
-			server.isRunning = false;
+		cp.exitCode = 0;
+		server.cp = cp as any;
+		server.isRunning = true;
 
-			const stopped = server.stop();
-
-			expect(cp.kill).toHaveBeenCalledWith('SIGTERM');
-
-			cp.exit();
-			await expect(stopped).resolves.toBe(true);
-		} finally {
-			restorePlatform();
-		};
+		await expect(server.stop()).resolves.toBe(true);
+		expect(cp.kill).not.toHaveBeenCalled();
+		expect(server.cp).toBeNull();
+		expect(server.isRunning).toBe(false);
 	});
 
 	test('requests graceful shutdown over stdin on Windows', async () => {
-		const restorePlatform = setPlatform('win32');
+		setPlatform('win32');
+
 		const cp = new FakeChildProcess();
 		const server = new Server();
 
-		try {
-			server.cp = cp as any;
+		server.cp = cp as any;
 
-			const stopped = server.stop();
+		const stopped = server.stop();
 
-			expect(cp.stdin.read()?.toString()).toBe('shutdown\n');
-			expect(cp.kill).not.toHaveBeenCalledWith('SIGTERM');
+		expect(cp.stdin.read()?.toString()).toBe('shutdown\n');
+		expect(cp.kill).not.toHaveBeenCalled();
 
-			cp.exit();
-			await expect(stopped).resolves.toBe(true);
-		} finally {
-			restorePlatform();
-		};
+		cp.exit();
+
+		await expect(stopped).resolves.toBe(true);
 	});
 
 	test('force stops when the Windows shutdown pipe fails', async () => {
-		const restorePlatform = setPlatform('win32');
+		setPlatform('win32');
+
 		const cp = new FakeChildProcess();
 		const server = new Server();
 
-		try {
-			server.cp = cp as any;
+		server.cp = cp as any;
 
-			const stopped = server.stop();
-			cp.stdin.emit('error', new Error('EPIPE'));
+		const stopped = server.stop();
 
-			expect(cp.kill).toHaveBeenCalledWith('SIGKILL');
+		cp.stdin.emit('error', new Error('EPIPE'));
 
-			cp.exit();
-			await expect(stopped).resolves.toBe(true);
-		} finally {
-			restorePlatform();
-		};
+		expect(cp.kill).toHaveBeenCalledWith('SIGKILL');
+
+		cp.exit();
+
+		await expect(stopped).resolves.toBe(true);
+	});
+
+	test('force stops when the helper has no stdin pipe on Windows', async () => {
+		setPlatform('win32');
+
+		const cp = new FakeChildProcess();
+		const server = new Server();
+
+		(cp as any).stdin = null;
+		server.cp = cp as any;
+
+		const stopped = server.stop();
+
+		expect(cp.kill).toHaveBeenCalledWith('SIGKILL');
+
+		cp.exit();
+
+		await expect(stopped).resolves.toBe(true);
+	});
+
+	test('force stops when the shutdown request throws', async () => {
+		const cp = new FakeChildProcess();
+		const server = new Server();
+
+		cp.kill.mockImplementationOnce(() => {
+			throw new Error('ESRCH');
+		});
+		server.cp = cp as any;
+
+		const stopped = server.stop();
+
+		expect(cp.kill).toHaveBeenCalledWith('SIGKILL');
+
+		cp.exit();
+
+		await expect(stopped).resolves.toBe(true);
 	});
 
 	test('deduplicates concurrent stop requests', async () => {
@@ -153,11 +463,40 @@ describe('Server helper lifecycle', () => {
 		const second = server.stop();
 
 		expect(second).toBe(first);
+		expect(cp.kill).toHaveBeenCalledOnce();
+
 		cp.exit();
+
 		await expect(first).resolves.toBe(true);
 	});
 
-	test('force kills a helper after the graceful deadline', async () => {
+	test('releases the dedup slot once a stop completes', async () => {
+		const cp = new FakeChildProcess();
+		const server = new Server();
+
+		server.cp = cp as any;
+
+		const first = server.stop();
+
+		cp.exit();
+		await expect(first).resolves.toBe(true);
+		expect(server.stopPromise).toBeNull();
+
+		// A later stop must not return the settled promise of the previous one
+		const other = new FakeChildProcess();
+
+		server.cp = other as any;
+
+		const second = server.stop();
+
+		expect(second).not.toBe(first);
+		expect(other.kill).toHaveBeenCalledWith('SIGTERM');
+
+		other.exit();
+		await expect(second).resolves.toBe(true);
+	});
+
+	test('force kills a helper that ignores the graceful request', async () => {
 		vi.useFakeTimers();
 
 		const cp = new FakeChildProcess();
@@ -166,11 +505,15 @@ describe('Server helper lifecycle', () => {
 		server.cp = cp as any;
 
 		const stopped = server.stop();
-		await vi.advanceTimersByTimeAsync(10000);
 
+		await vi.advanceTimersByTimeAsync(gracefulShutdownTimeoutMs - 1);
+		expect(cp.kill).not.toHaveBeenCalledWith('SIGKILL');
+
+		await vi.advanceTimersByTimeAsync(1);
 		expect(cp.kill).toHaveBeenCalledWith('SIGKILL');
 
 		cp.exit();
+
 		await expect(stopped).resolves.toBe(true);
 	});
 
@@ -183,9 +526,11 @@ describe('Server helper lifecycle', () => {
 		server.cp = cp as any;
 
 		const stopped = server.stop();
-		await vi.advanceTimersByTimeAsync(15000);
+
+		await vi.advanceTimersByTimeAsync(gracefulShutdownTimeoutMs + forceShutdownTimeoutMs);
 
 		await expect(stopped).resolves.toBe(false);
 		expect(server.cp).toBe(cp);
+		expect(server.stopPromise).toBeNull();
 	});
 });

--- a/electron/ts/server.test.ts
+++ b/electron/ts/server.test.ts
@@ -1,0 +1,191 @@
+import { EventEmitter } from 'events';
+import { PassThrough } from 'stream';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	spawn: vi.fn(),
+	appExit: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+	default: {
+		spawn: mocks.spawn,
+	},
+}));
+
+vi.mock('electron', () => ({
+	app: {
+		exit: mocks.appExit,
+		getPath: () => '/tmp',
+	},
+	dialog: {
+		showErrorBox: vi.fn(),
+	},
+	shell: {
+		showItemInFolder: vi.fn(),
+	},
+}));
+
+vi.mock('./util', () => ({
+	default: {
+		dateForFile: () => 'test-date',
+		logPath: () => '/tmp',
+	},
+}));
+
+import { Server } from './server';
+
+class FakeChildProcess extends EventEmitter {
+	stdin = new PassThrough();
+	stdout = new PassThrough();
+	stderr = new PassThrough();
+	exitCode: number | null = null;
+	signalCode: NodeJS.Signals | null = null;
+	pid = 123;
+	kill = vi.fn(() => true);
+
+	exit (code: number = 0): void {
+		this.exitCode = code;
+		this.emit('exit', code, null);
+	};
+};
+
+function setPlatform (platform: NodeJS.Platform): () => void {
+	const descriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+
+	Object.defineProperty(process, 'platform', { value: platform });
+	return () => Object.defineProperty(process, 'platform', descriptor!);
+};
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.clearAllMocks();
+});
+
+describe('Server helper lifecycle', () => {
+	test('opts the helper into the stdin parent lifeline', async () => {
+		const cp = new FakeChildProcess();
+		mocks.spawn.mockReturnValue(cp);
+		const server = new Server();
+		const started = server.start('/tmp/anytypeHelper', '/tmp');
+
+		await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledOnce());
+		const spawnOptions = mocks.spawn.mock.calls[0][2];
+
+		expect(spawnOptions.stdio).toEqual([ 'pipe', 'pipe', 'pipe' ]);
+		expect(spawnOptions.env.ANYTYPE_PARENT_LIFELINE).toBe('stdin');
+
+		cp.stdout.write('gRPC Web proxy started at: 127.0.0.1:1234\n');
+		await expect(started).resolves.toBe(true);
+
+		const stopped = server.stop();
+		cp.exit();
+		await expect(stopped).resolves.toBe(true);
+	});
+
+	test('stops a spawned helper before it reports ready', async () => {
+		const restorePlatform = setPlatform('darwin');
+		const cp = new FakeChildProcess();
+		const server = new Server();
+
+		try {
+			server.cp = cp as any;
+			server.isRunning = false;
+
+			const stopped = server.stop();
+
+			expect(cp.kill).toHaveBeenCalledWith('SIGTERM');
+
+			cp.exit();
+			await expect(stopped).resolves.toBe(true);
+		} finally {
+			restorePlatform();
+		};
+	});
+
+	test('requests graceful shutdown over stdin on Windows', async () => {
+		const restorePlatform = setPlatform('win32');
+		const cp = new FakeChildProcess();
+		const server = new Server();
+
+		try {
+			server.cp = cp as any;
+
+			const stopped = server.stop();
+
+			expect(cp.stdin.read()?.toString()).toBe('shutdown\n');
+			expect(cp.kill).not.toHaveBeenCalledWith('SIGTERM');
+
+			cp.exit();
+			await expect(stopped).resolves.toBe(true);
+		} finally {
+			restorePlatform();
+		};
+	});
+
+	test('force stops when the Windows shutdown pipe fails', async () => {
+		const restorePlatform = setPlatform('win32');
+		const cp = new FakeChildProcess();
+		const server = new Server();
+
+		try {
+			server.cp = cp as any;
+
+			const stopped = server.stop();
+			cp.stdin.emit('error', new Error('EPIPE'));
+
+			expect(cp.kill).toHaveBeenCalledWith('SIGKILL');
+
+			cp.exit();
+			await expect(stopped).resolves.toBe(true);
+		} finally {
+			restorePlatform();
+		};
+	});
+
+	test('deduplicates concurrent stop requests', async () => {
+		const cp = new FakeChildProcess();
+		const server = new Server();
+
+		server.cp = cp as any;
+
+		const first = server.stop();
+		const second = server.stop();
+
+		expect(second).toBe(first);
+		cp.exit();
+		await expect(first).resolves.toBe(true);
+	});
+
+	test('force kills a helper after the graceful deadline', async () => {
+		vi.useFakeTimers();
+
+		const cp = new FakeChildProcess();
+		const server = new Server();
+
+		server.cp = cp as any;
+
+		const stopped = server.stop();
+		await vi.advanceTimersByTimeAsync(10000);
+
+		expect(cp.kill).toHaveBeenCalledWith('SIGKILL');
+
+		cp.exit();
+		await expect(stopped).resolves.toBe(true);
+	});
+
+	test('reports failure and retains ownership when no exit is observed after force kill', async () => {
+		vi.useFakeTimers();
+
+		const cp = new FakeChildProcess();
+		const server = new Server();
+
+		server.cp = cp as any;
+
+		const stopped = server.stop();
+		await vi.advanceTimersByTimeAsync(15000);
+
+		await expect(stopped).resolves.toBe(false);
+		expect(server.cp).toBe(cp);
+	});
+});

--- a/electron/ts/server.ts
+++ b/electron/ts/server.ts
@@ -8,7 +8,11 @@ const stdoutWebProxyPrefix = 'gRPC Web proxy started at: ';
 const winShutdownStdinMessage = 'shutdown\n';
 const parentLifelineEnv = 'ANYTYPE_PARENT_LIFELINE';
 const parentLifelineStdin = 'stdin';
-const gracefulShutdownTimeoutMs = 10000;
+// Once the lifeline reports the owner is gone, the helper arms its own 10s
+// hard-exit deadline, so leave room for that path to win and keep SIGKILL a
+// last resort. The POSIX signal path has no deadline on the helper side,
+// which is what this timer really guards against.
+const gracefulShutdownTimeoutMs = 12000;
 const forceShutdownTimeoutMs = 5000;
 
 let maxStdErrChunksBuffer = 10;
@@ -20,6 +24,7 @@ export class Server {
 	isRunning: boolean = false;
 	stopTriggered: boolean = false;
 	stopPromise: Promise<boolean> | null = null;
+	startPromise: Promise<boolean> | null = null;
 	lastErrors: string[] = [];
 	readyResolve: ((address: string) => void) | null = null;
 	readyReject: ((err: Error) => void) | null = null;
@@ -46,6 +51,10 @@ export class Server {
 	};
 
 	start (binPath: string, workingDir: string): Promise<boolean> {
+		if (this.startPromise) {
+			return this.startPromise;
+		};
+
 		console.log('[Server]: start', binPath, workingDir);
 
 		const logPath = Util.logPath();
@@ -56,7 +65,9 @@ export class Server {
 			[parentLifelineEnv]: parentLifelineStdin,
 		};
 
-		return new Promise((resolve, reject) => {
+		let ready = false;
+
+		const startPromise = new Promise<boolean>((resolve, reject) => {
 
 			// stop will resolve immediately in case child process is not running
 			this.stop().then((stopped) => {
@@ -91,6 +102,10 @@ export class Server {
 				const cp = this.cp;
 
 				cp.on('error', (err: any) => {
+					if (this.cp !== cp) {
+						return;
+					};
+
 					this.isRunning = false;
 					console.error('[Server] Failed to start server: ', err.toString());
 					this.readyReject?.(err);
@@ -98,6 +113,12 @@ export class Server {
 				});
 
 				cp.stdout.on('data', (data: Buffer) => {
+					// Node flushes buffered output after exit; ignore a dead helper's
+					// late ready line so it cannot publish a stale address
+					if (this.cp !== cp) {
+						return;
+					};
+
 					const str = data.toString();
 
 					if (!this.isRunning && str && (str.indexOf(stdoutWebProxyPrefix) >= 0)) {
@@ -106,6 +127,7 @@ export class Server {
 						this.address = 'http://' + regex.exec(str)[1];
 						this.isRunning = true;
 
+						ready = true;
 						this.readyResolve?.(this.address);
 						resolve(true);
 					};
@@ -115,6 +137,10 @@ export class Server {
 				});
 
 				cp.stderr.on('data', (data: Buffer) => {
+					if (this.cp !== cp) {
+						return;
+					};
+
 					const chunk = data.toString();
 
 					// max chunk size is 8192 bytes
@@ -138,9 +164,26 @@ export class Server {
 				});
 
 				cp.on('exit', () => {
+					if (this.cp !== cp) {
+						return;
+					};
+
+					this.cp = null;
 					this.isRunning = false;
-					if (this.cp === cp) {
-						this.cp = null;
+
+					// The helper died before it reported readiness: settle start() so
+					// callers awaiting it are never left pending
+					if (!ready) {
+						ready = true;
+
+						if (this.stopTriggered) {
+							resolve(false);
+						} else {
+							const err = new Error('Anytype helper exited before it was ready');
+
+							this.readyReject?.(err);
+							reject(err);
+						};
 					};
 
 					if (this.stopTriggered) {
@@ -161,6 +204,20 @@ export class Server {
 				});
 			});
 		});
+
+		this.startPromise = startPromise;
+
+		// Registered before the promise is handed out so the slot is released
+		// before any caller awaiting start() resumes
+		const release = () => {
+			if (this.startPromise === startPromise) {
+				this.startPromise = null;
+			};
+		};
+
+		void startPromise.then(release, release);
+
+		return startPromise;
 	};
 
 	stop (signal?: string): Promise<boolean> {

--- a/electron/ts/server.ts
+++ b/electron/ts/server.ts
@@ -6,15 +6,20 @@ import Util from './util';
 
 const stdoutWebProxyPrefix = 'gRPC Web proxy started at: ';
 const winShutdownStdinMessage = 'shutdown\n';
+const parentLifelineEnv = 'ANYTYPE_PARENT_LIFELINE';
+const parentLifelineStdin = 'stdin';
+const gracefulShutdownTimeoutMs = 10000;
+const forceShutdownTimeoutMs = 5000;
 
 let maxStdErrChunksBuffer = 10;
 
-class Server {
+export class Server {
 
 	cp: childProcess.ChildProcess | null = null;
 	address: string = '';
 	isRunning: boolean = false;
 	stopTriggered: boolean = false;
+	stopPromise: Promise<boolean> | null = null;
 	lastErrors: string[] = [];
 	readyResolve: ((address: string) => void) | null = null;
 	readyReject: ((err: Error) => void) | null = null;
@@ -44,34 +49,55 @@ class Server {
 		console.log('[Server]: start', binPath, workingDir);
 
 		const logPath = Util.logPath();
-		const env = process.env;
+		const env: NodeJS.ProcessEnv = {
+			...process.env,
+			// The helper treats EOF on stdin as proof that its Electron main-process
+			// owner disappeared. Keep this pipe open for the helper's whole lifetime.
+			[parentLifelineEnv]: parentLifelineStdin,
+		};
 
 		return new Promise((resolve, reject) => {
 
 			// stop will resolve immediately in case child process is not running
-			this.stop().then(() => {
+			this.stop().then((stopped) => {
+				if (!stopped) {
+					const err = new Error('Failed to stop the previous Anytype helper process');
+
+					this.readyReject?.(err);
+					reject(err);
+					return;
+				};
+
 				this.isRunning = false;
+				this.stopTriggered = false;
 
 				try {
 					if (!process.stdout.isTTY) {
 						env['GOLOG_FILE'] = path.join(logPath, `anytype_${Util.dateForFile()}.log`);
 					};
 
-					this.cp = childProcess.spawn(binPath, [ '127.0.0.1:0', '127.0.0.1:0' ], { windowsHide: false, env });
+					this.cp = childProcess.spawn(binPath, [ '127.0.0.1:0', '127.0.0.1:0' ], {
+						windowsHide: false,
+						env,
+						stdio: [ 'pipe', 'pipe', 'pipe' ],
+					});
 				} catch (err: any) {
 					console.error('[Server] Process start error: ', err.toString());
 					this.readyReject?.(err);
 					reject(err);
+					return;
 				};
 
-				this.cp.on('error', (err: any) => {
+				const cp = this.cp;
+
+				cp.on('error', (err: any) => {
 					this.isRunning = false;
 					console.error('[Server] Failed to start server: ', err.toString());
 					this.readyReject?.(err);
 					reject(err);
 				});
 
-				this.cp.stdout.on('data', (data: Buffer) => {
+				cp.stdout.on('data', (data: Buffer) => {
 					const str = data.toString();
 
 					if (!this.isRunning && str && (str.indexOf(stdoutWebProxyPrefix) >= 0)) {
@@ -88,7 +114,7 @@ class Server {
 					console.log(str);
 				});
 
-				this.cp.stderr.on('data', (data: Buffer) => {
+				cp.stderr.on('data', (data: Buffer) => {
 					const chunk = data.toString();
 
 					// max chunk size is 8192 bytes
@@ -111,12 +137,15 @@ class Server {
 					console.log(chunk);
 				});
 
-				this.cp.on('exit', () => {
+				cp.on('exit', () => {
+					this.isRunning = false;
+					if (this.cp === cp) {
+						this.cp = null;
+					};
+
 					if (this.stopTriggered) {
 						return;
 					};
-
-					this.isRunning = false;
 
 					const log = path.join(logPath, `crash_${Util.dateForFile()}.log`);
 					try {
@@ -137,26 +166,117 @@ class Server {
 	stop (signal?: string): Promise<boolean> {
 		signal = String(signal || 'SIGTERM');
 
-		return new Promise((resolve, reject) => {
-			if (this.cp && this.isRunning) {
-				this.cp.on('exit', () => {
-					resolve(true);
+		if (this.stopPromise) {
+			return this.stopPromise;
+		};
 
-					this.isRunning = false;
-					this.cp = null;
-				});
+		const cp = this.cp;
+		if (!cp || (cp.exitCode !== null) || (cp.signalCode !== null)) {
+			this.isRunning = false;
+			if (this.cp === cp) {
+				this.cp = null;
+			};
+			return Promise.resolve(true);
+		};
 
-				this.stopTriggered = true;
- 				if (process.platform === 'win32') {
-					 // it is not possible to handle os signals on windows, so we can't do graceful shutdown on go side
-					this.cp.stdin.write(winShutdownStdinMessage);
-				} else {
-					this.cp.kill(signal as NodeJS.Signals);
+		this.stopTriggered = true;
+
+		const stopPromise = new Promise<boolean>((resolve) => {
+			let finished = false;
+			let forceTriggered = false;
+			let gracefulTimer: ReturnType<typeof setTimeout> | null = null;
+			let forceTimer: ReturnType<typeof setTimeout> | null = null;
+			let stdinErrorHandler: ((err: Error) => void) | null = null;
+
+			const finish = (stopped: boolean) => {
+				if (finished) {
+					return;
 				};
-			} else {
-				resolve(true);
+
+				finished = true;
+				if (gracefulTimer) {
+					clearTimeout(gracefulTimer);
+				};
+				if (forceTimer) {
+					clearTimeout(forceTimer);
+				};
+				if (cp.stdin && stdinErrorHandler) {
+					cp.stdin.removeListener('error', stdinErrorHandler);
+				};
+
+				cp.removeListener('exit', onExit);
+				if (stopped) {
+					this.isRunning = false;
+					if (this.cp === cp) {
+						this.cp = null;
+					};
+				};
+				resolve(stopped);
+			};
+
+			const onExit = () => finish(true);
+			const forceStop = () => {
+				if (finished || forceTriggered) {
+					return;
+				};
+
+				forceTriggered = true;
+				if (gracefulTimer) {
+					clearTimeout(gracefulTimer);
+				};
+
+				console.warn(`[Server] Helper did not stop within ${gracefulShutdownTimeoutMs}ms; killing it`);
+				try {
+					cp.kill('SIGKILL');
+				} catch (err: any) {
+					console.error('[Server] Failed to kill helper:', err.toString());
+				};
+
+				forceTimer = setTimeout(() => {
+					console.error(`[Server] Helper did not report exit within ${forceShutdownTimeoutMs}ms after SIGKILL`);
+					finish(false);
+				}, forceShutdownTimeoutMs);
+			};
+
+			cp.once('exit', onExit);
+			gracefulTimer = setTimeout(forceStop, gracefulShutdownTimeoutMs);
+
+			try {
+				if (process.platform === 'win32') {
+					// Windows does not support POSIX termination signals. The helper's
+					// stdin protocol requests a graceful shutdown instead.
+					if (!cp.stdin) {
+						forceStop();
+					} else {
+						stdinErrorHandler = (err: Error) => {
+							console.error('[Server] Failed to request helper shutdown:', err.toString());
+							forceStop();
+						};
+						cp.stdin.once('error', stdinErrorHandler);
+						cp.stdin.write(winShutdownStdinMessage, (err) => {
+							if (err) {
+								stdinErrorHandler?.(err);
+							};
+						});
+					};
+				} else
+				if (!cp.kill(signal as NodeJS.Signals)) {
+					forceStop();
+				};
+			} catch (err: any) {
+				console.error('[Server] Failed to request helper shutdown:', err.toString());
+				forceStop();
 			};
 		});
+
+		this.stopPromise = stopPromise;
+		void stopPromise.then(() => {
+			if (this.stopPromise === stopPromise) {
+				this.stopPromise = null;
+			};
+		});
+
+		return stopPromise;
 	};
 
 	getAddress (): string {

--- a/scripts/generate-protos.sh
+++ b/scripts/generate-protos.sh
@@ -79,7 +79,7 @@ else
 
 	# Rebuild the JS dev binary from anytype-heart
 	echo "Building anytype-heart JS dev binary..."
-	(cd "$HEART_DIR" && make install-dev-js)
+	(cd "$HEART_DIR" && make install-dev-js CLIENT_DESKTOP_PATH="$ROOT_DIR")
 
 	# pb/protos/ — commands, events, changes, snapshot
 	mkdir -p "$PROTO_ROOT/pb/protos"

--- a/scripts/start-web.js
+++ b/scripts/start-web.js
@@ -8,6 +8,8 @@ const os = require('os');
 
 const stdoutWebProxyPrefix = 'gRPC Web proxy started at: ';
 const winShutdownStdinMessage = 'shutdown\n';
+const parentLifelineEnv = 'ANYTYPE_PARENT_LIFELINE';
+const parentLifelineStdin = 'stdin';
 
 const webPort = process.env.WEB_PORT || 3030;
 const grpcWebAddr = process.env.ANYTYPE_GRPCWEB_ADDR || '127.0.0.1:31008';
@@ -78,7 +80,11 @@ function startHelper() {
 
 		helperProcess = childProcess.spawn(binPath, ['127.0.0.1:0', grpcWebAddr], {
 			windowsHide: false,
-			env: process.env,
+			env: {
+				...process.env,
+				[parentLifelineEnv]: parentLifelineStdin,
+			},
+			stdio: ['pipe', 'pipe', 'pipe'],
 		});
 
 		// Timeout if helper doesn't start in time

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
 		],
 	},
 	test: {
-		include: ['src/**/*.test.ts'],
+		include: ['src/**/*.test.ts', 'electron/**/*.test.ts'],
 		globals: true,
 		environment: 'node',
 		setupFiles: ['src/ts/test/setup.ts'],


### PR DESCRIPTION
## Problem

`anytypeHelper` could outlive the Electron main process. If the app was killed, crashed, or failed to reap the child, the helper kept running and held the account lock, so the next launch could not start.

Two independent holes:

1. **No lifeline.** Nothing told the helper its owner was gone.
2. **`stop()` was unreliable.** It resolved immediately whenever `isRunning` was false even with a live `cp` — exactly the quit-during-startup case that orphans a helper — and when `isRunning` was true it waited on `exit` with *no timeout at all*, so a hung helper hung the quit forever.

## What this does

**Opt into the middleware lifeline.** anytype-heart `0.51.0-rc7` (`cmd/grpcserver/lifeline.go`, PR anyproto/anytype-heart#3256) reads `ANYTYPE_PARENT_LIFELINE=stdin` and treats EOF on stdin as proof its owner disappeared, then shuts down under its own 10s hard-exit deadline. Both spawn sites — the Electron main process and `scripts/start-web.js` — now set the env var and keep stdin piped for the helper's whole lifetime. This covers the case no client-side code can: the main process dying without running any cleanup.

**Make `stop()` reliable.**
- Deduplicate concurrent calls behind a single promise.
- Escalate to `SIGKILL` after a 12s graceful deadline; resolve `false` if no exit is observed 5s after that, so `start()` never spawns a second helper on top of a live one.
- Fall back to force-stop when the Windows stdin shutdown pipe fails or is missing.
- Clear `cp`/`isRunning` on exit, and only for the process we actually own.

**Fix ownership and promise settlement in `start()`** (second commit, from review):
- The `error`/`stdout`/`stderr` handlers wrote shared state with no ownership check. Node flushes a child's buffered output *after* it exits, so a killed helper's late ready line could publish the dead process's address and flip `isRunning` — which then caused the live helper's real ready line to be discarded and its `start()` to never settle.
- `start()` only ever resolved from the stdout ready line, so if the helper was stopped or died first, the promise never settled and `main.ts`'s `waitLibraryPromise` stayed pending forever. It now resolves `false` on an intentional stop and rejects on a crash.
- `start()` is serialized against itself, mirroring `stop()`; two concurrent calls both spawned and the first child was dropped with no reference left to stop it.

### Why 12s

The helper arms its **own** 10s hard-exit deadline once the lifeline fires. A matching 10s client timer made the two race non-deterministically — our `SIGKILL` would usually pre-empt the helper's own clean exit. At 12s the helper's path wins where it has one, and the extra 2s is only ever paid when the helper has already missed its own deadline. Note the helper's POSIX **signal** path is explicitly *not* covered by that deadline ("OS-signal shutdown is not subject to the desktop parent's lifeline deadline"), which is what the client-side timer really guards.

## Also included

`scripts/generate-protos.sh` — pass `CLIENT_DESKTOP_PATH="$ROOT_DIR"` to `make install-dev-js`. Heart declares `CLIENT_DESKTOP_PATH ?= ../anytype-ts` relative to its own dir, so with a renamed heart checkout or a git worktree the old invocation either installed the freshly built binary and `pb` bindings into a *different* anytype-ts checkout — a silent binary-vs-bindings mismatch — or aborted under `set -euo pipefail`. Needed to test this feature locally against a heart build.

⚠️ Worth knowing: running that script in local mode overwrites the pinned `dist/anytypeHelper` (rc7) with a dev build from your heart working tree.

## Testing

`vitest.config.ts` now includes `electron/**/*.test.ts`, and `electron/ts/server.test.ts` covers the lifecycle: lifeline opt-in, stdin staying open, ownership races, crash reporting, the Windows stdin path and its failure modes, dedup, force-kill escalation, and give-up semantics.

- 22/22 new tests pass; stable across shuffled runs.
- Full suite: 90 failed / 836 passed — the same 90 pre-existing failures as `develop`, zero new (836 = 821 + the 15 tests added here).
- `bun run typecheck` clean for both tsconfigs; `bun run lint` has 0 errors.
- **Mutation-tested.** The first version of these tests caught only 1 of 12 seeded lifecycle defects. The current suite catches 15 of 15 — including dropping the `stopTriggered` reset, ignoring `kill()` returning false, removing the abort-on-stop-failure branch, never releasing `stopPromise`, and removing either ownership guard.

## Known limits (deliberately not addressed here)

- `stop()`'s dedup ignores the requested `signal`, so a `SIGKILL` arriving during an in-flight `SIGTERM` degrades to the graceful path. Unreachable today — every caller passes `''` → `SIGTERM`.
- After a give-up (`finish(false)`), `stopTriggered` stays `true`, so a later real crash of that zombie is not reported.
- `readyPromise` is created once in the constructor and not re-armed, so `start()` is not genuinely retryable. It is called once, from `ConfigManager.init`.
- Quit awaits `stop()` (`api.ts:524`), so a hung helper can delay quit by up to 17s behind an already-hidden window. Strictly better than the previous unbounded wait, but reworking the quit path is a separate change.

## Review

Three parallel review passes (lifecycle correctness, integration/packaging, tests/build scripts). Findings on ownership, promise settlement, start serialization, the timeout race, and test strength are folded into the second commit. Verified as non-issues: the `stdio: ['pipe','pipe','pipe']` addition is Node's default and both sites already drained stdout *and* stderr (no backpressure risk); no other spawn sites exist; a failed spawn sets `exitCode` to the negative errno, not `null`, so the already-exited guard handles it correctly. Incidental win: `env` is now a copy, so `GOLOG_FILE` no longer leaks into the main process's own `process.env`.

⚠️ CI note: no workflow runs vitest today, and `eslint.config.js` ignores `electron/**`, so these tests only run locally. `bun run typecheck` does cover them.
