### PR TITLE
GO-7495 Take the account from the WalletCreateSession response

### DIFF
--- a/src/ts/component/page/auth/login.tsx
+++ b/src/ts/component/page/auth/login.tsx
@@ -57,7 +57,22 @@ const PageAuthLogin = forwardRef<I.PageRef, I.PageComponent>((props, ref: any) =
 				};
 
 				S.Auth.accountListClear();
-				U.Data.createSession(phrase, '', '', () => {
+				U.Data.createSession(phrase, '', '', (message: any) => {
+					if (setErrorHandler(message.error.code, message.error.description)) {
+						return;
+					};
+
+					// The account comes back on the response itself. It used to arrive only as an
+					// accountShow event, which the middleware drops outright when this session's
+					// event stream has not attached yet - the two are independent requests, and the
+					// stream losing that race wedged login for good (GO-7494)
+					if (message.accountId) {
+						S.Auth.accountAdd({ id: message.accountId });
+						return;
+					};
+
+					// Middleware older than GO-7495 answers with an empty accountId and still needs
+					// the event. Remove once middleware.version is past it
 					C.AccountRecover(message => {
 						setErrorHandler(message.error.code, message.error.description);
 					});
@@ -260,9 +275,9 @@ const PageAuthLogin = forwardRef<I.PageRef, I.PageComponent>((props, ref: any) =
 		focus();
 	});
 
-	// Accounts arrive as AccountShow events - AccountRecover's own response carries none - so
-	// the store is the trigger, and the list length is what actually changes. Without the key
-	// every render re-ran select(), leaving the isSelecting guard as the only thing between a
+	// The account is added to the store by onSubmit once WalletCreateSession answers, so the
+	// store is the trigger and the list length is what actually changes. Without the key every
+	// render re-ran select(), leaving the isSelecting guard as the only thing between a
 	// re-render and a second AccountSelect on the same session
 	useEffect(() => {
 		select();


### PR DESCRIPTION
Client half of [GO-7495](https://linear.app/anytype/issue/GO-7495). Middleware half: anyproto/anytype-heart#3264. Fixes [GO-7494](https://linear.app/anytype/issue/GO-7494) — login wedging permanently after entering the phrase.

## Why

Login learned its own account id from an `accountShow` event. The middleware drops that event outright if this session's `ListenSessionEvents` stream has not attached yet — the stream and `AccountRecover` are two independent requests with no ordering between them. `select()` guards on `!accounts.length`, so a lost event means `AccountSelect` is never issued and login hangs until the app is restarted, with no error shown.

## What

`WalletCreateSession` now answers with the account id, and `response.ts:185` already mapped the field — it was just always `""`. So `onSubmit` reads it from there. The event carried nothing but the id, so nothing is lost.

`createSession`'s own error is now surfaced; it was previously ignored, and the flow only failed later inside `AccountRecover`.

## Fallback

If `accountId` comes back empty, it falls through to `AccountRecover` as before. This is **required today**: `middleware.version` is pinned at `0.51.0-rc7`, which predates the middleware change, so without it this branch would break login. Remove the fallback — and the `AccountShow` case in `dispatcher.ts` plus its mapper entry — once `middleware.version` is past anyproto/anytype-heart#3264.

## Testing

`bun run typecheck` and `biome lint` clean; existing unit tests pass. Worth a manual pass on login by phrase, wrong phrase, and login while a previous account start is being cancelled (the original repro).
