### PR TITLE
JS-9874: avoid unused highlights in mention and picker searches

### DIFF
--- a/src/ts/lib/util/subscription.ts
+++ b/src/ts/lib/util/subscription.ts
@@ -387,7 +387,7 @@ class UtilSubscription {
 	};
 
 	/**
-	 * Performs a search for objects matching the given parameters.
+	 * Performs a search for objects matching the given parameters without highlight metadata.
 	 * @param {Partial<I.SearchSubscribeParam> & { fullText?: string }} param - Search parameters.
 	 * @param {(message: any) => void} [callBack] - Optional callback for search results.
 	 */
@@ -425,9 +425,7 @@ class UtilSubscription {
 			return;
 		};
 
-		const cmd = fullText ? 'ObjectSearchWithMeta' : 'ObjectSearch';
-
-		C[cmd](spaceId, filters, sorts, keys, fullText, offset, limit, (message: any) => {
+		C.ObjectSearch(spaceId, filters, sorts, keys, fullText, offset, limit, (message: any) => {
 			if (message.records) {
 				message.records = message.records.map(it => S.Detail.mapper(it, skipLayoutFormat));
 			};


### PR DESCRIPTION
Typing `@` in chat/discussion or the editor requested highlight metadata that the mention menu never renders, causing unnecessary gt index syscalls for short queries. Make `U.Subscription.search` call `ObjectSearch` while forwarding `fullText` and preserving filters, sorts, keys, pagination, and result mapping.

This also removes unused metadata requests from 15 audited callers: dataview/widget/library filtering, object and file pickers, block add/link menus, type/relation suggestions, and media/cover/icon libraries. The search popup keeps its separate `ObjectSearchWithMeta` call because it renders highlights.

Fixes [JS-9874](https://linear.app/anytype/issue/JS-9874/avoid-highlight-metadata-in-mention-and-picker-searches).

Validation:
- `bun run typecheck` passed for renderer and Electron.
- 181 tests passed across subscription, object, chat, comment, and search-match suites.
- Biome and ESLint passed for the changed file.
- `git diff --check` passed.
